### PR TITLE
Add requirement for Windows build from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,10 @@ To generate a tarball archive that includes the agent binary and a configuration
 
 To generate an MSI that will install the agent as a Windows service using a configuration file compatible with Google Cloud Monitoring:
 
-1. Run `.build\msi\make.ps1 Install-Tools` to install the open source [WIX Toolset](https://wixtoolset.org).
-2. Run `.build\msi\make.ps1 New-MSI`.
-3. The MSI file will be generated in the `dist` folder.
+1. Ensure that [Chocolatey](https://docs.chocolatey.org/en-us/) is [installed](https://docs.chocolatey.org/en-us/choco/setup)
+2. Run `.build\msi\make.ps1 Install-Tools` to install the open source [WIX Toolset](https://wixtoolset.org).
+3. Run `.build\msi\make.ps1 New-MSI`.
+4. The MSI file will be generated in the `dist` folder.
 
 Alternatively, you can generate a [googet](https://github.com/google/googet) package by running `make build-googet`. This is the packaging method used to install the Collector on Windows GCE VMs.
 


### PR DESCRIPTION
Reference the fact that the Makefile requires choco to be installed.
Make clear that commands are in Powershell.