### PR TITLE
Update build image to go 1.22.8

### DIFF
--- a/.build/Dockerfile
+++ b/.build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.11-bullseye
+FROM golang:1.22.8-bullseye
 
 RUN apt-get update && apt-get install gettext-base
 


### PR DESCRIPTION
OTel v0.111.0 needs at least Go 1.22. This PR updates the build image to use this version.