### PR TITLE
Fork some config files in preparation for renaming the kokoro builds

### DIFF
--- a/kokoro/config/build/build_binaries.gcl
+++ b/kokoro/config/build/build_binaries.gcl
@@ -1,0 +1,9 @@
+import 'common.gcl' as common
+
+config build = common.build {
+  build_file = 'otelcol-google/kokoro/scripts/build/build_packages.sh'
+
+  params {
+    artifacts = common.pkg_artifacts_patterns
+  }
+}

--- a/kokoro/config/build/build_image.gcl
+++ b/kokoro/config/build/build_image.gcl
@@ -1,0 +1,35 @@
+import 'common.gcl' as common
+
+config build = common.build {
+  dockerfile_path =
+      'git/otelcol-google/google-built-opentelemetry-collector/Dockerfile.build'
+
+  container_build_argument = [
+    {
+      key = 'PROJECT_ROOT'
+      value = 'git/otelcol-google'
+    },
+    {
+      key = 'BUILD_CONTAINER'
+      value =
+          'us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/alpine:3'
+    },
+    {
+      key = 'CERT_CONTAINER'
+      value =
+          'us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/alpine:3'
+    },
+  ]
+  // I'm not sure why, but this build doesn't seem to need container_properties;
+  // null it out for now.
+  container_properties = null
+
+  container_artifact = [
+    {
+      // Path to the container tar file produced by the build. For a container build,
+      // this should always be "container/container.tar"
+      source = 'container/container.tar'
+      destination = 'us-docker.pkg.dev/cloud-ops-agents-art-staging/google-cloud-opentelemetry-collector-staging/otelcol-google'
+    },
+  ]
+}

--- a/kokoro/config/build/sign_linux_packages.gcl
+++ b/kokoro/config/build/sign_linux_packages.gcl
@@ -1,0 +1,15 @@
+import 'common.gcl' as common
+
+config build = common.build {
+  build_file = 'otelcol-google/kokoro/scripts/build/sign_packages.sh'
+
+  params {
+    artifacts = common.pkg_artifacts_patterns
+  }
+
+  // TODO: b/410866040#comment4 - Enable this when ready.
+  // verify_gfile_rules = [{
+  //   resource = "misc_software://cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google"
+  //   artifacts_to_verify = common.pkg_artifacts_patterns
+  // }]
+}


### PR DESCRIPTION
The plan is to do these renames:

```
build_linux_packages -> build_binaries
sign_packages        -> sign_linux_packages
image                -> build_image
```

In preparation for adding these new builds:

sign_windows_packages
package_windows