### PR TITLE
Add null check for the nvml client in the shutdown function 

### DIFF
--- a/receiver/nvmlreceiver/scraper.go
+++ b/receiver/nvmlreceiver/scraper.go
@@ -56,7 +56,10 @@ func (s *nvmlScraper) start(_ context.Context, host component.Host) error {
 }
 
 func (s *nvmlScraper) stop(_ context.Context) error {
-	return s.client.cleanup()
+	if s.client != nil {
+		return s.client.cleanup()
+	}
+	return nil
 }
 
 func (s *nvmlScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {


### PR DESCRIPTION
In the case when one of the receivers of the collector could not start, the shutdown function could be called without an instance of a nvml client. Add null check in the shutdown function. 
![Screen Shot 2023-01-16 at 1 38 45 PM](https://user-images.githubusercontent.com/9001073/213351444-072bfcad-1c38-444f-84ce-420b470b6bcb.png)
