### PR TITLE
processors: add groupbyattrs processor for the Ops Agent to use

### DIFF
--- a/cmd/otelopscol/components.go
+++ b/cmd/otelopscol/components.go
@@ -19,6 +19,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor"
@@ -135,6 +136,7 @@ func components() (component.Factories, error) {
 		resourcedetectionprocessor.NewFactory(),
 		resourceprocessor.NewFactory(),
 		transformprocessor.NewFactory(),
+		groupbyattrsprocessor.NewFactory(),
 	}
 	for _, pr := range factories.Processors {
 		processors = append(processors, pr)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.60.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.60.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.60.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.60.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.60.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.60.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.60.0

--- a/go.sum
+++ b/go.sum
@@ -765,6 +765,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters v0
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters v0.60.0/go.mod h1:H2xW/JlRzLreImGETqbSXIGuH0z8hmo//udRg4YGxtg=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.60.0 h1:CSVxKdZ3CHdXBAUxE2ykvDlgabG8HLh716/j4ZTDtWw=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.60.0/go.mod h1:UX6ECUemByrbz1eHDO5BbSbzJjtNWUvrfnAy57s0VZw=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.60.0 h1:vj2tQ/nMs5nD+cVOzkO0PlF6q087FhVMovAVe+N8lsk=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.60.0/go.mod h1:iNeduBokKDbmUue0lS27dX8qUo6lUKaqYsXHHEQ1mpk=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.60.0 h1:F2HREw9aG6/j9cIawAshAgJv7q7sEvT0bTzq+sUnjo4=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.60.0/go.mod h1:Se9HkDOcwy9sHs2mMkWB0eGtSAeUpn044LndxDvv+ao=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.60.0 h1:NACpxZI3eicntyiScxzhS/KOBBKIL0nbcvbUIIThiCE=


### PR DESCRIPTION
This processor is useful for prometheus to set the `namespace`, `location` and `cluster` labels in the monntored resource.