### PR TITLE
Update `transformprocessor` to not panic on gauges

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.59.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.1-0.20220906183641-4281e841024d
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver v0.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver v0.59.0
@@ -221,7 +221,7 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/goleak v1.1.12 // indirect
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
-	golang.org/x/exp v0.0.0-20220713135740-79cabaa25d75 // indirect
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.59.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.1-0.20220906183641-4281e841024d
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.1-0.20220906184950-aa1c1f330ec9
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver v0.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver v0.59.0
@@ -174,7 +174,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.59.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/metadataproviders v0.59.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.59.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage v0.59.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage v0.59.1-0.20220906184950-aa1c1f330ec9 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.59.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters v0.59.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -672,8 +672,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedete
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.59.0/go.mod h1:U6f1YRLbyDVAUUWHwUD1Ct5Q4kfAWiUsvYoIV6vazmU=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.59.0 h1:f7ATuUahmHYNPTI1Wt6GLOoz3WI1VE8/ZGtgNdCWAnU=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.59.0/go.mod h1:nhnX/K9se/lAqUHu6mHDVsFZylq3vPUIj1VCuGWyEg0=
-github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.0 h1:V/4kkttja+EOsfZhS35AYbdBpyBsET8B2ExKQ0eF/GM=
-github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.0/go.mod h1:ca6WFweyts0gGNS3dNSK5rZ1PkCpBmQMponxl/eLcCI=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.1-0.20220906183641-4281e841024d h1:7PGTS9Q0oD3W2EZegoPqn9b7/FPtIPSFO6ackwBtGhk=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.1-0.20220906183641-4281e841024d/go.mod h1:JnMJ5uICwCkl5Kjiie5K37uxjhfLl24HXdOMwizKknk=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.59.0 h1:7U3SYlOgOrHzmenx/VpN+MHZRRTUNjjq0e0xKhUqK1w=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.59.0/go.mod h1:l5fl9bEiXtImPS6Z8b4iOkZbAL5zvFW9GautY+52IvQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver v0.59.0 h1:DrvYcL91Y4EkfbetGPN6ayKjfx2izzsuTL9OuU21OyA=
@@ -949,8 +949,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20220713135740-79cabaa25d75 h1:x03zeu7B2B11ySp+daztnwM5oBJ/8wGUSqrwcw9L0RA=
-golang.org/x/exp v0.0.0-20220713135740-79cabaa25d75/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/go.sum
+++ b/go.sum
@@ -656,8 +656,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest v
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.59.0 h1:kaSqabTOdLy7E+5vC8K0xCJVPFANa4LMJvpaTo8MV6o=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.59.0/go.mod h1:24Z7QmC7MW0nV6/wHEOMIeDCMFfj7t/Qi5PPwotVIfo=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.59.0 h1:D9JetxR98ZSGYvJzpA0lIsGFYAuZOIpZ00Tq7Gnty8o=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage v0.59.0 h1:uVQmiE4MY3KfXNkxzCJYnqHEsTWufbaufRmbdfwB/lE=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage v0.59.0/go.mod h1:Z1WlPedBZ9JjN7BW330sdszqMBnxmBtD+Db4OkTI88k=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage v0.59.1-0.20220906184950-aa1c1f330ec9 h1:9T5ir35iiNyc2I0rGEoCzjSPFnznvmyoXXzLpVadG80=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage v0.59.1-0.20220906184950-aa1c1f330ec9/go.mod h1:Ik72N0d4FcOb6d3epDkBTJp3GFHLeo6b65BfQsxep8I=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.59.0 h1:/XBLDr44f+jOy0H5pOjxQu0kemccNsZuhC0ZLM85itw=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.59.0/go.mod h1:kxAMbgw8c6R5bPFylPiXXBdUwaZNP7CI3CECWBHE52g=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.59.0 h1:q93i8ABbyVsMV/0YJvozDlnGaMyzO8OKuyz4/eU2BOA=
@@ -672,8 +672,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedete
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.59.0/go.mod h1:U6f1YRLbyDVAUUWHwUD1Ct5Q4kfAWiUsvYoIV6vazmU=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.59.0 h1:f7ATuUahmHYNPTI1Wt6GLOoz3WI1VE8/ZGtgNdCWAnU=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.59.0/go.mod h1:nhnX/K9se/lAqUHu6mHDVsFZylq3vPUIj1VCuGWyEg0=
-github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.1-0.20220906183641-4281e841024d h1:7PGTS9Q0oD3W2EZegoPqn9b7/FPtIPSFO6ackwBtGhk=
-github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.1-0.20220906183641-4281e841024d/go.mod h1:JnMJ5uICwCkl5Kjiie5K37uxjhfLl24HXdOMwizKknk=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.1-0.20220906184950-aa1c1f330ec9 h1:RQKChGBEuKfjjsA25b9pfV40OvhWDjCeFqmuR9a+dsA=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.1-0.20220906184950-aa1c1f330ec9/go.mod h1:JnMJ5uICwCkl5Kjiie5K37uxjhfLl24HXdOMwizKknk=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.59.0 h1:7U3SYlOgOrHzmenx/VpN+MHZRRTUNjjq0e0xKhUqK1w=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.59.0/go.mod h1:l5fl9bEiXtImPS6Z8b4iOkZbAL5zvFW9GautY+52IvQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver v0.59.0 h1:DrvYcL91Y4EkfbetGPN6ayKjfx2izzsuTL9OuU21OyA=


### PR DESCRIPTION
It appears v0.59.0 had a bug where the `transformprocessor` would panic on gauges. For more context, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13905.

Updating this so that https://github.com/GoogleCloudPlatform/ops-agent/pull/825 can hopefully be unblocked. 