### PR TITLE
Fix kokoro build container

### DIFF
--- a/cmd/distrogen/templates/Makefile.go.tmpl
+++ b/cmd/distrogen/templates/Makefile.go.tmpl
@@ -35,6 +35,7 @@ OCB_BIN ?= $(TOOLS_DIR)/ocb
 GO_VERSION = {{ .GoVersion }}
 GO_BIN_DIR ?= $(TOOLS_DIR)/go/bin
 GO_BIN ?= $(GO_BIN_DIR)/go
+SET_GO_BIN_PATH ?= PATH="$(GO_BIN_DIR):$$PATH"
 
 .PHONY: build
 build: $(COLLECTOR_BINARY_NAME)
@@ -77,7 +78,7 @@ collector-build: clean-collector $(COLLECTOR_BINARY_NAME)
 
 # Using OCB and the local manifest file, build a collector.
 $(COLLECTOR_BINARY_NAME): $(OCB_BIN)
-	PATH="$(GO_BIN_DIR):$PATH" $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
+	$(SET_GO_BIN_PATH) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
 		GOWORK=off \
 		CGO_ENABLED=$(COLLECTOR_CGO) \

--- a/google-otel/Dockerfile.kokoro_build
+++ b/google-otel/Dockerfile.kokoro_build
@@ -18,11 +18,12 @@ ARG BUILD_CONTAINER="alpine:3"
 FROM ${BUILD_CONTAINER} AS build
 
 RUN apk --update add make curl
-RUN mkdir -p /build
 
 ARG DISTRO_ROOT
-COPY ${DISTRO_ROOT}/Makefile /build
-COPY ${DISTRO_ROOT}/manifest.yaml /build
+COPY ${DISTRO_ROOT}/google-otel /build
+COPY ${DISTRO_ROOT}/receiver /receiver
+COPY ${DISTRO_ROOT}/processor /processor
+COPY ${DISTRO_ROOT}/extension /extension
 
 WORKDIR /build
 RUN make build
@@ -37,9 +38,7 @@ USER ${USER_UID}
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build --chmod=755 /build/otelcol-google /otelcol-google
-
-ARG DISTRO_ROOT
-COPY ${DISTRO_ROOT}/config.yaml /etc/otelcol-google/config.yaml
+COPY --from=build --chmod=644 /build/config.yaml /etc/otelcol-google/config.yaml
 
 ENTRYPOINT ["/otelcol-google", "--feature-gates=exporter.googlemanagedprometheus.intToDouble"]
 CMD ["--config=/etc/otelcol-google/config.yaml"]

--- a/google-otel/Makefile
+++ b/google-otel/Makefile
@@ -35,6 +35,7 @@ OCB_BIN ?= $(TOOLS_DIR)/ocb
 GO_VERSION = 1.24.0
 GO_BIN_DIR ?= $(TOOLS_DIR)/go/bin
 GO_BIN ?= $(GO_BIN_DIR)/go
+SET_GO_BIN_PATH ?= PATH="$(GO_BIN_DIR):$$PATH"
 
 .PHONY: build
 build: $(COLLECTOR_BINARY_NAME)
@@ -77,7 +78,7 @@ collector-build: clean-collector $(COLLECTOR_BINARY_NAME)
 
 # Using OCB and the local manifest file, build a collector.
 $(COLLECTOR_BINARY_NAME): $(OCB_BIN)
-	PATH="$(GO_BIN_DIR):$PATH" $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
+	$(SET_GO_BIN_PATH) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
 		GOWORK=off \
 		CGO_ENABLED=$(COLLECTOR_CGO) \

--- a/google-otel/README.md
+++ b/google-otel/README.md
@@ -81,7 +81,7 @@ A curated distribution of the OpenTelemetry Collector for use in GCP.
 | hostobserver | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/README.md) |
 | httpforwarder | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/httpforwarderextension/README.md) |
 | k8sobserver | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/README.md) |
-| oauth2clientauth | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/oauth2clientauthextension/README.md) |
+| oauth2clientauth | [docs](No docs linked for component) |
 | oidcauth | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/oidcauthextension/README.md) |
 | opamp | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/opampextension/README.md) |
 | pprof | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/pprofextension/README.md) |

--- a/google-otel/manifest.yaml
+++ b/google-otel/manifest.yaml
@@ -79,6 +79,7 @@ extensions:
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.121.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension v0.121.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension v0.121.0
+  path: ../extension/oauth2clientauthextension
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver v0.121.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver v0.121.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension v0.121.0

--- a/registries/operations-collector-registry.yaml
+++ b/registries/operations-collector-registry.yaml
@@ -46,5 +46,5 @@ exporters:
 connectors:
 extensions:
   oauth2clientauth:
-    gomod: github.com/GoogleCloudPlatform/opentelemetry-operations-collector/extension/oauth2clientauthextension v0.0.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension v0.0.0
     path: "../extension/oauth2clientauthextension"

--- a/templates/google-otel/Dockerfile.kokoro_build.go.tmpl
+++ b/templates/google-otel/Dockerfile.kokoro_build.go.tmpl
@@ -18,11 +18,12 @@ ARG BUILD_CONTAINER="alpine:3"
 FROM ${BUILD_CONTAINER} AS build
 
 RUN apk --update add make curl
-RUN mkdir -p /build
 
 ARG DISTRO_ROOT
-COPY ${DISTRO_ROOT}/Makefile /build
-COPY ${DISTRO_ROOT}/manifest.yaml /build
+COPY ${DISTRO_ROOT}/{{ .Name }} /build
+COPY ${DISTRO_ROOT}/receiver /receiver
+COPY ${DISTRO_ROOT}/processor /processor
+COPY ${DISTRO_ROOT}/extension /extension
 
 WORKDIR /build
 RUN make build
@@ -37,9 +38,7 @@ USER ${USER_UID}
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build --chmod=755 /build/{{ .BinaryName }} /{{ .BinaryName }}
-
-ARG DISTRO_ROOT
-COPY ${DISTRO_ROOT}/config.yaml /etc/{{ .BinaryName }}/config.yaml
+COPY --from=build --chmod=644 /build/config.yaml /etc/{{ .BinaryName }}/config.yaml
 
 ENTRYPOINT ["/{{ .BinaryName }}"{{ $length := len .FeatureGates }}{{ if gt $length 0 }}, "--feature-gates={{ .FeatureGates.Render }}"{{ end }}]
 CMD ["--config=/etc/{{ .BinaryName }}/config.yaml"]


### PR DESCRIPTION
The Kokoro build container did not previously copy the local components from this repo onto it. Since we will be doing that with a couple components now, the root where we run the docker build from needs to change so we can copy all the components onto the container.

The registry entry for the local `oauth2clientauth` extension also had to change. We didn't change that module's name in our local copy, so that name needs to match. Otherwise the build fails for thinking we used an internal package from the real `oauth2clientauth` module.