### PR TITLE
Upgrade docker file to go 1.21.11

### DIFF
--- a/.build/Dockerfile
+++ b/.build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.6-bullseye
+FROM golang:1.21.11-bullseye
 
 RUN apt-get update && apt-get install gettext-base
 


### PR DESCRIPTION
To unblock the go upgrade for the project, update the Dockerfile to use the 1.21.11 base image. 