### PR TITLE
Dockerfile: update the dockerfile for go 1.20

### DIFF
--- a/.build/Dockerfile
+++ b/.build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-stretch
+FROM golang:1.20-bullseye
 
 RUN apt-get -y update \
     && apt-get -y install \
@@ -9,7 +9,7 @@ RUN apt-get -y update \
 ENV GO111MODULE=on
 
 RUN go install github.com/client9/misspell/cmd/misspell@v0.3.4 \
-    && go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0 \
+    && go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.1 \
     && go install github.com/google/addlicense@v1.0.0 \
     && go install github.com/google/googet/goopack@latest \
     && go install github.com/pavius/impi/cmd/impi@v0.0.3


### PR DESCRIPTION
Need to unblock #158 by uploading the updated Dockerfile to GCR when this gets merged