### PR TITLE
Patch prometheusreceiver in otelopscol

### DIFF
--- a/otelopscol/manifest.yaml
+++ b/otelopscol/manifest.yaml
@@ -79,3 +79,5 @@ connectors:
 providers:
 
 replaces:
+# https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39912
+- github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver => github.com/ridwanmsharif/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20250506222945-7c6fb072b376

--- a/otelopscol/spec.yaml
+++ b/otelopscol/spec.yaml
@@ -69,4 +69,8 @@ components:
         - otlphttp
     extensions:
         - zpages
+replaces:
+    - from: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
+      to: github.com/ridwanmsharif/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20250506222945-7c6fb072b376
+      reason: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39912
 feature_gates: []

--- a/specs/otelopscol.yaml
+++ b/specs/otelopscol.yaml
@@ -80,3 +80,7 @@ components:
   extensions:
     - zpages
 
+replaces:
+  - from: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
+    to: github.com/ridwanmsharif/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20250506222945-7c6fb072b376
+    reason: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39912


### PR DESCRIPTION
This PR patches the prometheusreceiver in otelopscol to fix the created timestamp interpretation bug.

The receiver is replaced with this commit: https://github.com/ridwanmsharif/opentelemetry-collector-contrib/commit/7c6fb072b3763bb01b34dfd486918ae1b4cfd4a0

This is a patch on top of v0.121.0 with the same patch as: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/39913

I found the Go module via a temporary `go.mod` file and did the following:
```
go mod init temp
go get github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver@v0.121.0
go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver=github.com/ridwanmsharif/opentelemetry-collector-contrib/receiver/prometheusreceiver@7c6fb072b3763bb01b34dfd486918ae1b4cfd4a0
```
After that I was able to open `go.mod` and copy the module version from the `replace` that was produced:
```
replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver => github.com/ridwanmsharif/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.0.0-20250506222945-7c6fb072b376
```

I tested a build of this and confirmed that the correct version of the receiver is used (and that it indeed solves the problem we are aiming to solve):
```
braydonk_google_com@mkc-dp-prober-vm-us-central1-autopush-r5t9:~$ ./otelopscol --config otel.yaml
2025-05-07T16:51:27.248Z        info    service@v0.121.0/service.go:193 Setting up own telemetry...
2025-05-07T16:51:27.248Z        warn    service@v0.121.0/service.go:241 service::telemetry::metrics::address is being deprecated in favor of service::telemetry::metrics::readers
2025-05-07T16:51:27.249Z        info    service@v0.121.0/service.go:258 Starting otelopscol...  {"Version": "", "NumCPU": 2}
2025-05-07T16:51:27.249Z        info    extensions/extensions.go:40     Starting extensions...
2025-05-07T16:51:27.255Z        info    prometheusreceiver@v0.0.0-20250506222945-7c6fb072b376/metrics_receiver.go:119   Starting discovery manager      {"otelcol.component.id": "prometheus/prometheus", "otelcol.component.kind": "Receiver", "otelcol.signal": "metrics"}
2025-05-07T16:51:27.255Z        info    targetallocator/manager.go:184  Scrape job added        {"otelcol.component.id": "prometheus/prometheus", "otelcol.component.kind": "Receiver", "otelcol.signal": "metrics", "jobName": "connector_prober_metrics"}
2025-05-07T16:51:27.256Z        info    service@v0.121.0/service.go:281 Everything is ready. Begin running and processing data.
2025-05-07T16:51:27.256Z        info    prometheusreceiver@v0.0.0-20250506222945-7c6fb072b376/metrics_receiver.go:189   Starting scrape manager {"otelcol.component.id": "prometheus/prometheus", "otelcol.component.kind": "Receiver", "otelcol.signal": "metrics"}
```