### PR TITLE
Bring in some kokoro fixes from the martijnvs-goreleaser-support branch

### DIFF
--- a/kokoro/config/build/publish_packages.gcl
+++ b/kokoro/config/build/publish_packages.gcl
@@ -3,8 +3,9 @@ import 'common.gcl' as common
 config build = common.build {
   build_file = 'otelcol-google/kokoro/scripts/build/publish_packages.sh'
 
-  verify_gfile_rules = [{
-    resource = "misc_software://cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google"
-    artifacts_to_verify = common.pkg_artifacts_patterns
-  }]
+  // TODO: b/410866040#comment4 - Enable this when ready.
+  // verify_gfile_rules = [{
+  //   resource = "misc_software://cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google"
+  //   artifacts_to_verify = common.pkg_artifacts_patterns
+  // }]
 }

--- a/kokoro/config/build/sign_packages.gcl
+++ b/kokoro/config/build/sign_packages.gcl
@@ -7,9 +7,9 @@ config build = common.build {
     artifacts = common.pkg_artifacts_patterns
   }
 
-  verify_gfile_rules = [{
-    resource = "misc_software://cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google"
-    artifacts_to_verify = common.pkg_artifacts_patterns
-  }]
-
+  // TODO: b/410866040#comment4 - Enable this when ready.
+  // verify_gfile_rules = [{
+  //   resource = "misc_software://cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google"
+  //   artifacts_to_verify = common.pkg_artifacts_patterns
+  // }]
 }

--- a/kokoro/scripts/build/build_packages.sh
+++ b/kokoro/scripts/build/build_packages.sh
@@ -15,17 +15,16 @@
 
 set -eux
 
-# Temporary, for debugging.
-function print_layout() {
-  echo "${KOKORO_ARTIFACTS_DIR}"
-  ls "${KOKORO_ARTIFACTS_DIR}" || true
-  pwd
-  ls .
-}
-print_layout
-
 cd "${KOKORO_ARTIFACTS_DIR}"/git/otelcol-google/google-built-opentelemetry-collector
+
+# The image we're using at the moment has set GOROOT and that mucks everything
+# up. Unset it and let's look for a cleaner image to use as a base.
+unset GOROOT
 
 make goreleaser-release
 
-ls dist || true  # Temporary, for debugging.
+ls dist || echo 'expected outputs to be put into a "dist" directory, proceeding anyway'
+
+# Put the output folder directly in KOKORO_ARTIFACTS_DIR instead of being deeply
+# nested within it.
+mv dist "${KOKORO_ARTIFACTS_DIR}"/dist

--- a/kokoro/scripts/build/sign_packages.sh
+++ b/kokoro/scripts/build/sign_packages.sh
@@ -18,15 +18,6 @@ set -o pipefail
 
 PKG_DIR="${KOKORO_GFILE_DIR}"/dist
 
-# Temporary, for debugging.
-function print_layout() {
-  echo "${KOKORO_GFILE_DIR}"
-  ls "${KOKORO_GFILE_DIR}" || true
-  ls "${KOKORO_GFILE_DIR}"/dist || true
-  ls "${KOKORO_ARTIFACTS_DIR}" || true
-}
-print_layout
-
 chmod 777 "${PKG_DIR}"
 chmod 666 "${PKG_DIR}"/*
 


### PR DESCRIPTION
This is a step towards minimizing the diff between what's on my branch vs what is in master.

After this PR, the package flows ([EXPERIMENTAL 2] and [EXPERIMENTAL 3]) will still be broken when run from `upstream/master`, but only because Braydon's changes haven't been merged yet.