### PR TITLE
distrogen: add feature flag and fix render

### DIFF
--- a/cmd/distrogen/distribution.go
+++ b/cmd/distrogen/distribution.go
@@ -266,12 +266,9 @@ func (fgs FeatureGates) Render() string {
 	}
 
 	gates := ""
-	first := true
-	for _, fg := range fgs {
+	for i, fg := range fgs {
 		gates += fg
-		if first {
-			first = false
-		} else {
+		if i < len(fgs)-1 {
 			gates += ","
 		}
 	}

--- a/google-built-opentelemetry-collector/Dockerfile
+++ b/google-built-opentelemetry-collector/Dockerfile
@@ -25,5 +25,5 @@ USER ${USER_UID}
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --chmod=755 otelcol-google /otelcol-google
 COPY config.yaml /etc/otelcol-google/config.yaml
-ENTRYPOINT ["/otelcol-google", "--feature-gates=exporter.googlemanagedprometheus.intToDouble"]
+ENTRYPOINT ["/otelcol-google", "--feature-gates=exporter.googlemanagedprometheus.intToDouble,exporter.googlecloud.CustomMonitoredResources"]
 CMD ["--config=/etc/otelcol-google/config.yaml"]

--- a/google-built-opentelemetry-collector/Dockerfile.build
+++ b/google-built-opentelemetry-collector/Dockerfile.build
@@ -36,5 +36,5 @@ COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 COPY --from=build --chmod=755 /google-built-opentelemetry-collector/otelcol-google /otelcol-google
 COPY --from=build --chmod=644 /google-built-opentelemetry-collector/config.yaml /etc/otelcol-google/config.yaml
 
-ENTRYPOINT ["/otelcol-google", "--feature-gates=exporter.googlemanagedprometheus.intToDouble"]
+ENTRYPOINT ["/otelcol-google", "--feature-gates=exporter.googlemanagedprometheus.intToDouble,exporter.googlecloud.CustomMonitoredResources"]
 CMD ["--config=/etc/otelcol-google/config.yaml"]

--- a/google-built-opentelemetry-collector/spec.yaml
+++ b/google-built-opentelemetry-collector/spec.yaml
@@ -98,3 +98,4 @@ components:
         - yaml
 feature_gates:
     - exporter.googlemanagedprometheus.intToDouble
+    - exporter.googlecloud.CustomMonitoredResources

--- a/specs/google-built-opentelemetry-collector.yaml
+++ b/specs/google-built-opentelemetry-collector.yaml
@@ -30,6 +30,7 @@ go_version: 1.24.0
 
 feature_gates:
   - exporter.googlemanagedprometheus.intToDouble
+  - exporter.googlecloud.CustomMonitoredResources
 
 components:
   receivers:


### PR DESCRIPTION
There seem to be changes that are added cause `make regen-all` was run.

I added a featureflag and fixed the feature flag render