### PR TITLE
Remove unsupported Powershell feature from googet install script

### DIFF
--- a/.build/googet/install.ps1
+++ b/.build/googet/install.ps1
@@ -33,7 +33,6 @@ try
         New-Service -DisplayName "Google Cloud Operations OpenTelemetry Collector" `
             -Name "google-cloudops-opentelemetry-collector" `
             -BinaryPathName "$InstallDir\google-cloudops-opentelemetry-collector.exe --config=""$InstallDir\config.yaml""" `
-            -StartupType AutomaticDelayedStart `
             -Description "Google Cloud Operations OpenTelemetry Collector based Monitoring Agent"
 
         Set-ServiceConfig


### PR DESCRIPTION
Needed to remove this line as the `AutomaticDelayedStart` parameter is only available on newer versions of Powershell. I had thought that version was installed on GCE images by default but that turns out to not be the case.

Also note this line is redundant because we set this on line 22 anyway 😮 