### PR TITLE
Add transform processor for moving resource attributes

### DIFF
--- a/cmd/otelopscol/components.go
+++ b/cmd/otelopscol/components.go
@@ -21,6 +21,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver"
@@ -125,6 +126,7 @@ func components() (component.Factories, error) {
 		metricstransformprocessor.NewFactory(),
 		resourcedetectionprocessor.NewFactory(),
 		resourceprocessor.NewFactory(),
+		transformprocessor.NewFactory(),
 	}
 	for _, pr := range factories.Processors {
 		processors = append(processors, pr)

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/SAP/go-hdb v0.105.5 // indirect
 	github.com/Showmax/go-fqdn v1.0.0 // indirect
 	github.com/StackExchange/wmi v1.2.1 // indirect
+	github.com/alecthomas/participle/v2 v2.0.0-alpha8 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/antonmedv/expr v1.9.0 // indirect
 	github.com/armon/go-metrics v0.3.10 // indirect
@@ -160,6 +161,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.51.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.51.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters v0.51.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.51.1-0.20220518173758-76d58ec42d82 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver v0.51.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -198,6 +198,9 @@ github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
+github.com/alecthomas/participle/v2 v2.0.0-alpha8 h1:X6nuChfgfQXNTE+ZdjTFSfnSNr8E07LSVLAqIIjtsGI=
+github.com/alecthomas/participle/v2 v2.0.0-alpha8/go.mod h1:NumScqsC42o9x+dGj8/YqsIfhrIQjFEOFovxotbBirA=
+github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -1369,6 +1372,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedete
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.51.0/go.mod h1:ZF9JooP9lc4SnGOFYGCqGFrlTUnngEm8KPKoQDRE4Nk=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.51.0 h1:o08VlJqVerBZy0wP+JoRl52SA5jCIApVAjXspW/i2uc=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.51.0/go.mod h1:YMH0z5mneD0AAWvtK6LzLGl+7uvy6B586m2HauRa7i8=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.51.1-0.20220518173758-76d58ec42d82 h1:X0MqXjbnOT7tjZJVPm4TBi2hXdvpHlM8g/H0xTCQ0Do=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.51.1-0.20220518173758-76d58ec42d82/go.mod h1:HsIFemgyUxgmtadVkkwz//dJgr7A2JpHfCTLztmPH7Q=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.51.0 h1:p4TSLlhj8XLMgJRZwNnRTM33B+fEcOKbRAIu/m2f7DU=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.51.0/go.mod h1:4uY+Tqzjt2A4d9ZYbch6ZrnFgP8Pxtn+FoJnJYGB794=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver v0.51.0 h1:xbvN8v/F8I1rfUYekdIp15+LYvqLAA4AhXwVplXfpYM=


### PR DESCRIPTION
This new(ly supporting metrics) [processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor) will allow a configuration like the following, which enables us to move forward with things like SQL Server & SAP Hana receivers which have resource attributes that need to be moved down to metric attributes.

```
processors:
  transform/sqlserver:
    metrics:
      queries:
        - set(attributes["host"], resource.attributes["sqlserver.host"]
  transform/saphana:
    metrics:
      queries:
        - set(attributes["host"], resource.attributes["saphana.host"]
```