### PR TITLE
Update go version in build image

### DIFF
--- a/.build/Dockerfile
+++ b/.build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-stretch
+FROM golang:1.17-stretch
 
 RUN apt-get -y update \
     && apt-get -y install \


### PR DESCRIPTION
Required to update to latest go required by the latest versions of the otel collector.