### PR TITLE
cmd/otelopscol: Filter intrusive log spam

### DIFF
--- a/cmd/otelopscol/filters.go
+++ b/cmd/otelopscol/filters.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/otelopscol/filters.go
+++ b/cmd/otelopscol/filters.go
@@ -29,7 +29,7 @@ type errorFilterConfig struct {
 
 // Returns zap options that will filter logs with some error message from a file.
 func errorFilterOptions() []zap.Option {
-	errorFilters := []errorFilterConfig{
+	errorFilterConfigs := []errorFilterConfig{
 		// Filter out a problematic upstream otel spam log from hostmetrics.
 		// Upstream issue: https://github.com/open-telemetry/opentelemetry-collector/issues/3004
 		{
@@ -39,7 +39,7 @@ func errorFilterOptions() []zap.Option {
 	}
 
 	options := []zap.Option{}
-	for _, filter := range errorFilters {
+	for _, filter := range errorFilterConfigs {
 		options = append(options, makeErrorFilterOption(filter))
 	}
 

--- a/cmd/otelopscol/filters.go
+++ b/cmd/otelopscol/filters.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"strings"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"moul.io/zapfilter"
+)
+
+// Returns a zapfilter core that will filter logs with some error message.
+func errorFilterCore() zap.Option {
+	errorSubstringsToFilter := []string{
+		// Filter out a problematic upstream otel spam log from hostmetrics.
+		// Upstream issue: https://github.com/open-telemetry/opentelemetry-collector/issues/3004
+		"error reading process name for pid",
+	}
+
+	logFilterFunc := func(entry zapcore.Entry, fields []zapcore.Field) bool {
+		if !strings.Contains(entry.Caller.File, "scrapercontroller.go") {
+			return true
+		}
+		for _, field := range fields {
+			if field.Key == "error" {
+				logError, ok := field.Interface.(error)
+				if !ok {
+					return true
+				}
+				return !matchAny(logError.Error(), errorSubstringsToFilter)
+			}
+		}
+		return true
+	}
+
+	return zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+		return zapfilter.NewFilteringCore(core, logFilterFunc)
+	})
+}
+
+func matchAny(s string, subs []string) bool {
+	matches := make([]bool, len(subs))
+	for i, sub := range subs {
+		matches[i] = strings.Contains(s, sub)
+	}
+	for _, match := range matches {
+		if match {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/otelopscol/filters_test.go
+++ b/cmd/otelopscol/filters_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/otelopscol/filters_test.go
+++ b/cmd/otelopscol/filters_test.go
@@ -35,7 +35,7 @@ func TestErrorFilterOption(t *testing.T) {
 				},
 			},
 			errors: []error{
-				errors.New("error reading process name for pid 1:"),
+				errors.New("error reading process name for pid 1"),
 			},
 			expectedLogCount: 0,
 		},
@@ -46,9 +46,9 @@ func TestErrorFilterOption(t *testing.T) {
 				},
 			},
 			errors: []error{
-				errors.New("error reading process name for pid 1:"),
-				errors.New("error reading process name for pid 2:"),
-				errors.New("error reading process name for pid 0:"),
+				errors.New("error reading process name for pid 1"),
+				errors.New("error reading process name for pid 2"),
+				errors.New("error reading process name for pid 0"),
 			},
 			expectedLogCount: 0,
 		},
@@ -59,7 +59,7 @@ func TestErrorFilterOption(t *testing.T) {
 				},
 			},
 			errors: []error{
-				errors.New("error reading process name for pid 1:"),
+				errors.New("error reading process name for pid 1"),
 				errors.New("unrelated error"),
 			},
 			expectedLogCount: 1,

--- a/cmd/otelopscol/filters_test.go
+++ b/cmd/otelopscol/filters_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestErrorFilterOption(t *testing.T) {
+	testCases := []struct {
+		filterConfigs    []errorFilterConfig
+		errors           []error
+		expectedLogCount int
+	}{
+		{
+			filterConfigs: []errorFilterConfig{
+				{
+					errorSubstrings: []string{"error reading process name"},
+				},
+			},
+			errors: []error{
+				errors.New("error reading process name for pid 1:"),
+			},
+			expectedLogCount: 0,
+		},
+		{
+			filterConfigs: []errorFilterConfig{
+				{
+					errorSubstrings: []string{"error reading process name"},
+				},
+			},
+			errors: []error{
+				errors.New("error reading process name for pid 1:"),
+				errors.New("error reading process name for pid 2:"),
+				errors.New("error reading process name for pid 0:"),
+			},
+			expectedLogCount: 0,
+		},
+		{
+			filterConfigs: []errorFilterConfig{
+				{
+					errorSubstrings: []string{"error reading process name"},
+				},
+			},
+			errors: []error{
+				errors.New("error reading process name for pid 1:"),
+				errors.New("unrelated error"),
+			},
+			expectedLogCount: 1,
+		},
+	}
+
+	for _, testCase := range testCases {
+		logger, observedLogs := makeErrorFilterLogger(testCase.filterConfigs)
+		for _, err := range testCase.errors {
+			logger.Error("error", zap.Error(err))
+		}
+		if len(observedLogs.All()) != testCase.expectedLogCount {
+			t.Fatalf("expected %d logs, got %d", testCase.expectedLogCount, len(observedLogs.All()))
+		}
+	}
+}
+
+func makeErrorFilterLogger(filterConfigs []errorFilterConfig) (*zap.Logger, *observer.ObservedLogs) {
+	observedCore, observedLogs := observer.New(zap.InfoLevel)
+	options := []zap.Option{}
+	for _, filterConfig := range filterConfigs {
+		options = append(options, makeErrorFilterOption(filterConfig))
+	}
+	logger := zap.New(observedCore, options...)
+	return logger, observedLogs
+}

--- a/cmd/otelopscol/main.go
+++ b/cmd/otelopscol/main.go
@@ -42,12 +42,15 @@ func main() {
 		Version:     version.Version,
 	}
 
+	loggingOptions := append(
+		[]zap.Option{},
+		errorFilterOptions()...,
+	)
+
 	params := service.CollectorSettings{
-		Factories: factories,
-		BuildInfo: info,
-		LoggingOptions: []zap.Option{
-			errorFilterCore(),
-		},
+		Factories:      factories,
+		BuildInfo:      info,
+		LoggingOptions: loggingOptions,
 	}
 
 	if err := run(params); err != nil {

--- a/cmd/otelopscol/main.go
+++ b/cmd/otelopscol/main.go
@@ -19,12 +19,11 @@ import (
 	"log"
 	"strings"
 
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/service"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"moul.io/zapfilter"
-
-	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/service"
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/internal/env"
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/internal/version"

--- a/cmd/otelopscol/main.go
+++ b/cmd/otelopscol/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -47,7 +48,11 @@ func main() {
 
 	// Remove hostmetrics logspam
 	logFilterFunc := func(entry zapcore.Entry, fields []zapcore.Field) bool {
-
+		if strings.Contains(entry.Caller.File, "scrapercontroller.go") {
+			if strings.Contains(entry.Message, "error reading process name for pid") {
+				return false
+			}
+		}
 		return true
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -183,6 +183,7 @@ require (
 	k8s.io/client-go v0.21.1 // indirect
 	k8s.io/klog/v2 v2.9.0 // indirect
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920 // indirect
+	moul.io/zapfilter v1.6.1
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.0 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1613,6 +1613,7 @@ go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.13.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
 go.uber.org/zap v1.14.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
 go.uber.org/zap v1.14.1/go.mod h1:Mb2vm2krFEG5DV0W9qcHBYFtp/Wku1cvYaqPsS/WYfc=
+go.uber.org/zap v1.16.0/go.mod h1:MA8QOfq0BHJwdXa996Y4dYkAqRKB8/1K1QMMZVaNZjQ=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
 go.uber.org/zap v1.19.1 h1:ue41HOKd1vGURxrmeKIgELGb3jPW9DMUDGtsinblHwI=
 go.uber.org/zap v1.19.1/go.mod h1:j3DNczoxDZroyBnOT1L/Q79cfUMGZxlv/9dzN7SM1rI=
@@ -2312,6 +2313,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 k8s.io/utils v0.0.0-20200414100711-2df71ebbae66/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920 h1:CbnUZsM497iRC5QMVkHwyl8s2tB3g7yaSHkYPkpgelw=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
+moul.io/zapfilter v1.6.1 h1:D5ySvqGTADgtOmjhKCrCOnH3DHZjIqIAQD0kwCeyBIw=
+moul.io/zapfilter v1.6.1/go.mod h1:zfT2z4z2YfI63Kifpe8GMt0M+sBXs8WQ4mfne4bGmic=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=


### PR DESCRIPTION
As outlined in open-telemetry/opentelemetry-collector#3004 the Open Telemetry Collector writes a consistent error log that is not user actionable and we would not like to see. This PR adds a logging option configuration that will detect the spamming log message and filter it.