### PR TITLE
Add container_properties to fix Kokoro runtime error

### DIFF
--- a/kokoro/config/build/common.gcl
+++ b/kokoro/config/build/common.gcl
@@ -4,6 +4,11 @@ template config build = {
     params {
       environment {}
     }
+    container_properties {
+      // Other options are available, especially foundry-based ones,
+      // once we get permission to use them.
+      docker_image = 'us-central1-docker.pkg.dev/kokoro-container-bakery/kokoro/ubuntu/ubuntu2204/full:next'
+    }
 
     env_vars = functions.environment_variables(params.environment)
 }

--- a/kokoro/config/build/image.gcl
+++ b/kokoro/config/build/image.gcl
@@ -14,6 +14,10 @@ config build = common.build {
       value = syntax error // TODO: b/410865698 - Fill this in with the correct value once the RBE team says it's OK.
     },
   ]
+  // I'm not sure why, but this build doesn't seem to need container_properties;
+  // null it out for now.
+  container_properties = null
+
   container_artifact = [
     {
       // Path to the container tar file produced by the build. For a container build,


### PR DESCRIPTION
The error is simply "container_properties must be set in the build config."

http://sponge/3e4d52f3-5321-48d3-9cca-bb8d19252fe8