### PR TITLE
DCGM: Enable the receiver to retry dcgm initialization at each collection time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.42.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.42.0
-	github.com/NVIDIA/go-dcgm v0.0.0-20221107203308-b6ed78cdc8d3
+	github.com/NVIDIA/go-dcgm v0.0.0-20230811193702-90bac724c747
 	github.com/NVIDIA/go-nvml v0.11.6-0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.81.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.81.0

--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,8 @@ github.com/Microsoft/go-winio v0.6.0/go.mod h1:cTAf44im0RAYeL23bpB+fzCyDH2MJiz2B
 github.com/Mottl/ctimefmt v0.0.0-20190803144728-fd2ac23a585a/go.mod h1:eyj2WSIdoPMPs2eNTLpSmM6Nzqo4V80/d6jHpnJ1SAI=
 github.com/NVIDIA/go-dcgm v0.0.0-20221107203308-b6ed78cdc8d3 h1:qk/qQaBY+918SBhcJsqYwZdDaS3MRtUH2SUX53SC7Cs=
 github.com/NVIDIA/go-dcgm v0.0.0-20221107203308-b6ed78cdc8d3/go.mod h1:atKWXstYFllLarJucBxnt9ivFIPe26Y6S4JQvzqeSr8=
+github.com/NVIDIA/go-dcgm v0.0.0-20230811193702-90bac724c747 h1:inukNBh/RJl4CsxPL3rwSAUwKI90YC3Vf8uaJ0V/J3o=
+github.com/NVIDIA/go-dcgm v0.0.0-20230811193702-90bac724c747/go.mod h1:atKWXstYFllLarJucBxnt9ivFIPe26Y6S4JQvzqeSr8=
 github.com/NVIDIA/go-nvml v0.11.6-0 h1:tugQzmaX84Y/6+03wZ/MAgcpfSKDkvkAWeuxFNLHmxY=
 github.com/NVIDIA/go-nvml v0.11.6-0/go.mod h1:hy7HYeQy335x6nEss0Ne3PYqleRa6Ct+VKD9RQ4nyFs=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/receiver/dcgmreceiver/client_gpu_test.go
+++ b/receiver/dcgmreceiver/client_gpu_test.go
@@ -52,8 +52,7 @@ type modelSupportedFields struct {
 // files for the current GPU model
 func TestSupportedFieldsWithGolden(t *testing.T) {
 	config := createDefaultConfig().(*Config)
-	logger := zaptest.NewLogger(t)
-	client, err := newClient(config, logger)
+	client, err := newClient(config, zaptest.NewLogger(t))
 	require.Nil(t, err, "can not initialize DCGM. Install and run DCGM before running tests.")
 
 	assert.NotEmpty(t, client.devicesModelName)
@@ -138,12 +137,11 @@ func getModelGoldenFilePath(t *testing.T, model string) string {
 }
 
 func TestNewDcgmClientWithGpuPresent(t *testing.T) {
-	config := createDefaultConfig().(*Config)
-	logger := zaptest.NewLogger(t)
-	client, err := newClient(config, logger)
+	client, err := newClient(createDefaultConfig().(*Config), zaptest.NewLogger(t))
 	require.Nil(t, err, "can not initialize DCGM. Install and run DCGM before running tests.")
 
 	assert.NotNil(t, client)
+	assert.NotNil(t, client.handleCleanup)
 	assert.Greater(t, len(client.deviceIndices), 0)
 	for gpuIndex := range client.deviceIndices {
 		assert.Greater(t, len(client.devicesModelName[gpuIndex]), 0)
@@ -153,9 +151,7 @@ func TestNewDcgmClientWithGpuPresent(t *testing.T) {
 }
 
 func TestCollectGpuProfilingMetrics(t *testing.T) {
-	config := createDefaultConfig().(*Config)
-	logger := zaptest.NewLogger(t)
-	client, err := newClient(config, logger)
+	client, err := newClient(createDefaultConfig().(*Config), zaptest.NewLogger(t))
 	require.Nil(t, err, "can not initialize DCGM. Install and run DCGM before running tests.")
 	expectedMetrics := LoadExpectedMetrics(t, client.devicesModelName[0])
 	var maxCollectionInterval = 60 * time.Second

--- a/receiver/dcgmreceiver/client_gpu_test.go
+++ b/receiver/dcgmreceiver/client_gpu_test.go
@@ -53,10 +53,8 @@ type modelSupportedFields struct {
 func TestSupportedFieldsWithGolden(t *testing.T) {
 	config := createDefaultConfig().(*Config)
 	logger := zaptest.NewLogger(t)
-	dcgmCleanup, err := initializeDcgm(config, logger)
-	require.Nil(t, err, "can not initialize DCGM. Install and run DCGM before running tests.")
 	client, err := newClient(config, logger)
-	require.Nil(t, err)
+	require.Nil(t, err, "can not initialize DCGM. Install and run DCGM before running tests.")
 
 	assert.NotEmpty(t, client.devicesModelName)
 	gpuModel := client.getDeviceModelName(0)
@@ -89,7 +87,7 @@ func TestSupportedFieldsWithGolden(t *testing.T) {
 	assert.Equal(t, len(dcgmNameToMetricName), len(client.enabledFieldIDs)+len(unavailableFieldsString))
 	goldenPath := getModelGoldenFilePath(t, gpuModel)
 	golden.Assert(t, string(actual), goldenPath)
-	dcgmCleanup()
+	client.cleanup()
 }
 
 // LoadExpectedMetrics read the supported metrics of a GPU model from the golden
@@ -142,10 +140,8 @@ func getModelGoldenFilePath(t *testing.T, model string) string {
 func TestNewDcgmClientWithGpuPresent(t *testing.T) {
 	config := createDefaultConfig().(*Config)
 	logger := zaptest.NewLogger(t)
-	dcgmCleanup, err := initializeDcgm(config, logger)
-	require.Nil(t, err, "can not initialize DCGM. Install and run DCGM before running tests.")
 	client, err := newClient(config, logger)
-	require.Nil(t, err)
+	require.Nil(t, err, "can not initialize DCGM. Install and run DCGM before running tests.")
 
 	assert.NotNil(t, client)
 	assert.Greater(t, len(client.deviceIndices), 0)
@@ -153,16 +149,14 @@ func TestNewDcgmClientWithGpuPresent(t *testing.T) {
 		assert.Greater(t, len(client.devicesModelName[gpuIndex]), 0)
 		assert.Greater(t, len(client.devicesUUID[gpuIndex]), 0)
 	}
-	dcgmCleanup()
+	client.cleanup()
 }
 
 func TestCollectGpuProfilingMetrics(t *testing.T) {
 	config := createDefaultConfig().(*Config)
 	logger := zaptest.NewLogger(t)
-	dcgmCleanup, err := initializeDcgm(config, logger)
-	require.Nil(t, err, "can not initialize DCGM. Install and run DCGM before running tests.")
 	client, err := newClient(config, logger)
-	require.Nil(t, err)
+	require.Nil(t, err, "can not initialize DCGM. Install and run DCGM before running tests.")
 	expectedMetrics := LoadExpectedMetrics(t, client.devicesModelName[0])
 	var maxCollectionInterval = 60 * time.Second
 	before := time.Now().UnixMicro() - maxCollectionInterval.Microseconds()
@@ -225,5 +219,5 @@ func TestCollectGpuProfilingMetrics(t *testing.T) {
 			assert.Equal(t, seenMetric[fmt.Sprintf("gpu{%d}.metric{%s}", gpuIndex, metric)], true)
 		}
 	}
-	dcgmCleanup()
+	client.cleanup()
 }

--- a/receiver/dcgmreceiver/client_gpu_test.go
+++ b/receiver/dcgmreceiver/client_gpu_test.go
@@ -53,7 +53,7 @@ type modelSupportedFields struct {
 func TestSupportedFieldsWithGolden(t *testing.T) {
 	config := createDefaultConfig().(*Config)
 	client, err := newClient(config, zaptest.NewLogger(t))
-	require.Nil(t, err, "can not initialize DCGM. Install and run DCGM before running tests.")
+	require.Nil(t, err, "cannot initialize DCGM. Install and run DCGM before running tests.")
 
 	assert.NotEmpty(t, client.devicesModelName)
 	gpuModel := client.getDeviceModelName(0)
@@ -138,7 +138,7 @@ func getModelGoldenFilePath(t *testing.T, model string) string {
 
 func TestNewDcgmClientWithGpuPresent(t *testing.T) {
 	client, err := newClient(createDefaultConfig().(*Config), zaptest.NewLogger(t))
-	require.Nil(t, err, "can not initialize DCGM. Install and run DCGM before running tests.")
+	require.Nil(t, err, "cannot initialize DCGM. Install and run DCGM before running tests.")
 
 	assert.NotNil(t, client)
 	assert.NotNil(t, client.handleCleanup)
@@ -152,7 +152,7 @@ func TestNewDcgmClientWithGpuPresent(t *testing.T) {
 
 func TestCollectGpuProfilingMetrics(t *testing.T) {
 	client, err := newClient(createDefaultConfig().(*Config), zaptest.NewLogger(t))
-	require.Nil(t, err, "can not initialize DCGM. Install and run DCGM before running tests.")
+	require.Nil(t, err, "cannot initialize DCGM. Install and run DCGM before running tests.")
 	expectedMetrics := LoadExpectedMetrics(t, client.devicesModelName[0])
 	var maxCollectionInterval = 60 * time.Second
 	before := time.Now().UnixMicro() - maxCollectionInterval.Microseconds()

--- a/receiver/dcgmreceiver/client_test.go
+++ b/receiver/dcgmreceiver/client_test.go
@@ -18,6 +18,7 @@
 package dcgmreceiver
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -44,8 +45,9 @@ func TestNewDcgmClientOnInitializationError(t *testing.T) {
 	})))
 
 	config := createDefaultConfig().(*Config)
-	dcgmCleanup, err := initializeDcgm(config, logger)
+	client, err := newClient(config, logger)
 	assert.Equal(t, seenDcgmConnectionWarning, true)
+	assert.True(t, errors.Is(err, ErrDcgmInitialization))
 	assert.Regexp(t, ".*Unable to connect.*", err)
-	assert.Nil(t, dcgmCleanup)
+	assert.Nil(t, client)
 }

--- a/receiver/dcgmreceiver/client_test.go
+++ b/receiver/dcgmreceiver/client_test.go
@@ -46,7 +46,6 @@ func TestNewDcgmClientOnInitializationError(t *testing.T) {
 
 	client, err := newClient(createDefaultConfig().(*Config), logger)
 	assert.Equal(t, seenDcgmConnectionWarning, true)
-	require.NotNil(t, client)
-	require.Equal(t, client.disable, true)
-	require.Nil(t, err)
+	assert.Regexp(t, ".*Unable to connect.*", err)
+	require.Nil(t, client)
 }

--- a/receiver/dcgmreceiver/client_test.go
+++ b/receiver/dcgmreceiver/client_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
@@ -44,8 +43,9 @@ func TestNewDcgmClientOnInitializationError(t *testing.T) {
 		return nil
 	})))
 
-	client, err := newClient(createDefaultConfig().(*Config), logger)
+	config := createDefaultConfig().(*Config)
+	dcgmCleanup, err := initializeDcgm(config, logger)
 	assert.Equal(t, seenDcgmConnectionWarning, true)
 	assert.Regexp(t, ".*Unable to connect.*", err)
-	require.Nil(t, client)
+	assert.Nil(t, dcgmCleanup)
 }

--- a/receiver/dcgmreceiver/scraper.go
+++ b/receiver/dcgmreceiver/scraper.go
@@ -50,13 +50,9 @@ func (s *dcgmScraper) initClient() error {
 	if s.client != nil {
 		return nil
 	}
-	if !isDcgmInstalled() {
-		s.settings.Logger.Warn("cannot initialize a DCGM client; DCGM is not installed.")
-		return nil
-	}
-
 	client, err := newClient(s.config, s.settings.Logger)
 	if err != nil {
+		s.settings.Logger.Sugar().Warn(err)
 		if errors.Is(err, ErrDcgmInitialization) {
 			// If cannot connect to DCGM, return no error and retry at next
 			// collection time

--- a/receiver/dcgmreceiver/scraper_gpu_test.go
+++ b/receiver/dcgmreceiver/scraper_gpu_test.go
@@ -49,6 +49,39 @@ func TestScrapeWithGpuPresent(t *testing.T) {
 	validateScraperResult(t, metrics, expectedMetrics)
 }
 
+func TestScrapeWithDelayedDcgmService(t *testing.T) {
+	realDcgmInit := dcgmInit
+	defer func() { dcgmInit = realDcgmInit }()
+	dcgmInit = func(args ...string) (func(), error) {
+		return nil, fmt.Errorf("No DCGM client library *OR* No DCGM connection")
+	}
+
+	var settings receiver.CreateSettings
+	settings.Logger = zaptest.NewLogger(t)
+
+	scraper := newDcgmScraper(createDefaultConfig().(*Config), settings)
+	require.NotNil(t, scraper)
+
+	err := scraper.start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	metrics, err := scraper.scrape(context.Background())
+	assert.NoError(t, err) // If failed to init DCGM, should have no error
+	assert.Equal(t, metrics.MetricCount(), 0)
+
+	// Scrape again with DCGM not available
+	metrics, err = scraper.scrape(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, metrics.MetricCount(), 0)
+
+	// Simulate DCGM becomes available
+	dcgmInit = realDcgmInit
+	metrics, err = scraper.scrape(context.Background())
+	assert.NoError(t, err)
+	expectedMetrics := loadExpectedScraperMetrics(t, scraper.client.getDeviceModelName(0))
+	validateScraperResult(t, metrics, expectedMetrics)
+}
+
 func TestScrapeOnPollingError(t *testing.T) {
 	realDcgmGetLatestValuesForFields := dcgmGetLatestValuesForFields
 	defer func() { dcgmGetLatestValuesForFields = realDcgmGetLatestValuesForFields }()
@@ -111,7 +144,7 @@ func TestScrapeOnProfilingPaused(t *testing.T) {
 
 // loadExpectedScraperMetrics calls LoadExpectedMetrics to read the supported
 // metrics from the golden file given a GPU model, and then convert the name
-// from how they are definied in the dcgm client to scraper naming
+// from how they are defined in the dcgm client to scraper naming
 func loadExpectedScraperMetrics(t *testing.T, model string) map[string]int {
 	t.Helper()
 	expectedMetrics := make(map[string]int)

--- a/receiver/dcgmreceiver/scraper_test.go
+++ b/receiver/dcgmreceiver/scraper_test.go
@@ -35,7 +35,7 @@ func TestScraperWithoutDcgm(t *testing.T) {
 	var settings receiver.CreateSettings
 	seenDcgmNotInstalledWarning := false
 	settings.Logger = zaptest.NewLogger(t, zaptest.WrapOptions(zap.Hooks(func(e zapcore.Entry) error {
-		if e.Level == zap.WarnLevel && strings.Contains(e.Message, "cannot initialize a DCGM client; DCGM is not installed") {
+		if e.Level == zap.WarnLevel && strings.Contains(e.Message, "Unable to connect to DCGM daemon at localhost:5555 on libdcgm.so not Found; Is the DCGM daemon running") {
 			seenDcgmNotInstalledWarning = true
 		}
 		return nil

--- a/receiver/dcgmreceiver/scraper_test.go
+++ b/receiver/dcgmreceiver/scraper_test.go
@@ -35,7 +35,7 @@ func TestScraperWithoutDcgm(t *testing.T) {
 	var settings receiver.CreateSettings
 	seenDcgmNotInstalledWarning := false
 	settings.Logger = zaptest.NewLogger(t, zaptest.WrapOptions(zap.Hooks(func(e zapcore.Entry) error {
-		if e.Level == zap.WarnLevel && strings.Contains(e.Message, "can not initialize a DCGM client; DCGM is not installed.") {
+		if e.Level == zap.WarnLevel && strings.Contains(e.Message, "cannot initialize a DCGM client; DCGM is not installed.") {
 			seenDcgmNotInstalledWarning = true
 		}
 		return nil

--- a/receiver/dcgmreceiver/scraper_test.go
+++ b/receiver/dcgmreceiver/scraper_test.go
@@ -1,0 +1,63 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build gpu && !has_gpu
+// +build gpu,!has_gpu
+
+package dcgmreceiver
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/receiver"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestScraperWithoutDcgm(t *testing.T) {
+	var settings receiver.CreateSettings
+	seenDcgmNotInstalledWarning := false
+	settings.Logger = zaptest.NewLogger(t, zaptest.WrapOptions(zap.Hooks(func(e zapcore.Entry) error {
+		if e.Level == zap.WarnLevel && strings.Contains(e.Message, "can not initialize a DCGM client; DCGM is not installed.") {
+			seenDcgmNotInstalledWarning = true
+		}
+		return nil
+	})))
+
+	scraper := newDcgmScraper(createDefaultConfig().(*Config), settings)
+	require.NotNil(t, scraper)
+
+	err := scraper.start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	metrics, err := scraper.scrape(context.Background())
+	assert.Equal(t, true, seenDcgmNotInstalledWarning)
+	assert.NoError(t, err) // If failed to init DCGM, should have no error
+	assert.Equal(t, 0, metrics.MetricCount())
+
+	// Scrape again with DCGM not available
+	metrics, err = scraper.scrape(context.Background())
+	assert.Equal(t, true, seenDcgmNotInstalledWarning)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, metrics.MetricCount())
+
+	err = scraper.stop(context.Background())
+	assert.NoError(t, err)
+}

--- a/receiver/dcgmreceiver/scraper_test.go
+++ b/receiver/dcgmreceiver/scraper_test.go
@@ -35,7 +35,7 @@ func TestScraperWithoutDcgm(t *testing.T) {
 	var settings receiver.CreateSettings
 	seenDcgmNotInstalledWarning := false
 	settings.Logger = zaptest.NewLogger(t, zaptest.WrapOptions(zap.Hooks(func(e zapcore.Entry) error {
-		if e.Level == zap.WarnLevel && strings.Contains(e.Message, "cannot initialize a DCGM client; DCGM is not installed.") {
+		if e.Level == zap.WarnLevel && strings.Contains(e.Message, "cannot initialize a DCGM client; DCGM is not installed") {
 			seenDcgmNotInstalledWarning = true
 		}
 		return nil


### PR DESCRIPTION
[b/292514145](http://b/292514145)

- First, revert #174;
- Modify the receiver to reinitialize the connection to DCGM by trying to create a new client at each collection time;
- The DCGM lib has an issue right now, where dcgm.init() can't be called more than once when DCGM is not installed: https://github.com/NVIDIA/go-dcgm/issues/13. Added a workaround by checking the `libdcgm.so` directly before calling dcgm.init().
- Testing in the Ops Agent: https://github.com/GoogleCloudPlatform/ops-agent/pull/1348