### PR TITLE
Update Windows build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ On Linux:
 GOOS=windows go build ./cmd/otelopscol
 ```
 
-Alternatively, you can generate a [googet](https://github.com/google/googet) package by running `make build-goo`. This is the packaging method used to install the Collector on Windows GCE VMs.
+Alternatively, you can generate a [googet](https://github.com/google/googet) package, which includes a configuration file compatible with Google Cloud Monitoring, by running `make build-goo`. This is the packaging method used to install the Collector on Windows GCE VMs.
 
 ### Other Operating Systems
 

--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ To generate a tarball archive that includes the agent binary and a configuration
 
 ### Windows
 
-To generate an MSI that will install the agent as a Windows service using a configuration file compatible with Google Cloud Monitoring:
+To build the source locally, run:
 
-1. Run `.build\msi\make.ps1 Install-Tools` to install the open source [WIX Toolset](https://wixtoolset.org).
-2. Run `.build\msi\make.ps1 New-MSI`.
-3. The MSI file will be generated in the `dist` folder.
+```
+go build  .\cmd\otelopscol\
+```
 
 Alternatively, you can generate a [googet](https://github.com/google/googet) package by running `make build-googet`. This is the packaging method used to install the Collector on Windows GCE VMs.
 

--- a/README.md
+++ b/README.md
@@ -100,13 +100,21 @@ To generate a tarball archive that includes the agent binary and a configuration
 
 ### Windows
 
-To build the source locally, run:
+To build the source locally:
+
+On Windows:
 
 ```
 go build  .\cmd\otelopscol\
 ```
 
-Alternatively, you can generate a [googet](https://github.com/google/googet) package by running `make build-googet`. This is the packaging method used to install the Collector on Windows GCE VMs.
+On Linux:
+
+```
+GOOS=windows go build ./cmd/otelopscol
+```
+
+Alternatively, you can generate a [googet](https://github.com/google/googet) package by running `make build-goo`. This is the packaging method used to install the Collector on Windows GCE VMs.
 
 ### Other Operating Systems
 


### PR DESCRIPTION
- Remove instructions for building an .msi which do not work
- Add instructions for building from source