### PR TITLE
Add a deprecated overload for WaitForTrace

### DIFF
--- a/integration_test/gce-testing-internal/gce/gce_testing.go
+++ b/integration_test/gce-testing-internal/gce/gce_testing.go
@@ -512,6 +512,12 @@ func WaitForMetricSeries(ctx context.Context, logger *log.Logger, vm *VM, metric
 	return nil, fmt.Errorf("WaitForMetricSeries(metric=%s, extraFilters=%v) failed: %s", metric, extraFilters, exhaustedRetriesSuffix)
 }
 
+// Temporary overload for WaitForTrace, which will soon change to have a
+// different signature.
+func WaitForTraceDeprecated(ctx context.Context, logger *log.Logger, vm *VM, window time.Duration) (*cloudtrace.Trace, error) {
+	return WaitForTrace(ctx, logger, vm, window)
+}
+
 // WaitForTrace looks for any trace from the given VM in the backend and returns
 // it if it exists. An error is returned otherwise. This function will retry
 // "no data" errors a fixed number of times. This is useful because it takes


### PR DESCRIPTION
The plan is to merge this, switch the only callsite (https://github.com/GoogleCloudPlatform/ops-agent/blob/af59da87b11ad7cdf44ac07d7cd59c0be8559bf1/integration_test/ops_agent_test/main_test.go#L4685) to call WaitForTraceDeprecated, change the signature of WaitForTrace (to take an options struct), and then switch that callsite from WaitForTraceDeprecated to WaitForTrace. Finally I will delete WaitForTraceDeprecated.