### PR TITLE
Create and use Zap core to combat log spam

### DIFF
--- a/cmd/otelopscol/main.go
+++ b/cmd/otelopscol/main.go
@@ -20,8 +20,11 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/service"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/internal/env"
+	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/internal/levelchanger"
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/internal/version"
 )
 
@@ -44,6 +47,12 @@ func main() {
 	params := service.CollectorSettings{
 		Factories: factories,
 		BuildInfo: info,
+		LoggingOptions: []zap.Option{
+			levelchanger.NewLevelChangerOption(
+				zapcore.ErrorLevel,
+				zapcore.DebugLevel,
+				levelchanger.FilePathLevelChangeCondition("scrapercontroller.go")),
+		},
 	}
 
 	if err := run(params); err != nil {

--- a/cmd/otelopscol/main.go
+++ b/cmd/otelopscol/main.go
@@ -51,6 +51,8 @@ func main() {
 			levelchanger.NewLevelChangerOption(
 				zapcore.ErrorLevel,
 				zapcore.DebugLevel,
+				// We would like the Error logs from this file to be logged at Debug instead.
+				// https://github.com/open-telemetry/opentelemetry-collector/blob/831373ae6c6959f6c9258ac585a2ec0ab19a074f/receiver/scraperhelper/scrapercontroller.go#L198
 				levelchanger.FilePathLevelChangeCondition("scrapercontroller.go")),
 		},
 	}

--- a/internal/levelchanger/levelchanger.go
+++ b/internal/levelchanger/levelchanger.go
@@ -1,0 +1,89 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package levelchanger
+
+import (
+	"strings"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type LevelChangeCondition func(entry zapcore.Entry, fields []zapcore.Field) bool
+
+type levelChangerCore struct {
+	next       zapcore.Core
+	fromLevel  zapcore.Level
+	toLevel    zapcore.Level
+	conditions []LevelChangeCondition
+}
+
+// This core is enabled at the requested level if the core it wraps
+// is enabled at the requested level.
+func (l levelChangerCore) Enabled(level zapcore.Level) bool {
+	return l.next.Enabled(level)
+}
+
+// This core does not allow adding additional context.
+func (l levelChangerCore) With([]zapcore.Field) zapcore.Core { return l }
+
+// This core will always add itself to the checked entry, since the Write
+// method will determine whether the entry continues to the next core.
+func (l levelChangerCore) Check(entry zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	return ce.AddCore(entry, l)
+}
+
+// Check if the log passes any core conditions, and if the log level matches the fromLevel,
+// change the log's level to the toLevel.
+func (l levelChangerCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
+	// Always pass if there are no conditions, otherwise check if any conditions are met.
+	changeLevels := len(l.conditions) == 0
+	for _, condition := range l.conditions {
+		changeLevels = changeLevels || condition(entry, fields)
+	}
+
+	if changeLevels && entry.Level == l.fromLevel {
+		entry.Level = l.toLevel
+	}
+
+	// Check if the next core is enabled at the (potentially) new log level.
+	if !l.next.Enabled(entry.Level) {
+		return nil
+	}
+	return l.next.Write(entry, fields)
+}
+
+// No special syncing is required for this core.
+func (levelChangerCore) Sync() error { return nil }
+
+// Create a zap option that wraps a core with a new levelChangerCore.
+func NewLevelChangerOption(from, to zapcore.Level, conditions ...LevelChangeCondition) zap.Option {
+	return zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+		return levelChangerCore{
+			next:       core,
+			fromLevel:  from,
+			toLevel:    to,
+			conditions: conditions,
+		}
+	})
+}
+
+// Make a level change condition that passes if the Entry's Caller File contains a
+// substring. Can be used to change the level of all logs from some file or package.
+func FilePathLevelChangeCondition(pathSubstr string) LevelChangeCondition {
+	return func(entry zapcore.Entry, fields []zapcore.Field) bool {
+		return strings.Contains(entry.Caller.File, pathSubstr)
+	}
+}

--- a/internal/levelchanger/levelchanger_test.go
+++ b/internal/levelchanger/levelchanger_test.go
@@ -1,0 +1,122 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package levelchanger_test
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/internal/levelchanger"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+type baseTestCase struct {
+	name              string
+	loggerLevel       zapcore.Level
+	from              zapcore.Level
+	to                zapcore.Level
+	logWriteFunc      func(logger *zap.Logger)
+	expectedLogLevels []zapcore.Level
+}
+
+func TestLevelChangerCoreNoConditions(t *testing.T) {
+	t.Parallel()
+
+	testCases := []baseTestCase{
+		{
+			name:        "changes level",
+			loggerLevel: zapcore.DebugLevel,
+			from:        zapcore.ErrorLevel,
+			to:          zapcore.DebugLevel,
+			logWriteFunc: func(logger *zap.Logger) {
+				logger.Error("this should be debug")
+			},
+			expectedLogLevels: []zapcore.Level{zapcore.DebugLevel},
+		},
+		{
+			name:        "does not output the log when it changes to level the logger doesn't allow",
+			loggerLevel: zapcore.ErrorLevel,
+			from:        zapcore.ErrorLevel,
+			to:          zapcore.DebugLevel,
+			logWriteFunc: func(logger *zap.Logger) {
+				logger.Error("this should not get logged")
+			},
+			expectedLogLevels: []zapcore.Level{},
+		},
+		{
+			name:        "only changes level of logs it's supposed to",
+			loggerLevel: zapcore.DebugLevel,
+			from:        zapcore.ErrorLevel,
+			to:          zapcore.DebugLevel,
+			logWriteFunc: func(logger *zap.Logger) {
+				logger.Error("this should become debug")
+				logger.Info("this should stay info")
+			},
+			expectedLogLevels: []zapcore.Level{zapcore.DebugLevel, zapcore.InfoLevel},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			observedCore, observedLogs := observer.New(testCase.loggerLevel)
+			logger := zap.New(
+				observedCore,
+				levelchanger.NewLevelChangerOption(testCase.from, testCase.to))
+
+			testCase.logWriteFunc(logger)
+
+			allLogs := observedLogs.All()
+			assert.Equal(t, len(testCase.expectedLogLevels), len(allLogs))
+			for i, expectedLevel := range testCase.expectedLogLevels {
+				assert.Equal(t, expectedLevel, allLogs[i].Level)
+			}
+		})
+	}
+}
+
+func TestLevelChangerCoreFilePathCondition(t *testing.T) {
+	t.Parallel()
+
+	filename := "levelchanger_test.go"
+
+	observedCore, observedLogs := observer.New(zapcore.DebugLevel)
+	observedCoreOption := zap.WrapCore(func(zapcore.Core) zapcore.Core {
+		return observedCore
+	})
+
+	from := zapcore.ErrorLevel
+	to := zapcore.DebugLevel
+	levelChangeOption := levelchanger.NewLevelChangerOption(
+		from,
+		to,
+		levelchanger.FilePathLevelChangeCondition(filename))
+
+	// Using a development logger will log at debug level and will populate the entry
+	// with the calling file so we can test our condition with it.
+	logger, _ := zap.NewDevelopment(observedCoreOption, levelChangeOption)
+
+	logger.Error("should be debug")
+	assert.Len(t, observedLogs.All(), 1)
+	log := observedLogs.All()[0]
+	assert.Equal(t, zapcore.DebugLevel, log.Level)
+}
+
+func newLevelChangeLoggerAndObserver(loggerLevel, from, to zapcore.Level) (*zap.Logger, *observer.ObservedLogs) {
+	observedCore, observedLogs := observer.New(loggerLevel)
+	logger := zap.New(observedCore, levelchanger.NewLevelChangerOption(from, to))
+	return logger, observedLogs
+}

--- a/internal/levelchanger/levelchanger_test.go
+++ b/internal/levelchanger/levelchanger_test.go
@@ -17,11 +17,12 @@ package levelchanger_test
 import (
 	"testing"
 
-	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/internal/levelchanger"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/internal/levelchanger"
 )
 
 type baseTestCase struct {

--- a/internal/levelchanger/levelchanger_test.go
+++ b/internal/levelchanger/levelchanger_test.go
@@ -115,9 +115,3 @@ func TestLevelChangerCoreFilePathCondition(t *testing.T) {
 	log := observedLogs.All()[0]
 	assert.Equal(t, zapcore.DebugLevel, log.Level)
 }
-
-func newLevelChangeLoggerAndObserver(loggerLevel, from, to zapcore.Level) (*zap.Logger, *observer.ObservedLogs) {
-	observedCore, observedLogs := observer.New(loggerLevel)
-	logger := zap.New(observedCore, levelchanger.NewLevelChangerOption(from, to))
-	return logger, observedLogs
-}


### PR DESCRIPTION
`scrapercontroller.go` from the OpenTelemetry Collector logs all scraper errors at Error level, causing a lot of log spam even from default installations. This PR implements a new Zap core that will change log levels before writing, either unilaterally or under some condition. We can use this on configuring the CollectorSettings to change all Error level logs from `scrapercontroller.go` to be Debug level.