### PR TITLE
Fix some errors in kokoro configs for sign and publish steps

### DIFF
--- a/kokoro/config/build/build_linux_packages.gcl
+++ b/kokoro/config/build/build_linux_packages.gcl
@@ -3,5 +3,5 @@ import 'common.gcl' as common
 config build = common.build {
   build_file = 'otelcol-google/kokoro/scripts/build/build_packages.sh'
 
-  fileset_artifacts = common.deb_rpm_fileset_artifacts
+  fileset_artifacts = common.pkg_fileset_artifacts
 }

--- a/kokoro/config/build/common.gcl
+++ b/kokoro/config/build/common.gcl
@@ -28,4 +28,5 @@ local _fileset = lambda ext: {
   }]
 }
 
-deb_rpm_fileset_artifacts = [_fileset('deb'), _fileset('rpm')]
+pkg_artifacts_patterns = ['**/*.deb', '**/*.rpm']
+pkg_fileset_artifacts = [_fileset('deb'), _fileset('rpm')]

--- a/kokoro/config/build/publish_packages.gcl
+++ b/kokoro/config/build/publish_packages.gcl
@@ -5,6 +5,6 @@ config build = common.build {
 
   verify_gfile_rules = [{
     resource = "misc_software://cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google"
-    artifacts_to_verify = common.deb_rpm_artifacts_patterns
+    artifacts_to_verify = common.pkg_artifacts_patterns
   }]
 }

--- a/kokoro/config/build/sign_packages.gcl
+++ b/kokoro/config/build/sign_packages.gcl
@@ -5,8 +5,8 @@ config build = common.build {
 
   verify_gfile_rules = [{
     resource = "misc_software://cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google"
-    artifacts_to_verify = common.deb_rpm_artifacts_patterns
+    artifacts_to_verify = common.pkg_artifacts_patterns
   }]
 
-  fileset_artifacts = common.deb_rpm_fileset_artifacts
+  fileset_artifacts = common.pkg_fileset_artifacts
 }


### PR DESCRIPTION
This is to fix http://sponge2/61dd8eaa-596a-4952-9c42-937216ca577d.

I took the opportunity to rename some things that mentioned debs and rpms specifically to be about packages in general, in anticipation of .goo files arriving someday, somehow.