### PR TITLE
Add a system.disk.average_utilization_time metric

### DIFF
--- a/processor/agentmetricsprocessor/agentmetricsprocessor.go
+++ b/processor/agentmetricsprocessor/agentmetricsprocessor.go
@@ -46,7 +46,10 @@ type agentMetricsProcessor struct {
 }
 
 func newAgentMetricsProcessor(logger *zap.Logger) *agentMetricsProcessor {
-	return &agentMetricsProcessor{logger: logger}
+	return &agentMetricsProcessor{
+		logger: logger,
+		prevOp: make(map[opKey]opData),
+	}
 }
 
 // ProcessMetrics implements the MProcessor interface.

--- a/processor/agentmetricsprocessor/agentmetricsprocessor.go
+++ b/processor/agentmetricsprocessor/agentmetricsprocessor.go
@@ -32,8 +32,8 @@ type opKey struct {
 }
 
 type opData struct {
-	operations metric.IntDataPoint
-	time       metric.DoubleDataPoint
+	operations pdata.IntDataPoint
+	time       pdata.DoubleDataPoint
 	cumAvgTime float64
 }
 

--- a/processor/agentmetricsprocessor/agentmetricsprocessor_test.go
+++ b/processor/agentmetricsprocessor/agentmetricsprocessor_test.go
@@ -299,14 +299,16 @@ func assertEqualDoubleDataPointSlice(t *testing.T, metricName string, ddpsAct, d
 	for l := 0; l < ddpsAct.Len(); l++ {
 		ddpAct := ddpsAct.At(l)
 
-		ddpExp, ok := ddpsExpMap[labelsAsKey(ddpAct.LabelsMap())]
+		key := labelsAsKey(ddpAct.LabelsMap())
+
+		ddpExp, ok := ddpsExpMap[key]
 		if !ok {
-			require.Failf(t, fmt.Sprintf("no data point for %s", labelsAsKey(ddpAct.LabelsMap())), "Metric %s", metricName)
+			require.Failf(t, fmt.Sprintf("no data point for %s", key), "Metric %s", metricName)
 		}
 
-		assert.Equalf(t, ddpExp.LabelsMap().Sort(), ddpAct.LabelsMap().Sort(), "Metric %s", metricName)
-		assert.Equalf(t, ddpExp.StartTimestamp(), ddpAct.StartTimestamp(), "Metric %s", metricName)
-		assert.Equalf(t, ddpExp.Timestamp(), ddpAct.Timestamp(), "Metric %s", metricName)
-		assert.InDeltaf(t, ddpExp.Value(), ddpAct.Value(), 0.00000001, "Metric %s", metricName)
+		assert.Equalf(t, ddpExp.LabelsMap().Sort(), ddpAct.LabelsMap().Sort(), "Metric %s point %d labels %q", metricName, l, labelsAsKey(ddpAct.LabelsMap()))
+		assert.Equalf(t, ddpExp.StartTimestamp(), ddpAct.StartTimestamp(), "Metric %s point %d labels %q", metricName, l, labelsAsKey(ddpAct.LabelsMap()))
+		assert.Equalf(t, ddpExp.Timestamp(), ddpAct.Timestamp(), "Metric %s point %d labels %q", metricName, l, labelsAsKey(ddpAct.LabelsMap()))
+		assert.InDeltaf(t, ddpExp.Value(), ddpAct.Value(), 0.00000001, "Metric %s point %d labels %q", metricName, l, labelsAsKey(ddpAct.LabelsMap()))
 	}
 }

--- a/processor/agentmetricsprocessor/agentmetricsprocessor_test.go
+++ b/processor/agentmetricsprocessor/agentmetricsprocessor_test.go
@@ -35,6 +35,7 @@ type testCase struct {
 	expected                  pdata.Metrics
 	prevCPUTimeValuesInput    map[string]float64
 	prevCPUTimeValuesExpected map[string]float64
+	prevOpInput               map[opKey]opData
 }
 
 func TestAgentMetricsProcessor(t *testing.T) {
@@ -66,6 +67,11 @@ func TestAgentMetricsProcessor(t *testing.T) {
 			input:    generateCPUMetricsInput(),
 			expected: generateCPUMetricsExpected(),
 		},
+		{
+			name:     "average-disk",
+			input:    generateAverageDiskInput(),
+			expected: generateAverageDiskExpected(),
+		},
 	}
 
 	for _, tt := range tests {
@@ -83,6 +89,9 @@ func TestAgentMetricsProcessor(t *testing.T) {
 			require.NoError(t, err)
 
 			amp.prevCPUTimeValues = tt.prevCPUTimeValuesInput
+			if tt.prevOpInput != nil {
+				amp.prevOp = tt.prevOpInput
+			}
 			require.NoError(t, rmp.Start(context.Background(), componenttest.NewNopHost()))
 			defer func() { assert.NoError(t, rmp.Shutdown(context.Background())) }()
 

--- a/processor/agentmetricsprocessor/agentmetricsprocessor_test.go
+++ b/processor/agentmetricsprocessor/agentmetricsprocessor_test.go
@@ -72,6 +72,12 @@ func TestAgentMetricsProcessor(t *testing.T) {
 			input:    generateAverageDiskInput(),
 			expected: generateAverageDiskExpected(),
 		},
+		{
+			name:        "average-disk-prev",
+			input:       generateAverageDiskInput(),
+			expected:    generateAverageDiskPrevExpected(),
+			prevOpInput: generateAverageDiskPrevOpInput(),
+		},
 	}
 
 	for _, tt := range tests {

--- a/processor/agentmetricsprocessor/utils_calculate_average_disk.go
+++ b/processor/agentmetricsprocessor/utils_calculate_average_disk.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/agentmetricsprocessor/utils_calculate_average_disk.go
+++ b/processor/agentmetricsprocessor/utils_calculate_average_disk.go
@@ -71,10 +71,14 @@ func (mtp *agentMetricsProcessor) appendAverageDiskMetrics(rms pdata.ResourceMet
 					continue
 				}
 			}
+			if len(newOp) == 0 {
+				// No point making a new metric if there is no data.
+				continue
+			}
 			averageTimeMetric := pdata.NewMetric()
 			opTimeMetric.CopyTo(averageTimeMetric)
 			opTimeMetric.SetName(metricPostfixRegex.ReplaceAllString(opTimeMetric.Name(), "average_operation_time"))
-			ddps := opTimeMetric.DoubleGauge().DataPoints()
+			ddps := opTimeMetric.DoubleSum().DataPoints()
 			ddps.Resize(len(newOp))
 			i := 0
 			for key, new := range newOp {

--- a/processor/agentmetricsprocessor/utils_calculate_average_disk.go
+++ b/processor/agentmetricsprocessor/utils_calculate_average_disk.go
@@ -95,7 +95,9 @@ func (mtp *agentMetricsProcessor) appendAverageDiskMetrics(rms pdata.ResourceMet
 					t -= prev.time.Value()
 					ops -= prev.operations.Value()
 				}
-				new.cumAvgTime += t / float64(ops)
+				if ops > 0 {
+					new.cumAvgTime += t / float64(ops)
+				}
 				ddp.SetValue(new.cumAvgTime)
 				i++
 				mtp.prevOp[key] = new

--- a/processor/agentmetricsprocessor/utils_calculate_average_disk.go
+++ b/processor/agentmetricsprocessor/utils_calculate_average_disk.go
@@ -1,0 +1,348 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentmetricsprocessor
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+const opName = "system.disk.operations"
+const opTimeName = "system.disk.operation_time"
+
+const stateLabel = "state"
+
+func (mtp *agentMetricsProcessor) appendAverageDiskMetrics(rms pdata.ResourceMetricsSlice) error {
+	for i := 0; i < rms.Len(); i++ {
+		ilms := rms.At(i).InstrumentationLibraryMetrics()
+		for j := 0; j < ilms.Len(); j++ {
+			newOp := make(map[string]opData)
+			var opMetric, opTimeMetric metrics.Metric
+			metrics := ilms.At(j).Metrics()
+			for k := 0; k < metrics.Len(); k++ {
+				metric := metrics.At(k)
+
+				// ignore all metrics except the ones we want to compute utilizations for
+				metricName := metric.Name()
+				switch metricName {
+				case opName:
+					opMetric = metric
+					idps = metric.IntSum().DataPoints()
+					for i := 0; i < idps.Len(); i++ {
+						idp := idps.At(i)
+
+						lm := idp.LabelsMap()
+						device, _ := lm.Get("device")
+						direction, _ := lm.Get("direction")
+						key := opKey{device, direction}
+
+						op, ok := newOp[opKey]
+						if !ok {
+							op = mtp.prevOp[opKey]
+						}
+						op.operations = idp
+						newOp[opKey] = op
+					}
+				case opTimeName:
+					opTimeMetric = metric
+					ddps = metric.DoubleSum().DataPoints()
+					for i := 0; i < ddps.Len(); i++ {
+						ddp := ddps.At(i)
+
+						lm := ddp.LabelsMap()
+						device, _ := lm.Get("device")
+						direction, _ := lm.Get("direction")
+						key := opKey{device, direction}
+
+						op, ok := newOp[opKey]
+						if !ok {
+							op = mtp.prevOp[opKey]
+						}
+						op.time = ddp
+						newOp[opKey] = op
+					}
+				default:
+					continue
+				}
+			}
+			averageTimeMetric := pdata.NewMetric()
+			opTimeMetric.CopyTo(averageTimeMetric)
+			opTimeMetric.SetName(metricPostfixRegex.ReplaceAllString(opTimeMetric.Name(), "average_operation_time"))
+			ddps := opTimeMetric.DoubleGauge().DataPoints()
+			ddps.Resize(len(newOp))
+			i := 0
+			for key, new := range newOp {
+				prev, prevOk := mtp.prevOp[key]
+				ddp := ddps.At(i)
+				new.time.CopyTo(ddp)
+				ddp.SetValue(new.cumAvgTime)
+				i++
+			}
+		}
+	}
+
+	return nil
+}
+
+func (mtp *agentMetricsProcessor) calculateUtilizationMetric(usageMetric pdata.Metric) (pdata.Metric, error) {
+	utilizationMetric := pdata.NewMetric()
+	usageMetric.CopyTo(utilizationMetric)
+
+	utilizationMetric.SetName(metricPostfixRegex.ReplaceAllString(usageMetric.Name(), "utilization"))
+	utilizationMetric.SetDataType(pdata.MetricDataTypeDoubleGauge)
+	utilizationMetric.DoubleGauge()
+
+	metric := usageMetric
+
+	// for "cpu.time", we need to convert cumulative values to delta values before
+	// computing utilization of the deltas
+	isCPUTime := usageMetric.Name() == cpuTime
+	if isCPUTime {
+		delta := pdata.NewMetric()
+		usageMetric.CopyTo(delta)
+		mtp.convertPrevCPUTimeToDelta(delta)
+		metric = delta
+	}
+
+	var err error
+	switch t := metric.DataType(); t {
+	case pdata.MetricDataTypeIntSum, pdata.MetricDataTypeIntGauge:
+		err = calculateUtilizationFromIntDataPoints(metric, utilizationMetric)
+	case pdata.MetricDataTypeDoubleSum, pdata.MetricDataTypeDoubleGauge:
+		err = calculateUtilizationFromDoubleDataPoints(metric, utilizationMetric)
+	default:
+		return pdata.NewMetric(), fmt.Errorf("unsupported metric data type: %v", t)
+	}
+
+	if err != nil {
+		return pdata.NewMetric(), err
+	}
+
+	// persist the values of "cpu.time" so we can compute deltas on the next cycle
+	if isCPUTime {
+		mtp.setPrevCPUTimes(usageMetric)
+	}
+
+	return utilizationMetric, nil
+}
+
+// convertPrevCPUTimeToDelta converts the cpu.time values to delta values using the
+// values persisted in the previous snapshot
+func (mtp *agentMetricsProcessor) convertPrevCPUTimeToDelta(cpuTimeMetric pdata.Metric) {
+	mtp.mutex.Lock()
+	defer mtp.mutex.Unlock()
+
+	ddps := cpuTimeMetric.DoubleSum().DataPoints()
+	for i := 0; i < ddps.Len(); {
+		ddp := ddps.At(i)
+
+		// if we have no previous value for this cpu/state combination,
+		// remove the data point as we cannot calculate a utilization
+		prevValue, ok := mtp.prevCPUTimeValues[labelsAsKey(ddp.LabelsMap())]
+		if !ok {
+			removeElementAt(ddps, i)
+			continue
+		}
+
+		// delta value = current cumulative value - previous cumulative value
+		ddp.SetValue(ddp.Value() - prevValue)
+		i++
+	}
+}
+
+// setPrevCPUTimes persists the cpu.time cumulative values as a map so they can
+// be used to calculate deltas in the next snapshot
+func (mtp *agentMetricsProcessor) setPrevCPUTimes(cpuTimeMetric pdata.Metric) {
+	mtp.mutex.Lock()
+	defer mtp.mutex.Unlock()
+
+	mtp.prevCPUTimeValues = doubleDataPointsToMap(cpuTimeMetric)
+}
+
+type int64Points struct {
+	pts []pdata.IntDataPoint
+	sum float64
+}
+
+func calculateUtilizationFromIntDataPoints(metric, utilizationMetric pdata.Metric) error {
+	var idps pdata.IntDataPointSlice
+	switch t := metric.DataType(); t {
+	case pdata.MetricDataTypeIntSum:
+		idps = metric.IntSum().DataPoints()
+	case pdata.MetricDataTypeIntGauge:
+		idps = metric.IntGauge().DataPoints()
+	}
+
+	pointCount := idps.Len()
+	groupedPoints := make(map[string]*int64Points, pointCount) // overallocate to ensure no resizes are required
+	for i := 0; i < pointCount; i++ {
+		idp := idps.At(i)
+
+		key, err := otherLabelsAsKey(idp.LabelsMap(), stateLabel)
+		if err != nil {
+			return fmt.Errorf("metric %v: %w", metric.Name(), err)
+		}
+
+		points, ok := groupedPoints[key]
+		if !ok {
+			points = &int64Points{}
+			groupedPoints[key] = points
+		}
+
+		points.sum += float64(idp.Value())
+		points.pts = append(points.pts, idp)
+	}
+
+	ddps := utilizationMetric.DoubleGauge().DataPoints()
+	ddps.Resize(pointCount)
+	index := 0
+	for _, points := range groupedPoints {
+		for _, point := range points.pts {
+			ddp := ddps.At(index)
+
+			// copy dp, setting the value based on utilization calculation
+			point.LabelsMap().CopyTo(ddp.LabelsMap())
+			ddp.SetStartTimestamp(point.StartTimestamp())
+			ddp.SetTimestamp(point.Timestamp())
+			ddp.SetValue(float64(point.Value()) / points.sum * 100)
+			index++
+		}
+	}
+
+	return nil
+}
+
+type doublePoints struct {
+	pts []pdata.DoubleDataPoint
+	sum float64
+}
+
+func calculateUtilizationFromDoubleDataPoints(metric, utilizationMetric pdata.Metric) error {
+	var ddps pdata.DoubleDataPointSlice
+	switch t := metric.DataType(); t {
+	case pdata.MetricDataTypeDoubleSum:
+		ddps = metric.DoubleSum().DataPoints()
+	case pdata.MetricDataTypeDoubleGauge:
+		ddps = metric.DoubleGauge().DataPoints()
+	}
+
+	pointCount := ddps.Len()
+	groupedPoints := make(map[string]*doublePoints, pointCount) // overallocate to ensure no resizes are required
+	for i := 0; i < pointCount; i++ {
+		ddp := ddps.At(i)
+
+		key, err := otherLabelsAsKey(ddp.LabelsMap(), stateLabel)
+		if err != nil {
+			return fmt.Errorf("metric %v: %w", metric.Name(), err)
+		}
+
+		points, ok := groupedPoints[key]
+		if !ok {
+			points = &doublePoints{}
+			groupedPoints[key] = points
+		}
+
+		points.sum += ddp.Value()
+		points.pts = append(points.pts, ddp)
+	}
+
+	ddps = utilizationMetric.DoubleGauge().DataPoints()
+	ddps.Resize(pointCount)
+	index := 0
+	for _, points := range groupedPoints {
+		for _, point := range points.pts {
+			ddp := ddps.At(index)
+
+			// copy dp, setting the value based on utilization calculation
+			point.LabelsMap().CopyTo(ddp.LabelsMap())
+			ddp.SetStartTimestamp(point.StartTimestamp())
+			ddp.SetTimestamp(point.Timestamp())
+			ddp.SetValue(point.Value() / points.sum * 100)
+			index++
+		}
+	}
+
+	return nil
+}
+
+// doubleDataPointsToMap converts the double data points in the provided metric
+// to a map of labels to values
+func doubleDataPointsToMap(metric pdata.Metric) map[string]float64 {
+	ddps := metric.DoubleSum().DataPoints()
+	labelToValuesMap := make(map[string]float64, ddps.Len())
+	for i := 0; i < ddps.Len(); i++ {
+		ddp := ddps.At(i)
+		key, _ := otherLabelsAsKey(ddp.LabelsMap())
+		labelToValuesMap[key] = ddp.Value()
+	}
+	return labelToValuesMap
+}
+
+// removeElementAt removes the element at the specified index. This operation
+// does not preserve the order of elements in the data point slice
+func removeElementAt(ddps pdata.DoubleDataPointSlice, index int) {
+	ddps.At(ddps.Len() - 1).CopyTo(ddps.At(index))
+	ddps.Resize(ddps.Len() - 1)
+}
+
+// labelsAsKey returns a key representing the labels in the provided labelset.
+func labelsAsKey(labels pdata.StringMap) string {
+	otherLabelsLen := labels.Len()
+
+	idx, otherLabels := 0, make([]string, otherLabelsLen)
+	labels.Range(func(k string, v string) bool {
+		otherLabels[idx] = k + "=" + v
+		idx++
+		return true
+	})
+
+	// sort the slice so that we consider labelsets
+	// the same regardless of order
+	sort.StringSlice(otherLabels).Sort()
+	return strings.Join(otherLabels, ";")
+}
+
+// otherLabelsAsKey returns a key representing the other labels in the provided
+// labelset excluding the specified label keys. An error is returned if any of the
+// specified labels to exclude do not exist in the labelset.
+func otherLabelsAsKey(labels pdata.StringMap, excluding ...string) (string, error) {
+	otherLabelsLen := labels.Len() - len(excluding)
+
+	otherLabels := make([]string, 0, otherLabelsLen)
+	labels.Range(func(k string, v string) bool {
+		// ignore any keys specified in excluding
+		for _, e := range excluding {
+			if k == e {
+				return true
+			}
+		}
+
+		otherLabels = append(otherLabels, fmt.Sprintf("%s=%s", k, v))
+
+		return true
+	})
+
+	if len(otherLabels) > otherLabelsLen {
+		return "", fmt.Errorf("label set did not include all expected labels: %v", excluding)
+	}
+
+	// sort the slice so that we consider labelsets
+	// the same regardless of order
+	sort.StringSlice(otherLabels).Sort()
+	return strings.Join(otherLabels, ";"), nil
+}

--- a/processor/agentmetricsprocessor/utils_calculate_average_disk.go
+++ b/processor/agentmetricsprocessor/utils_calculate_average_disk.go
@@ -100,6 +100,7 @@ func (mtp *agentMetricsProcessor) appendAverageDiskMetrics(rms pdata.ResourceMet
 					new.time.CopyTo(ddp)
 					if ops > 0 {
 						interval := new.time.Timestamp() - prev.time.Timestamp()
+						// Logic from https://github.com/Stackdriver/collectd/blob/2d176c650d9d6e4cd45d2add7977016c82dd8b55/src/disk.c#L321
 						new.cumAvgTime += (t / float64(ops)) * float64(interval) / 1e9
 					}
 					ddp.SetValue(new.cumAvgTime)

--- a/processor/agentmetricsprocessor/utils_calculate_average_disk.go
+++ b/processor/agentmetricsprocessor/utils_calculate_average_disk.go
@@ -14,18 +14,10 @@
 
 package agentmetricsprocessor
 
-import (
-	"fmt"
-	"sort"
-	"strings"
-
-	"go.opentelemetry.io/collector/consumer/pdata"
-)
+import "go.opentelemetry.io/collector/consumer/pdata"
 
 const opName = "system.disk.operations"
 const opTimeName = "system.disk.operation_time"
-
-const stateLabel = "state"
 
 func (mtp *agentMetricsProcessor) appendAverageDiskMetrics(rms pdata.ResourceMetricsSlice) error {
 	for i := 0; i < rms.Len(); i++ {
@@ -90,259 +82,20 @@ func (mtp *agentMetricsProcessor) appendAverageDiskMetrics(rms pdata.ResourceMet
 				prev, prevOk := mtp.prevOp[key]
 				ddp := ddps.At(i)
 				new.time.CopyTo(ddp)
+				t := new.time.Value()
+				ops := new.ops.Value()
+				if prevOk {
+					t -= prev.time.Value()
+					ops -= prev.ops.Value()
+				}
+				new.cumAvgTime += t / float64(ops)
 				ddp.SetValue(new.cumAvgTime)
 				i++
+				mtp.prevOp[key] = new
 			}
+			metrics.Append(averageTimeMetric)
 		}
 	}
 
 	return nil
-}
-
-func (mtp *agentMetricsProcessor) calculateUtilizationMetric(usageMetric pdata.Metric) (pdata.Metric, error) {
-	utilizationMetric := pdata.NewMetric()
-	usageMetric.CopyTo(utilizationMetric)
-
-	utilizationMetric.SetName(metricPostfixRegex.ReplaceAllString(usageMetric.Name(), "utilization"))
-	utilizationMetric.SetDataType(pdata.MetricDataTypeDoubleGauge)
-	utilizationMetric.DoubleGauge()
-
-	metric := usageMetric
-
-	// for "cpu.time", we need to convert cumulative values to delta values before
-	// computing utilization of the deltas
-	isCPUTime := usageMetric.Name() == cpuTime
-	if isCPUTime {
-		delta := pdata.NewMetric()
-		usageMetric.CopyTo(delta)
-		mtp.convertPrevCPUTimeToDelta(delta)
-		metric = delta
-	}
-
-	var err error
-	switch t := metric.DataType(); t {
-	case pdata.MetricDataTypeIntSum, pdata.MetricDataTypeIntGauge:
-		err = calculateUtilizationFromIntDataPoints(metric, utilizationMetric)
-	case pdata.MetricDataTypeDoubleSum, pdata.MetricDataTypeDoubleGauge:
-		err = calculateUtilizationFromDoubleDataPoints(metric, utilizationMetric)
-	default:
-		return pdata.NewMetric(), fmt.Errorf("unsupported metric data type: %v", t)
-	}
-
-	if err != nil {
-		return pdata.NewMetric(), err
-	}
-
-	// persist the values of "cpu.time" so we can compute deltas on the next cycle
-	if isCPUTime {
-		mtp.setPrevCPUTimes(usageMetric)
-	}
-
-	return utilizationMetric, nil
-}
-
-// convertPrevCPUTimeToDelta converts the cpu.time values to delta values using the
-// values persisted in the previous snapshot
-func (mtp *agentMetricsProcessor) convertPrevCPUTimeToDelta(cpuTimeMetric pdata.Metric) {
-	mtp.mutex.Lock()
-	defer mtp.mutex.Unlock()
-
-	ddps := cpuTimeMetric.DoubleSum().DataPoints()
-	for i := 0; i < ddps.Len(); {
-		ddp := ddps.At(i)
-
-		// if we have no previous value for this cpu/state combination,
-		// remove the data point as we cannot calculate a utilization
-		prevValue, ok := mtp.prevCPUTimeValues[labelsAsKey(ddp.LabelsMap())]
-		if !ok {
-			removeElementAt(ddps, i)
-			continue
-		}
-
-		// delta value = current cumulative value - previous cumulative value
-		ddp.SetValue(ddp.Value() - prevValue)
-		i++
-	}
-}
-
-// setPrevCPUTimes persists the cpu.time cumulative values as a map so they can
-// be used to calculate deltas in the next snapshot
-func (mtp *agentMetricsProcessor) setPrevCPUTimes(cpuTimeMetric pdata.Metric) {
-	mtp.mutex.Lock()
-	defer mtp.mutex.Unlock()
-
-	mtp.prevCPUTimeValues = doubleDataPointsToMap(cpuTimeMetric)
-}
-
-type int64Points struct {
-	pts []pdata.IntDataPoint
-	sum float64
-}
-
-func calculateUtilizationFromIntDataPoints(metric, utilizationMetric pdata.Metric) error {
-	var idps pdata.IntDataPointSlice
-	switch t := metric.DataType(); t {
-	case pdata.MetricDataTypeIntSum:
-		idps = metric.IntSum().DataPoints()
-	case pdata.MetricDataTypeIntGauge:
-		idps = metric.IntGauge().DataPoints()
-	}
-
-	pointCount := idps.Len()
-	groupedPoints := make(map[string]*int64Points, pointCount) // overallocate to ensure no resizes are required
-	for i := 0; i < pointCount; i++ {
-		idp := idps.At(i)
-
-		key, err := otherLabelsAsKey(idp.LabelsMap(), stateLabel)
-		if err != nil {
-			return fmt.Errorf("metric %v: %w", metric.Name(), err)
-		}
-
-		points, ok := groupedPoints[key]
-		if !ok {
-			points = &int64Points{}
-			groupedPoints[key] = points
-		}
-
-		points.sum += float64(idp.Value())
-		points.pts = append(points.pts, idp)
-	}
-
-	ddps := utilizationMetric.DoubleGauge().DataPoints()
-	ddps.Resize(pointCount)
-	index := 0
-	for _, points := range groupedPoints {
-		for _, point := range points.pts {
-			ddp := ddps.At(index)
-
-			// copy dp, setting the value based on utilization calculation
-			point.LabelsMap().CopyTo(ddp.LabelsMap())
-			ddp.SetStartTimestamp(point.StartTimestamp())
-			ddp.SetTimestamp(point.Timestamp())
-			ddp.SetValue(float64(point.Value()) / points.sum * 100)
-			index++
-		}
-	}
-
-	return nil
-}
-
-type doublePoints struct {
-	pts []pdata.DoubleDataPoint
-	sum float64
-}
-
-func calculateUtilizationFromDoubleDataPoints(metric, utilizationMetric pdata.Metric) error {
-	var ddps pdata.DoubleDataPointSlice
-	switch t := metric.DataType(); t {
-	case pdata.MetricDataTypeDoubleSum:
-		ddps = metric.DoubleSum().DataPoints()
-	case pdata.MetricDataTypeDoubleGauge:
-		ddps = metric.DoubleGauge().DataPoints()
-	}
-
-	pointCount := ddps.Len()
-	groupedPoints := make(map[string]*doublePoints, pointCount) // overallocate to ensure no resizes are required
-	for i := 0; i < pointCount; i++ {
-		ddp := ddps.At(i)
-
-		key, err := otherLabelsAsKey(ddp.LabelsMap(), stateLabel)
-		if err != nil {
-			return fmt.Errorf("metric %v: %w", metric.Name(), err)
-		}
-
-		points, ok := groupedPoints[key]
-		if !ok {
-			points = &doublePoints{}
-			groupedPoints[key] = points
-		}
-
-		points.sum += ddp.Value()
-		points.pts = append(points.pts, ddp)
-	}
-
-	ddps = utilizationMetric.DoubleGauge().DataPoints()
-	ddps.Resize(pointCount)
-	index := 0
-	for _, points := range groupedPoints {
-		for _, point := range points.pts {
-			ddp := ddps.At(index)
-
-			// copy dp, setting the value based on utilization calculation
-			point.LabelsMap().CopyTo(ddp.LabelsMap())
-			ddp.SetStartTimestamp(point.StartTimestamp())
-			ddp.SetTimestamp(point.Timestamp())
-			ddp.SetValue(point.Value() / points.sum * 100)
-			index++
-		}
-	}
-
-	return nil
-}
-
-// doubleDataPointsToMap converts the double data points in the provided metric
-// to a map of labels to values
-func doubleDataPointsToMap(metric pdata.Metric) map[string]float64 {
-	ddps := metric.DoubleSum().DataPoints()
-	labelToValuesMap := make(map[string]float64, ddps.Len())
-	for i := 0; i < ddps.Len(); i++ {
-		ddp := ddps.At(i)
-		key, _ := otherLabelsAsKey(ddp.LabelsMap())
-		labelToValuesMap[key] = ddp.Value()
-	}
-	return labelToValuesMap
-}
-
-// removeElementAt removes the element at the specified index. This operation
-// does not preserve the order of elements in the data point slice
-func removeElementAt(ddps pdata.DoubleDataPointSlice, index int) {
-	ddps.At(ddps.Len() - 1).CopyTo(ddps.At(index))
-	ddps.Resize(ddps.Len() - 1)
-}
-
-// labelsAsKey returns a key representing the labels in the provided labelset.
-func labelsAsKey(labels pdata.StringMap) string {
-	otherLabelsLen := labels.Len()
-
-	idx, otherLabels := 0, make([]string, otherLabelsLen)
-	labels.Range(func(k string, v string) bool {
-		otherLabels[idx] = k + "=" + v
-		idx++
-		return true
-	})
-
-	// sort the slice so that we consider labelsets
-	// the same regardless of order
-	sort.StringSlice(otherLabels).Sort()
-	return strings.Join(otherLabels, ";")
-}
-
-// otherLabelsAsKey returns a key representing the other labels in the provided
-// labelset excluding the specified label keys. An error is returned if any of the
-// specified labels to exclude do not exist in the labelset.
-func otherLabelsAsKey(labels pdata.StringMap, excluding ...string) (string, error) {
-	otherLabelsLen := labels.Len() - len(excluding)
-
-	otherLabels := make([]string, 0, otherLabelsLen)
-	labels.Range(func(k string, v string) bool {
-		// ignore any keys specified in excluding
-		for _, e := range excluding {
-			if k == e {
-				return true
-			}
-		}
-
-		otherLabels = append(otherLabels, fmt.Sprintf("%s=%s", k, v))
-
-		return true
-	})
-
-	if len(otherLabels) > otherLabelsLen {
-		return "", fmt.Errorf("label set did not include all expected labels: %v", excluding)
-	}
-
-	// sort the slice so that we consider labelsets
-	// the same regardless of order
-	sort.StringSlice(otherLabels).Sort()
-	return strings.Join(otherLabels, ";"), nil
 }

--- a/processor/agentmetricsprocessor/utils_calculate_average_disk.go
+++ b/processor/agentmetricsprocessor/utils_calculate_average_disk.go
@@ -46,7 +46,9 @@ func (mtp *agentMetricsProcessor) appendAverageDiskMetrics(rms pdata.ResourceMet
 						if !ok {
 							op = mtp.prevOp[key]
 						}
-						op.operations = idp
+						// Can't just save idp because it is overwritten by OT.
+						op.operations = pdata.NewIntDataPoint()
+						idp.CopyTo(op.operations)
 						newOp[key] = op
 					}
 				case opTimeName:
@@ -64,7 +66,9 @@ func (mtp *agentMetricsProcessor) appendAverageDiskMetrics(rms pdata.ResourceMet
 						if !ok {
 							op = mtp.prevOp[key]
 						}
-						op.time = ddp
+						// Can't just save ddp because it is overwritten by OT.
+						op.time = pdata.NewDoubleDataPoint()
+						ddp.CopyTo(op.time)
 						newOp[key] = op
 					}
 				default:

--- a/processor/agentmetricsprocessor/utils_calculate_average_disk_test.go
+++ b/processor/agentmetricsprocessor/utils_calculate_average_disk_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/agentmetricsprocessor/utils_calculate_average_disk_test.go
+++ b/processor/agentmetricsprocessor/utils_calculate_average_disk_test.go
@@ -1,0 +1,73 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentmetricsprocessor
+
+import (
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func generateAverageDiskInput() pdata.Metrics {
+	input := pdata.NewMetrics()
+
+	rmb := newResourceMetricsBuilder()
+	b := rmb.addResourceMetrics(nil)
+
+	mb1 := b.addMetric("system.disk.operation_time", pdata.MetricDataTypeDoubleSum, true)
+	mb1.addDoubleDataPoint(200, map[string]string{"device": "hda", "direction": "read"})
+	mb1.addDoubleDataPoint(400, map[string]string{"device": "hda", "direction": "write"})
+	mb1.addDoubleDataPoint(100, map[string]string{"device": "hdb", "direction": "read"})
+	mb1.addDoubleDataPoint(100, map[string]string{"device": "hdb", "direction": "write"})
+
+	mb2 := b.addMetric("system.disk.operations", pdata.MetricDataTypeIntSum, true)
+	mb2.addIntDataPoint(5, map[string]string{"device": "hda", "direction": "read"})
+	mb2.addIntDataPoint(4, map[string]string{"device": "hda", "direction": "write"})
+	mb2.addIntDataPoint(2, map[string]string{"device": "hdb", "direction": "read"})
+	mb2.addIntDataPoint(20, map[string]string{"device": "hdb", "direction": "write"})
+
+	rmb.Build().CopyTo(input.ResourceMetrics())
+	return input
+}
+
+func generateAverageDiskPrevOpInput() map[opKey]opData {
+	return map[opKey]opData{}
+}
+
+func generateAverageDiskExpected() pdata.Metrics {
+	expected := pdata.NewMetrics()
+
+	rmb := newResourceMetricsBuilder()
+	b := rmb.addResourceMetrics(nil)
+
+	mb1 := b.addMetric("system.disk.operation_time", pdata.MetricDataTypeDoubleSum, true)
+	mb1.addDoubleDataPoint(200, map[string]string{"device": "hda", "direction": "read"})
+	mb1.addDoubleDataPoint(400, map[string]string{"device": "hda", "direction": "write"})
+	mb1.addDoubleDataPoint(100, map[string]string{"device": "hdb", "direction": "read"})
+	mb1.addDoubleDataPoint(100, map[string]string{"device": "hdb", "direction": "write"})
+
+	mb2 := b.addMetric("system.disk.operations", pdata.MetricDataTypeIntSum, true)
+	mb2.addIntDataPoint(5, map[string]string{"device": "hda", "direction": "read"})
+	mb2.addIntDataPoint(4, map[string]string{"device": "hda", "direction": "write"})
+	mb2.addIntDataPoint(2, map[string]string{"device": "hdb", "direction": "read"})
+	mb2.addIntDataPoint(20, map[string]string{"device": "hdb", "direction": "write"})
+
+	mb3 := b.addMetric("system.disk.average_operation_time", pdata.MetricDataTypeDoubleSum, true)
+	mb3.addDoubleDataPoint(40, map[string]string{"device": "hda", "direction": "read"})
+	mb3.addDoubleDataPoint(100, map[string]string{"device": "hda", "direction": "write"})
+	mb3.addDoubleDataPoint(50, map[string]string{"device": "hdb", "direction": "read"})
+	mb3.addDoubleDataPoint(5, map[string]string{"device": "hdb", "direction": "write"})
+
+	rmb.Build().CopyTo(expected.ResourceMetrics())
+	return expected
+}

--- a/processor/agentmetricsprocessor/utils_calculate_average_disk_test.go
+++ b/processor/agentmetricsprocessor/utils_calculate_average_disk_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func commonAverageDiskInput(b metricsBuilder) {
+	b.timestamp = oneSecond
+
 	mb1 := b.addMetric("system.disk.operation_time", pdata.MetricDataTypeDoubleSum, true)
 	mb1.addDoubleDataPoint(200, map[string]string{"device": "hda", "direction": "read"})
 	mb1.addDoubleDataPoint(400, map[string]string{"device": "hda", "direction": "write"})
@@ -73,21 +75,22 @@ func generateAverageDiskExpected() pdata.Metrics {
 
 	commonAverageDiskInput(b)
 
-	mb3 := b.addMetric("system.disk.average_operation_time", pdata.MetricDataTypeDoubleSum, true)
-	mb3.addDoubleDataPoint(40, map[string]string{"device": "hda", "direction": "read"})
-	mb3.addDoubleDataPoint(100, map[string]string{"device": "hda", "direction": "write"})
-	mb3.addDoubleDataPoint(50, map[string]string{"device": "hdb", "direction": "read"})
-	mb3.addDoubleDataPoint(5, map[string]string{"device": "hdb", "direction": "write"})
+	// No average_operation_time expected for the first point
 
 	rmb.Build().CopyTo(expected.ResourceMetrics())
 	return expected
 }
+
+const oneSecond = 1000000000
 
 func generateAverageDiskPrevExpected() pdata.Metrics {
 	expected := pdata.NewMetrics()
 
 	rmb := newResourceMetricsBuilder()
 	b := rmb.addResourceMetrics(nil)
+
+	// One second elapsed
+	b.timestamp = oneSecond
 
 	commonAverageDiskInput(b)
 

--- a/processor/agentmetricsprocessor/utils_calculate_average_disk_test.go
+++ b/processor/agentmetricsprocessor/utils_calculate_average_disk_test.go
@@ -58,10 +58,10 @@ func od(ops int64, time, cum float64) opData {
 
 func generateAverageDiskPrevOpInput() map[opKey]opData {
 	return map[opKey]opData{
-		opKey{"hda", "read"}:  od(0, 100, 15),
-		opKey{"hda", "write"}: od(3, 300, 20),
-		opKey{"hdb", "read"}:  od(2, 100, 30),
-		opKey{"hdb", "write"}: od(10, 50, 5),
+		{"hda", "read"}:  od(0, 100, 15),
+		{"hda", "write"}: od(3, 300, 20),
+		{"hdb", "read"}:  od(2, 100, 30),
+		{"hdb", "write"}: od(10, 50, 5),
 	}
 }
 

--- a/processor/agentmetricsprocessor/utils_calculate_average_disk_test.go
+++ b/processor/agentmetricsprocessor/utils_calculate_average_disk_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func commonAverageDiskInput(b metricsBuilder) {
-	b.timestamp = oneSecond
+	b.timestamp = twoSeconds
 
 	mb1 := b.addMetric("system.disk.operation_time", pdata.MetricDataTypeDoubleSum, true)
 	mb1.addDoubleDataPoint(200, map[string]string{"device": "hda", "direction": "read"})
@@ -81,7 +81,7 @@ func generateAverageDiskExpected() pdata.Metrics {
 	return expected
 }
 
-const oneSecond = 1000000000
+const twoSeconds = 2000000000
 
 func generateAverageDiskPrevExpected() pdata.Metrics {
 	expected := pdata.NewMetrics()
@@ -90,15 +90,15 @@ func generateAverageDiskPrevExpected() pdata.Metrics {
 	b := rmb.addResourceMetrics(nil)
 
 	// One second elapsed
-	b.timestamp = oneSecond
+	b.timestamp = twoSeconds
 
 	commonAverageDiskInput(b)
 
 	mb3 := b.addMetric("system.disk.average_operation_time", pdata.MetricDataTypeDoubleSum, true)
-	mb3.addDoubleDataPoint(15+(100/5), map[string]string{"device": "hda", "direction": "read"})
-	mb3.addDoubleDataPoint(20+(100/1), map[string]string{"device": "hda", "direction": "write"})
+	mb3.addDoubleDataPoint(15+2*(100/5), map[string]string{"device": "hda", "direction": "read"})
+	mb3.addDoubleDataPoint(20+2*(100/1), map[string]string{"device": "hda", "direction": "write"})
 	mb3.addDoubleDataPoint(30, map[string]string{"device": "hdb", "direction": "read"})
-	mb3.addDoubleDataPoint(5+(50/10), map[string]string{"device": "hdb", "direction": "write"})
+	mb3.addDoubleDataPoint(5+2*(50/10), map[string]string{"device": "hdb", "direction": "write"})
 
 	rmb.Build().CopyTo(expected.ResourceMetrics())
 	return expected


### PR DESCRIPTION
This represents the fraction of time that a disk is busy performing I/O. This is the underlying value needed for `agent.googleapis.com/disk/operation_time`