### PR TITLE
Include health_check in documented config

### DIFF
--- a/google-built-opentelemetry-collector/docs/examples/configuration/config-standard.yaml
+++ b/google-built-opentelemetry-collector/docs/examples/configuration/config-standard.yaml
@@ -104,7 +104,23 @@ exporters:
   # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlemanagedprometheusexporter
   googlemanagedprometheus:
 
+extensions:
+  # Opens an endpoint on 13133 that can be used to check the
+  # status of the collector. Since this does not configure the
+  # `path` config value, the endpoint will default to `/`.
+  #
+  # When running on Cloud Run, this extension is required and not optional.
+  # In other environments it is recommended but may not be required for operation
+  # (i.e. in Container-Optimized OS or other GCE environments).
+  #
+  # Docs:
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension
+  health_check:
+    endpoint: 0.0.0.0:13133
+
 service:
+  extensions:
+  - health_check
   pipelines:
     logs:
       receivers:

--- a/templates/google-built-opentelemetry-collector/docs/examples/configuration/config-standard.yaml.go.tmpl
+++ b/templates/google-built-opentelemetry-collector/docs/examples/configuration/config-standard.yaml.go.tmpl
@@ -104,7 +104,23 @@ exporters:
   # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlemanagedprometheusexporter
   googlemanagedprometheus:
 
+extensions:
+  # Opens an endpoint on 13133 that can be used to check the
+  # status of the collector. Since this does not configure the
+  # `path` config value, the endpoint will default to `/`.
+  #
+  # When running on Cloud Run, this extension is required and not optional.
+  # In other environments it is recommended but may not be required for operation
+  # (i.e. in Container-Optimized OS or other GCE environments).
+  #
+  # Docs:
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension
+  health_check:
+    endpoint: 0.0.0.0:13133
+
 service:
+  extensions:
+  - health_check
   pipelines:
     logs:
       receivers:


### PR DESCRIPTION
Fixes #264 

Since we decided to link the same example config for Cloud Run as COS, we have to include the `health_check` extension as that is required for functionality on Cloud Run.