### PR TITLE
add header-checker-lint config yaml

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -1,0 +1,6 @@
+allowedLicenses:
+  - Apache-2.0
+sourceFileExtensions:
+  - go
+  - ps1
+  - sh


### PR DESCRIPTION
Check `.sh`, `.go`, and `.ps1` files for copyright headers. There are still `Copyright 20xx, OpenTelemetry Authors` headers, which we will have to leave for now.