### PR TITLE
prometheusreceiver: add metric attribute for untyped metrics

### DIFF
--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -737,6 +737,7 @@ func TestMetricBuilderUntyped(t *testing.T) {
 				pt0.SetStartTimestamp(0)
 				pt0.SetTimestamp(tsNanos)
 				pt0.Attributes().PutStr("foo", "bar")
+				pt0.Attributes().PutBool(PrometheusUntypedKey, true)
 
 				return []pmetric.Metrics{md0}
 			},
@@ -762,6 +763,7 @@ func TestMetricBuilderUntyped(t *testing.T) {
 				pt0.SetDoubleValue(100.0)
 				pt0.SetTimestamp(tsNanos)
 				pt0.Attributes().PutStr("foo", "bar")
+				pt0.Attributes().PutBool(PrometheusUntypedKey, true)
 
 				m1 := mL0.AppendEmpty()
 				m1.SetName("theother_not_exists")
@@ -770,11 +772,13 @@ func TestMetricBuilderUntyped(t *testing.T) {
 				pt1.SetDoubleValue(200.0)
 				pt1.SetTimestamp(tsNanos)
 				pt1.Attributes().PutStr("foo", "bar")
+				pt1.Attributes().PutBool(PrometheusUntypedKey, true)
 
 				pt2 := gauge1.DataPoints().AppendEmpty()
 				pt2.SetDoubleValue(300.0)
 				pt2.SetTimestamp(tsNanos)
 				pt2.Attributes().PutStr("bar", "foo")
+				pt2.Attributes().PutBool(PrometheusUntypedKey, true)
 
 				return []pmetric.Metrics{md0}
 			},
@@ -798,6 +802,7 @@ func TestMetricBuilderUntyped(t *testing.T) {
 				pt0.SetDoubleValue(100.0)
 				pt0.SetTimestamp(tsNanos)
 				pt0.Attributes().PutStr("foo", "bar")
+				pt0.Attributes().PutBool(PrometheusUntypedKey, true)
 
 				return []pmetric.Metrics{md0}
 			},

--- a/receiver/prometheusreceiver/metrics_receiver_non_numerical_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_non_numerical_test.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/receiver/prometheusreceiver/internal"
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/featuregate"
@@ -287,7 +288,7 @@ func verifyNormalNaNs(t *testing.T, td *testData, resourceMetrics []pmetric.Reso
 				{
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
-						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6380"}),
+						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6380", internal.PrometheusUntypedKey: "true"}),
 						assertNormalNan(),
 					},
 				},
@@ -371,7 +372,7 @@ func verifyInfValues(t *testing.T, td *testData, resourceMetrics []pmetric.Resou
 				{
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
-						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6380"}),
+						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6380", internal.PrometheusUntypedKey: "true"}),
 						compareDoubleValue(math.Inf(-1)),
 					},
 				},

--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/receiver/prometheusreceiver/internal"
 	"github.com/prometheus/common/model"
 	promConfig "github.com/prometheus/prometheus/config"
 	"github.com/stretchr/testify/assert"
@@ -1452,7 +1453,6 @@ func verifyUntypedMetrics(t *testing.T, td *testData, resourceMetrics []pmetric.
 	assert.Equal(t, 7, metricsCount(m1))
 
 	wantAttributes := td.attributes
-
 	metrics1 := m1.ScopeMetrics().At(0).Metrics()
 	ts1 := getTS(metrics1)
 	e1 := []testExpectation{
@@ -1463,14 +1463,14 @@ func verifyUntypedMetrics(t *testing.T, td *testData, resourceMetrics []pmetric.
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
 						compareDoubleValue(100),
-						compareAttributes(map[string]string{"method": "post", "code": "200"}),
+						compareAttributes(map[string]string{"method": "post", "code": "200", internal.PrometheusUntypedKey: "true"}),
 					},
 				},
 				{
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
 						compareDoubleValue(5),
-						compareAttributes(map[string]string{"method": "post", "code": "400"}),
+						compareAttributes(map[string]string{"method": "post", "code": "400", internal.PrometheusUntypedKey: "true"}),
 					},
 				},
 			}),
@@ -1481,14 +1481,14 @@ func verifyUntypedMetrics(t *testing.T, td *testData, resourceMetrics []pmetric.
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
 						compareDoubleValue(10),
-						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6380"}),
+						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6380", internal.PrometheusUntypedKey: "true"}),
 					},
 				},
 				{
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
 						compareDoubleValue(12),
-						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6381"}),
+						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6381", internal.PrometheusUntypedKey: "true"}),
 					},
 				},
 			}),

--- a/receiver/prometheusreceiver/metrics_reciever_metric_rename_test.go
+++ b/receiver/prometheusreceiver/metrics_reciever_metric_rename_test.go
@@ -17,6 +17,7 @@ package prometheusreceiver
 import (
 	"testing"
 
+	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/receiver/prometheusreceiver/internal"
 	"github.com/prometheus/common/model"
 	promcfg "github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/relabel"
@@ -141,10 +142,11 @@ func verifyRenameMetric(t *testing.T, td *testData, resourceMetrics []pmetric.Re
 				},
 				{
 					// renaming config converts any metric type to untyped metric, which then gets converted to gauge double type by metric builder
+					// This bug is tracked here: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5001
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
 						compareDoubleValue(15),
-						compareAttributes(map[string]string{"method": "post", "port": "6380"}),
+						compareAttributes(map[string]string{"method": "post", "port": "6380", internal.PrometheusUntypedKey: "true"}),
 					},
 				},
 			}),
@@ -156,14 +158,14 @@ func verifyRenameMetric(t *testing.T, td *testData, resourceMetrics []pmetric.Re
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
 						compareDoubleValue(10),
-						compareAttributes(map[string]string{"method": "post", "port": "6380"}),
+						compareAttributes(map[string]string{"method": "post", "port": "6380", internal.PrometheusUntypedKey: "true"}),
 					},
 				},
 				{
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
 						compareDoubleValue(12),
-						compareAttributes(map[string]string{"method": "post", "port": "6381"}),
+						compareAttributes(map[string]string{"method": "post", "port": "6381", internal.PrometheusUntypedKey: "true"}),
 					},
 				},
 			}),


### PR DESCRIPTION
This change adds a metric attribute that encodes whether the original promehteus metric was untyped. It is still convereted to an OTLP gauge but with an additional attribute so the exporters and processors can use this information to drop the metric to support it differently than gauges.