### PR TITLE
Support mongo index metric from introduction of indexStats

### DIFF
--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -103,10 +103,10 @@ func (s *mongodbScraper) collectMetrics(ctx context.Context, errs *scrapererror.
 			return
 		}
 
-		// Mongo version 4.0+ is required to have authorized access to list collection names
-		// reference: https://www.mongodb.com/docs/manual/reference/method/db.getCollectionNames/
-		mongo40, _ := version.NewVersion("4.0")
-		if s.mongoVersion.GreaterThanOrEqual(mongo40) {
+		// Collect the the indexStats aggregation is only available if version is >= 3.2
+		// https://www.mongodb.com/docs/v3.2/reference/operator/aggregation/indexStats/
+		mongo32, _ := version.NewVersion("3.2")
+		if s.mongoVersion.GreaterThanOrEqual(mongo32) {
 			for _, collectionName := range collectionNames {
 				s.collectIndexStats(ctx, now, dbName, collectionName, errs)
 			}

--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -103,7 +103,7 @@ func (s *mongodbScraper) collectMetrics(ctx context.Context, errs *scrapererror.
 			return
 		}
 
-		// Collect the the indexStats aggregation is only available if version is >= 3.2
+		// The indexStats aggregation is only available if version is >= 3.2
 		// https://www.mongodb.com/docs/v3.2/reference/operator/aggregation/indexStats/
 		mongo32, _ := version.NewVersion("3.2")
 		if s.mongoVersion.GreaterThanOrEqual(mongo32) {


### PR DESCRIPTION
The comment & version comparison (which came directly from the ported version in otel) were inaccurate, causing an expected metric to be missing in kokoro.

getCollectionNames is available [as far back as v3.0](https://www.mongodb.com/docs/v3.0/reference/method/db.getCollectionNames/)  and the code being blocked by a version check would not even be executed unless collectionNames were successfully requested a few lines above.