### PR TITLE
DCGM receiver: Soft disable the receiver when DCGM not installed

### DIFF
--- a/receiver/dcgmreceiver/client_test.go
+++ b/receiver/dcgmreceiver/client_test.go
@@ -46,6 +46,7 @@ func TestNewDcgmClientOnInitializationError(t *testing.T) {
 
 	client, err := newClient(createDefaultConfig().(*Config), logger)
 	assert.Equal(t, seenDcgmConnectionWarning, true)
-	assert.Regexp(t, ".*Unable to connect.*", err)
-	require.Nil(t, client)
+	require.NotNil(t, client)
+	require.Equal(t, client.disable, true)
+	require.Nil(t, err)
 }


### PR DESCRIPTION
b/279022165

Modify the start up behaviour of the DCGM receiver to have similar logic as the NVML receiver - when the receiver is enabled and the DCGM app is not installed OR not running, soft disable the receiver, emit no metrics, and log the warning message. Throwing errors in this case could cause the entire collector to exit, which is normally not the expected behaviour. 

Tests in the Ops Agent: https://github.com/GoogleCloudPlatform/ops-agent/pull/1338
