### PR TITLE
remove stable from googlesecretmanager registry entry

### DIFF
--- a/cmd/distrogen/registry.yaml
+++ b/cmd/distrogen/registry.yaml
@@ -641,5 +641,4 @@ providers:
         docs_url: https://www.github.com/open-telemetry/opentelemetry-collector/tree/main/confmap/provider/yamlprovider
     googlesecretmanager:
         gomod: github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/googlesecretmanagerprovider
-        stable: true
         docs_url: https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/confmap/provider/googlesecretmanagerprovider


### PR DESCRIPTION
`stable: true` indicates for `distrogen` to use the otel stable version when generating the manifest entry for the component. This component does not exist under the stable version tag, so we need to remove that line from the registry.