### PR TITLE
prometheusreceiver: add namespace to internal metric label

### DIFF
--- a/receiver/prometheusreceiver/internal/metricfamily.go
+++ b/receiver/prometheusreceiver/internal/metricfamily.go
@@ -34,9 +34,10 @@ import (
 )
 
 const (
-	traceIDKey           = "trace_id"
-	spanIDKey            = "span_id"
-	PrometheusUntypedKey = "prometheus_untyped_metric"
+	traceIDKey = "trace_id"
+	spanIDKey  = "span_id"
+
+	GCPOpsAgentUntypedMetricKey = "prometheus.googleapis.com/internal/untyped_metric"
 )
 
 type metricFamily struct {
@@ -265,7 +266,7 @@ func populateAttributes(mType pmetric.MetricType, pType textparse.MetricType, ls
 
 	// Preserve the untypedness of the metric as a metric attribute.
 	if preserveUntyped && (pType == textparse.MetricTypeUnknown) {
-		dest.PutBool(PrometheusUntypedKey, true)
+		dest.PutBool(GCPOpsAgentUntypedMetricKey, true)
 	}
 }
 

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -737,7 +737,7 @@ func TestMetricBuilderUntyped(t *testing.T) {
 				pt0.SetStartTimestamp(0)
 				pt0.SetTimestamp(tsNanos)
 				pt0.Attributes().PutStr("foo", "bar")
-				pt0.Attributes().PutBool(PrometheusUntypedKey, true)
+				pt0.Attributes().PutBool(GCPOpsAgentUntypedMetricKey, true)
 
 				return []pmetric.Metrics{md0}
 			},
@@ -763,7 +763,7 @@ func TestMetricBuilderUntyped(t *testing.T) {
 				pt0.SetDoubleValue(100.0)
 				pt0.SetTimestamp(tsNanos)
 				pt0.Attributes().PutStr("foo", "bar")
-				pt0.Attributes().PutBool(PrometheusUntypedKey, true)
+				pt0.Attributes().PutBool(GCPOpsAgentUntypedMetricKey, true)
 
 				m1 := mL0.AppendEmpty()
 				m1.SetName("theother_not_exists")
@@ -772,13 +772,13 @@ func TestMetricBuilderUntyped(t *testing.T) {
 				pt1.SetDoubleValue(200.0)
 				pt1.SetTimestamp(tsNanos)
 				pt1.Attributes().PutStr("foo", "bar")
-				pt1.Attributes().PutBool(PrometheusUntypedKey, true)
+				pt1.Attributes().PutBool(GCPOpsAgentUntypedMetricKey, true)
 
 				pt2 := gauge1.DataPoints().AppendEmpty()
 				pt2.SetDoubleValue(300.0)
 				pt2.SetTimestamp(tsNanos)
 				pt2.Attributes().PutStr("bar", "foo")
-				pt2.Attributes().PutBool(PrometheusUntypedKey, true)
+				pt2.Attributes().PutBool(GCPOpsAgentUntypedMetricKey, true)
 
 				return []pmetric.Metrics{md0}
 			},
@@ -802,7 +802,7 @@ func TestMetricBuilderUntyped(t *testing.T) {
 				pt0.SetDoubleValue(100.0)
 				pt0.SetTimestamp(tsNanos)
 				pt0.Attributes().PutStr("foo", "bar")
-				pt0.Attributes().PutBool(PrometheusUntypedKey, true)
+				pt0.Attributes().PutBool(GCPOpsAgentUntypedMetricKey, true)
 
 				return []pmetric.Metrics{md0}
 			},

--- a/receiver/prometheusreceiver/metrics_receiver_non_numerical_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_non_numerical_test.go
@@ -288,7 +288,7 @@ func verifyNormalNaNs(t *testing.T, td *testData, resourceMetrics []pmetric.Reso
 				{
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
-						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6380", internal.PrometheusUntypedKey: "true"}),
+						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6380", internal.GCPOpsAgentUntypedMetricKey: "true"}),
 						assertNormalNan(),
 					},
 				},
@@ -372,7 +372,7 @@ func verifyInfValues(t *testing.T, td *testData, resourceMetrics []pmetric.Resou
 				{
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
-						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6380", internal.PrometheusUntypedKey: "true"}),
+						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6380", internal.GCPOpsAgentUntypedMetricKey: "true"}),
 						compareDoubleValue(math.Inf(-1)),
 					},
 				},

--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -1463,14 +1463,14 @@ func verifyUntypedMetrics(t *testing.T, td *testData, resourceMetrics []pmetric.
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
 						compareDoubleValue(100),
-						compareAttributes(map[string]string{"method": "post", "code": "200", internal.PrometheusUntypedKey: "true"}),
+						compareAttributes(map[string]string{"method": "post", "code": "200", internal.GCPOpsAgentUntypedMetricKey: "true"}),
 					},
 				},
 				{
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
 						compareDoubleValue(5),
-						compareAttributes(map[string]string{"method": "post", "code": "400", internal.PrometheusUntypedKey: "true"}),
+						compareAttributes(map[string]string{"method": "post", "code": "400", internal.GCPOpsAgentUntypedMetricKey: "true"}),
 					},
 				},
 			}),
@@ -1481,14 +1481,14 @@ func verifyUntypedMetrics(t *testing.T, td *testData, resourceMetrics []pmetric.
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
 						compareDoubleValue(10),
-						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6380", internal.PrometheusUntypedKey: "true"}),
+						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6380", internal.GCPOpsAgentUntypedMetricKey: "true"}),
 					},
 				},
 				{
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
 						compareDoubleValue(12),
-						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6381", internal.PrometheusUntypedKey: "true"}),
+						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6381", internal.GCPOpsAgentUntypedMetricKey: "true"}),
 					},
 				},
 			}),

--- a/receiver/prometheusreceiver/metrics_reciever_metric_rename_test.go
+++ b/receiver/prometheusreceiver/metrics_reciever_metric_rename_test.go
@@ -146,7 +146,7 @@ func verifyRenameMetric(t *testing.T, td *testData, resourceMetrics []pmetric.Re
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
 						compareDoubleValue(15),
-						compareAttributes(map[string]string{"method": "post", "port": "6380", internal.PrometheusUntypedKey: "true"}),
+						compareAttributes(map[string]string{"method": "post", "port": "6380", internal.GCPOpsAgentUntypedMetricKey: "true"}),
 					},
 				},
 			}),
@@ -158,14 +158,14 @@ func verifyRenameMetric(t *testing.T, td *testData, resourceMetrics []pmetric.Re
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
 						compareDoubleValue(10),
-						compareAttributes(map[string]string{"method": "post", "port": "6380", internal.PrometheusUntypedKey: "true"}),
+						compareAttributes(map[string]string{"method": "post", "port": "6380", internal.GCPOpsAgentUntypedMetricKey: "true"}),
 					},
 				},
 				{
 					numberPointComparator: []numberPointComparator{
 						compareTimestamp(ts1),
 						compareDoubleValue(12),
-						compareAttributes(map[string]string{"method": "post", "port": "6381", internal.PrometheusUntypedKey: "true"}),
+						compareAttributes(map[string]string{"method": "post", "port": "6381", internal.GCPOpsAgentUntypedMetricKey: "true"}),
 					},
 				},
 			}),


### PR DESCRIPTION
Leveraged by https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/684

The namespace prefix we're adding is so OTLP gauge metrics don't conflict with this metric attribute - this will be part of the Ops Agent documentation