### PR TITLE
Rename feature gate in the `googlemanagedprometheus` exporter

### DIFF
--- a/exporter/googlemanagedprometheusexporter/config.go
+++ b/exporter/googlemanagedprometheusexporter/config.go
@@ -66,7 +66,7 @@ func (c *GMPConfig) toCollectorConfig() (collector.Config, error) {
 	cfg.MetricConfig.ClientConfig = c.MetricConfig.ClientConfig
 	cfg.MetricConfig.ExtraMetrics = c.MetricConfig.Config.ExtraMetrics
 	if c.UntypedDoubleExport {
-		err := featuregate.GlobalRegistry().Set("gcp.untyped_double_export", true)
+		err := featuregate.GlobalRegistry().Set("gcp.untypedDoubleExport", true)
 		if err != nil {
 			return cfg, err
 		}


### PR DESCRIPTION
`opentelemetry-operations-go v0.45.0` renames the `gcp.untyped_double_export` feature gate to `gcp.untypedDoubleExport` and this wasn't caught by any of the tests in this repo. :(

On the bright side, the Ops Agent integration tests did catch it.