### PR TITLE
Add lint commands, etc

### DIFF
--- a/.build/Dockerfile
+++ b/.build/Dockerfile
@@ -6,4 +6,10 @@ RUN apt-get -y update \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN go get github.com/google/googet/goopack
+ENV GO111MODULE=on
+
+RUN go get github.com/client9/misspell/cmd/misspell \
+    && go get github.com/golangci/golangci-lint/cmd/golangci-lint \
+    && go get github.com/google/addlicense \
+    && go get github.com/google/googet/goopack \
+    && go get github.com/pavius/impi/cmd/impi

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,46 @@
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - gocritic
+    - gofmt
+    - goimports
+    - golint
+    - govet
+    - misspell
+    - scopelint
+    - staticcheck
+    - unconvert
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - scopelint
+
+linters-settings:
+  gofmt:
+    # simplify code: gofmt with `-s` option, true by default
+    simplify: true
+  goimports:
+    # put imports beginning with prefix after 3rd-party packages;
+    # it's a comma-separated list of prefixes
+    local-prefixes: github.com/GoogleCloudPlatform/opentelemetry-operations-collector
+  golint:
+    # minimal confidence for issues, default is 0.8
+    min-confidence: 0.8
+  govet:
+    # report about shadowed variables
+    check-shadowing: true
+    # settings per analyzer
+    settings:
+      printf: # analyzer name, run `go tool vet help` to see all analyzers
+        funcs: # run `go tool vet help printf` to see available settings for `printf` analyzer
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+    enable-all: true
+  misspell:
+    locale: US

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705 // indirect
 	github.com/go-ole/go-ole v1.2.4 // indirect
+	github.com/google/addlicense v0.0.0-20200817051935-6f4cd4aacc89 // indirect
 	github.com/hashicorp/consul/api v1.4.0 // indirect
 	github.com/hashicorp/serf v0.9.2 // indirect
 	github.com/mitchellh/go-testing-interface v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -620,8 +620,9 @@ github.com/golangci/revgrep v0.0.0-20180526074752-d9c87f5ffaf0 h1:HVfrLniijszjS1
 github.com/golangci/revgrep v0.0.0-20180526074752-d9c87f5ffaf0/go.mod h1:qOQCunEYvmd/TLamH+7LlVccLvUH5kZNhbCgTHoBbp4=
 github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4 h1:zwtduBRr5SSWhqsYNgcuWO2kFlpdOZbP0+yRjmvPGys=
 github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4/go.mod h1:Izgrg8RkN3rCIMLGE9CyYmU9pY2Jer6DgANEnZ/L/cQ=
-github.com/google/addlicense v0.0.0-20200622132530-df58acafd6d5 h1:m6Z1Cm53o4VecQFxKCnvULGfIT0Igo3MX131i+00IIo=
 github.com/google/addlicense v0.0.0-20200622132530-df58acafd6d5/go.mod h1:EMjYTRimagHs1FwlIqKyX3wAM0u3rA+McvlIIWmSamA=
+github.com/google/addlicense v0.0.0-20200817051935-6f4cd4aacc89 h1:oTppmscIAQ2Y1tcsMDcTLR3z4MN/96/pvIsBSLGl7o8=
+github.com/google/addlicense v0.0.0-20200817051935-6f4cd4aacc89/go.mod h1:EMjYTRimagHs1FwlIqKyX3wAM0u3rA+McvlIIWmSamA=
 github.com/google/btree v0.0.0-20160524151835-7d79101e329e/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -26,28 +26,33 @@ var Version = "latest"
 // GitHash variable will be replaced at link time after `make` has been run.
 var GitHash = "<NOT PROPERLY GENERATED>"
 
-// Info returns a formatted string, with linebreaks, intended to be displayed
+// InfoVar is a singleton instance of the Info struct.
+var InfoVar = Info([][2]string{
+	{"Version", Version},
+	{"GitHash", GitHash},
+	{"Goversion", runtime.Version()},
+	{"OS", runtime.GOOS},
+	{"Architecture", runtime.GOARCH},
+	// Add other valuable build-time information here.
+})
+
+// Info has properties about the build and runtime.
+type Info [][2]string
+
+// String returns a formatted string, with linebreaks, intended to be displayed
 // on stdout.
-func Info() string {
+func (i Info) String() string {
 	buf := new(bytes.Buffer)
-	rows := [][2]string{
-		{"Version", Version},
-		{"GitHash", GitHash},
-		{"Goversion", runtime.Version()},
-		{"OS", runtime.GOOS},
-		{"Architecture", runtime.GOARCH},
-		// Add other valuable build-time information here.
-	}
 	maxRow1Alignment := 0
-	for _, row := range rows {
-		if cl0 := len(row[0]); cl0 > maxRow1Alignment {
+	for _, prop := range i {
+		if cl0 := len(prop[0]); cl0 > maxRow1Alignment {
 			maxRow1Alignment = cl0
 		}
 	}
 
-	for _, row := range rows {
+	for _, prop := range i {
 		// Then finally print them with left alignment
-		fmt.Fprintf(buf, "%*s %s\n", -maxRow1Alignment, row[0], row[1])
+		fmt.Fprintf(buf, "%*s %s\n", -maxRow1Alignment, prop[0], prop[1])
 	}
 	return buf.String()
 }

--- a/processor/agentmetricsprocessor/agentmetricsprocessor.go
+++ b/processor/agentmetricsprocessor/agentmetricsprocessor.go
@@ -31,8 +31,8 @@ import (
 var metricPostfixRegex = regexp.MustCompile(`([^.]*$)`)
 
 type agentMetricsProcessor struct {
-	logger            *zap.Logger
-	next              consumer.MetricsConsumer
+	logger *zap.Logger
+	next   consumer.MetricsConsumer
 
 	mutex             sync.Mutex
 	prevCPUTimeValues map[string]float64

--- a/processor/agentmetricsprocessor/utils_calculate_utilizations.go
+++ b/processor/agentmetricsprocessor/utils_calculate_utilizations.go
@@ -266,7 +266,7 @@ func otherLabelsAsKey(labels pdata.StringMap, excluding ...string) (string, erro
 			}
 		}
 
-		otherLabels = append(otherLabels, k + "=" + v.Value())
+		otherLabels = append(otherLabels, fmt.Sprintf("%s=%s", k, v.Value()))
 	})
 
 	if len(otherLabels) > otherLabelsLen {


### PR DESCRIPTION
Fix bug: `build-goo` was running `go test` with GOOS set to Windows so this would fail on any machine other than Windows. We were also passing GOOS & GOARCH from the local OS into the docker run target which could be problematic.

Also added additional CI: linters, etc (and fixed some minor related lint errors)

Targets expected to be run by CI are now (`build-<package>` is optional)):
```make
make install-tools presubmit build-<package>
```
Or using the docker-run target:
```make
make TARGET="presubmit build-<package>" docker-run
```