### PR TITLE
Switch to legacy generic artifacts for now.

### DIFF
--- a/kokoro/config/build/build_linux_packages.gcl
+++ b/kokoro/config/build/build_linux_packages.gcl
@@ -3,5 +3,7 @@ import 'common.gcl' as common
 config build = common.build {
   build_file = 'otelcol-google/kokoro/scripts/build/build_packages.sh'
 
-  fileset_artifacts = common.pkg_fileset_artifacts
+  params {
+    artifacts = common.pkg_artifacts_patterns
+  }
 }

--- a/kokoro/config/build/common.gcl
+++ b/kokoro/config/build/common.gcl
@@ -3,30 +3,27 @@ import '../utils/functions.gcl' as functions
 template config build = {
     params {
       environment {}
+      artifacts = []
     }
+
     container_properties {
       // Other options are available, especially foundry-based ones,
       // once we get permission to use them.
       docker_image = 'us-central1-docker.pkg.dev/kokoro-container-bakery/kokoro/ubuntu/ubuntu2204/full:next'
     }
 
+    action = cond(params.artifacts == [], [], [
+      {
+        // We are using "legacy Generic Artifacts"
+        // (http://go/kokoro-generic-artifacts-legacy) for now because Louhi
+        // does not yet support the replacement. See b/367727311.
+        define_artifacts = {
+          regex = params.artifacts
+        }
+      },
+    ])
+
     env_vars = functions.environment_variables(params.environment)
 }
 
-local _fileset = lambda ext: {
-  name = ext
-  artifact_globs = '**/*.' + ext
-  extra_sbom_globs = '**/*.spdx.json'
-  generate_attestation = true
-  generate_sbom_from_fileset = true
-  destinations = [{
-    gcs = {
-      gcs_root_path = 'stackdriver-test-143416-release-builds'
-      populate_content_type = true
-    }
-    store_attestation = true
-  }]
-}
-
 pkg_artifacts_patterns = ['**/*.deb', '**/*.rpm']
-pkg_fileset_artifacts = [_fileset('deb'), _fileset('rpm')]

--- a/kokoro/config/build/sign_packages.gcl
+++ b/kokoro/config/build/sign_packages.gcl
@@ -3,10 +3,13 @@ import 'common.gcl' as common
 config build = common.build {
   build_file = 'otelcol-google/kokoro/scripts/build/sign_packages.sh'
 
+  params {
+    artifacts = common.pkg_artifacts_patterns
+  }
+
   verify_gfile_rules = [{
     resource = "misc_software://cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google"
     artifacts_to_verify = common.pkg_artifacts_patterns
   }]
 
-  fileset_artifacts = common.pkg_fileset_artifacts
 }


### PR DESCRIPTION
Due to b/367727311, we can't use fileset artifacts and have to use generic artifacts. Hopefully that is fine.