### PR TITLE
Upgrade go to 1.21.11

### DIFF
--- a/.build/Dockerfile
+++ b/.build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.6-bullseye
+FROM golang:1.21.11-bullseye
 
 RUN apt-get update && apt-get install gettext-base
 

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -6,7 +6,7 @@ on:
       - master
 env:
   # Default minimum version of Go to support.
-  DEFAULT_GO_VERSION: 1.21.10
+  DEFAULT_GO_VERSION: 1.21.11
 jobs:
   build:
     strategy:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-collector
 
-go 1.21.0
+go 1.21.11
 
 require (
 	github.com/NVIDIA/go-dcgm v0.0.0-20240409130410-eeff1ddeec19
@@ -356,7 +356,7 @@ require (
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.26.0 // indirect
 	golang.org/x/oauth2 v0.20.0 // indirect
-	golang.org/x/sync v0.7.0 // indirect
+	golang.org/x/sync v0.7.0
 	golang.org/x/term v0.21.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect


### PR DESCRIPTION
Upgrade go to 1.21.11 for [b/373514270](http://b/373514270). 

Test: integration tests passing in [Ops Agent](https://github.com/GoogleCloudPlatform/ops-agent/pull/1814). 