### PR TITLE
components: add googlemanagedprometheus as an exporter

### DIFF
--- a/cmd/otelopscol/components.go
+++ b/cmd/otelopscol/components.go
@@ -17,6 +17,7 @@ package main
 import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor"
@@ -113,6 +114,7 @@ func components() (component.Factories, error) {
 	exporters := []component.ExporterFactory{
 		fileexporter.NewFactory(),
 		googlecloudexporter.NewFactory(),
+		googlemanagedprometheusexporter.NewFactory(),
 	}
 	for _, exp := range factories.Exporters {
 		exporters = append(exporters, exp)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.59.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.59.0
@@ -62,6 +63,7 @@ require (
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.6 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.6 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.32.6 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.8.6 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.32.6 // indirect
 	github.com/Microsoft/go-winio v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.6
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.6/go.mod h1:s7Gpwj0tk7XnVCm4BQEmx/mbS36SuTCY/vMB2SNxe8o=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.6 h1:bQirpWOAAbrd/ZRBs8f8M9Ch82fnxNYLg5KpJa67S3U=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.6/go.mod h1:4xKDyI4iB3HAjcQkcumkn8V9U3/qkxAijjnetJQsDPk=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.32.6 h1:gcsVmUcUOAby0ssrmCAm6DfSXYuUMg5+bQXX4GsGT5c=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.32.6/go.mod h1:PNgIRojXx6njOk9Ka9aTccJBO6xzqtIUSz8PJNZJGbM=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.8.6 h1:TOxk7n3PE2OkdNMgrXDtDr3ju4pIvwhY515tCoH0CpE=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.8.6/go.mod h1:NE8dAwJ1VU4WFdJYTlO0tdobQFdy70z8wNDU1L3VAr4=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.32.6 h1:QHbRbU/HI7SuNVqP0rDHK5jAMcwzuAex2akl3p+7YTo=
@@ -642,6 +644,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter 
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.59.0/go.mod h1:PXapW0E1vEAW2v0tVQonmJusk5psmkAuGCdTpFi2rDQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.59.0 h1:uGXDpCLUinHJy9QZv9V1jZ1TOfftVr3VzF0QPRg4sI0=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.59.0/go.mod h1:EkMAXBlr1Tm1kDJbvaxA3UgfahxrcWjIBvuUuQSGLhA=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.59.0 h1:O40KGetWnzT72JgDxtU99PCroN3E4it58iOW/2HbTog=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.59.0/go.mod h1:Tc7Qia4qgUuNgo0doXK1xOfZuZtlV35Le0raPtkZvjg=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.59.0 h1:d/2BGEdrs/ZYlV1nWk/Xy+jJHyVREvfsAkh5UjSjINw=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil v0.59.0 h1:WZT6ElIgz62U72R/uBEdrptkjTN7muVvE7RQNbb5gjQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil v0.59.0/go.mod h1:G8hyw/9V67YXtxMYOjnzjPYXDqeuuzY8P4NlDiNSEZc=


### PR DESCRIPTION
This change adds google managed prometheus as an exporter. To be used by the `prometheus` receiver the Ops Agent will support.