### PR TITLE
[gce_testing] Update `QueryLog` backoff parameters and set retriable `VM Delete`, `QueryLog` quota errors.

### DIFF
--- a/integration_test/gce-testing-internal/gce/gce_testing.go
+++ b/integration_test/gce-testing-internal/gce/gce_testing.go
@@ -127,14 +127,17 @@ const (
 	// take before it is forcibly killed.
 	SuggestedTimeout = 2 * time.Hour
 
-	// QueryMaxAttempts is the default number of retries when calling WaitForLog and WaitForMetricSeries.
+	// QueryMaxAttempts is the default number of retries when calling WaitForMetricSeries.
 	// Retries are spaced by 10 seconds, so 40 retries denotes 6 minutes 40 seconds total.
 	QueryMaxAttempts              = 40 // 6 minutes 40 seconds total.
 	queryMaxAttemptsMetricMissing = 5  // 50 seconds total.
 	queryMaxAttemptsLogMissing    = 5  // 50 seconds total.
 	queryBackoffDuration          = 10 * time.Second
-	LogQueryMaxAttempts           = 15 // 7 minutes 30 seconds total.
-	logQueryBackoffDuration       = 30 * time.Second
+
+	// LogQueryMaxAttempts is the default number of retries when calling WaitForLog.
+	// Retries are spaced by 30 seconds, so 15 retries denotes 7 minutes 30 seconds total.
+	LogQueryMaxAttempts     = 15 // 7 minutes 30 seconds total.
+	logQueryBackoffDuration = 30 * time.Second
 
 	// traceQueryDerate is the number of backoff durations to wait before retrying a trace query.
 	// Cloud Trace quota is incredibly low, and each call to ListTraces uses 25 quota tokens.

--- a/integration_test/gce-testing-internal/gce/gce_testing.go
+++ b/integration_test/gce-testing-internal/gce/gce_testing.go
@@ -133,6 +133,8 @@ const (
 	queryMaxAttemptsMetricMissing = 5  // 50 seconds total.
 	queryMaxAttemptsLogMissing    = 5  // 50 seconds total.
 	queryBackoffDuration          = 10 * time.Second
+	LogQueryMaxAttempts           = 15 // 7 minutes 30 seconds total.
+	logQueryBackoffDuration       = 30 * time.Second
 
 	// traceQueryDerate is the number of backoff durations to wait before retrying a trace query.
 	// Cloud Trace quota is incredibly low, and each call to ListTraces uses 25 quota tokens.
@@ -624,9 +626,9 @@ func hasMatchingLog(ctx context.Context, logger *log.Logger, vm *VM, logNameRege
 
 // WaitForLog looks in the logging backend for a log matching the given query,
 // over the trailing time interval specified by the given window.
-// Returns an error if the log could not be found after QueryMaxAttempts retries.
+// Returns an error if the log could not be found after LogQueryMaxAttempts retries.
 func WaitForLog(ctx context.Context, logger *log.Logger, vm *VM, logNameRegex string, window time.Duration, query string) error {
-	_, err := QueryLog(ctx, logger, vm, logNameRegex, window, query, QueryMaxAttempts)
+	_, err := QueryLog(ctx, logger, vm, logNameRegex, window, query, LogQueryMaxAttempts)
 	return err
 }
 
@@ -647,7 +649,7 @@ func QueryLog(ctx context.Context, logger *log.Logger, vm *VM, logNameRegex stri
 			return nil, fmt.Errorf("QueryLog() failed: %v", err)
 		}
 		// found was false, or we hit a retryable error.
-		time.Sleep(queryBackoffDuration)
+		time.Sleep(logQueryBackoffDuration)
 	}
 	return nil, fmt.Errorf("QueryLog() failed: %s not found, exhausted retries", logNameRegex)
 }
@@ -671,7 +673,7 @@ func AssertLogMissing(ctx context.Context, logger *log.Logger, vm *VM, logNameRe
 			return fmt.Errorf("AssertLogMissing() failed: %v", err)
 		}
 		// found was false, or we hit a retryable error.
-		time.Sleep(queryBackoffDuration)
+		time.Sleep(logQueryBackoffDuration)
 	}
 
 	// Success


### PR DESCRIPTION
PR to alleviate quota issues related to the Google `Compute Engine` and `Logging` APIs from tests using `gce_testing`. This PR does the following updates : 
-  Update `QueryLog` backoff parameters : 
    - `logQueryBackoffDuration = 30 * time.Second`
    - `LogQueryMaxAttempts = 15 // 7 minutes 30 seconds total.`
-  Set VM deletion and `QueryLog` quota errors as retriable.

b/414819213