### PR TITLE
Remove `--add-instance-id` flag

### DIFF
--- a/.build/googet/install.ps1
+++ b/.build/googet/install.ps1
@@ -32,7 +32,7 @@ try
     {
         New-Service -DisplayName "Google Cloud Metrics Agent" `
             -Name "google-cloud-metrics-agent" `
-            -BinaryPathName "$InstallDir\google-cloud-metrics-agent.exe --add-instance-id=false --config=""$InstallDir\config.yaml""" `
+            -BinaryPathName "$InstallDir\google-cloud-metrics-agent.exe  --config=""$InstallDir\config.yaml""" `
             -Description "Collects agent metrics and reports them to Google Cloud Operations."
 
         Set-ServiceConfig

--- a/.build/msi/google-cloud-metrics-agent.wxs
+++ b/.build/msi/google-cloud-metrics-agent.wxs
@@ -38,7 +38,7 @@
                Start="auto"
                Account="LocalSystem"
                ErrorControl="normal"
-               Arguments=" --add-instance-id=false --config=&quot;[INSTALLDIR]config.yaml&quot;"
+               Arguments=" --config=&quot;[INSTALLDIR]config.yaml&quot;"
                Interactive="no" />
             <ServiceControl
                Id="StartStopRemoveService"


### PR DESCRIPTION
Remove use of flag that was removed in update to collector. [applicable changelog](https://github.com/open-telemetry/opentelemetry-collector/commit/e080cae46f19a3b30135db1dbe1070d676b1c2ae). Quoting:

```
- `--add-instance-id` is no longer operative; an instance ID will always be added.
```