### PR TITLE
change featuregate name

### DIFF
--- a/.build/Dockerfile
+++ b/.build/Dockerfile
@@ -2,7 +2,10 @@ FROM golang:1.21.6-bullseye
 
 RUN apt-get update && apt-get install gettext-base
 
+# This is to fix https://github.com/golangci/golangci-lint/issues/4033
+RUN git config --global --add safe.directory '*'
+
 RUN go install github.com/client9/misspell/cmd/misspell@v0.3.4 \
-    && go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.1 \
+    && go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2 \
     && go install github.com/google/addlicense@v1.0.0 \
     && go install github.com/google/googet/goopack@latest

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ endif
 # googet (Windows)
 .PHONY: build-goo
 build-goo:
-	make GOOS=windows build_full_name package-goo
+	$(MAKE) GOOS=windows build_full_name package-goo
 
 .PHONY: package-goo
 package-goo: export GOOS=windows

--- a/exporter/googlemanagedprometheusexporter/config.go
+++ b/exporter/googlemanagedprometheusexporter/config.go
@@ -66,7 +66,7 @@ func (c *GMPConfig) toCollectorConfig() (collector.Config, error) {
 	cfg.MetricConfig.ClientConfig = c.MetricConfig.ClientConfig
 	cfg.MetricConfig.ExtraMetrics = c.MetricConfig.Config.ExtraMetrics
 	if c.UntypedDoubleExport {
-		err := featuregate.GlobalRegistry().Set("gcp.untyped_double_export", true)
+		err := featuregate.GlobalRegistry().Set("gcp.untypedDoubleExport", true)
 		if err != nil {
 			return cfg, err
 		}


### PR DESCRIPTION
The featuregate name changed in the googlemanagedprometheus exporter library in `opentelemetry-operations-go` library. This PR changes the featuregate name to match.

I would add a test for this, but I am trying to reduce how much we deviate from upstream to make it easier to migrate for future changes we need to move forward in our fork.