### PR TITLE
Add googleservicecontrol to google-otel spec

### DIFF
--- a/google-otel/README.md
+++ b/google-otel/README.md
@@ -61,6 +61,7 @@ A curated distribution of the OpenTelemetry Collector for use in GCP.
 | file | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/fileexporter/README.md) |
 | googlecloud | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudexporter/README.md) |
 | googlemanagedprometheus | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlemanagedprometheusexporter/README.md) |
+| googleservicecontrol | [docs](No docs linked for component) |
 | loadbalancing | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/loadbalancingexporter/README.md) |
 | nop | [docs](https://www.github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/nopexporter/README.md) |
 | otelarrow | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/otelarrowexporter/README.md) |

--- a/google-otel/manifest.yaml
+++ b/google-otel/manifest.yaml
@@ -61,6 +61,8 @@ processors:
 - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.121.0
 
 exporters:
+- gomod: github.com/GoogleCloudPlatform/opentelemetry-operations-collector/exporter/googleservicecontrolexporter v0.121.0
+  path: ../exporter/googleservicecontrolexporter
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.121.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.121.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.121.0

--- a/google-otel/spec.yaml
+++ b/google-otel/spec.yaml
@@ -61,6 +61,7 @@ components:
         - otelarrow
         - googlecloud
         - googlemanagedprometheus
+        - googleservicecontrol
     connectors:
         - forward
         - count

--- a/specs/google-otel.yaml
+++ b/specs/google-otel.yaml
@@ -82,6 +82,7 @@ components:
     - otelarrow
     - googlecloud
     - googlemanagedprometheus
+    - googleservicecontrol
 
   extensions:
     - zpages


### PR DESCRIPTION
This PR adds googleservicecontrolexporter to the google-otel spec so that it is built into google-otel by default.