### PR TITLE
Makefile cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ go.work.sum
 # Binaries from builds
 /google-built-opentelemetry-collector/otelcol-google
 /otelopscol/otelopscol
+
+# Package list files
+**/packages.txt

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ update-otelopscol-components: SPEC_FILE := specs/otelopscol.yaml
 update-otelopscol-components: COMPONENT_DIR := components/otelopscol
 
 update-google-otel-components update-otelopscol-components: DISTROGEN_QUERY := go run ./cmd/distrogen -spec $(SPEC_FILE) -query
-update-google-otel-components update-otelopscol-components: export OTEL_VERSION := v$(shell $(DISTROGEN_QUERY) opentelemetry_version)
-update-google-otel-components update-otelopscol-components: export OTEL_CONTRIB_VERSION := v$(shell $(DISTROGEN_QUERY) opentelemetry_contrib_version)
+update-google-otel-components update-otelopscol-components: export OTEL_VERSION = v$(shell $(DISTROGEN_QUERY) opentelemetry_version)
+update-google-otel-components update-otelopscol-components: export OTEL_CONTRIB_VERSION = v$(shell $(DISTROGEN_QUERY) opentelemetry_contrib_version)
 update-google-otel-components update-otelopscol-components: go.work install-tools
 	cd $(COMPONENT_DIR) && PATH="$(TOOLS_DIR):${PATH}" $(MAKE) update-components
 
@@ -212,9 +212,10 @@ misspell:
 # more sophisticated if we want to supply separate tags for every subcomponent. For
 # now it is pretty simply.
 .PHONY: tag-repo
+tag-repo: GOOGLE_OTEL_VERSION = v$(shell go run ./cmd/distrogen -spec specs/google-built-opentelemetry-collector.yaml -query version)
 tag-repo:
-	git tag -a $(OTEL_VERSION) -m "Update to OpenTelemetry Collector version $(OTEL_VERSION)"
-	@echo "Created git tag $(OTEL_VERSION). If it looks good, push it to the remote by running: git push origin $(OTEL_VERSION)"
+	git tag -a $(GOOGLE_OTEL_VERSION) -m "Update to OpenTelemetry Collector version $(OTEL_VERSION)"
+	@echo "Created git tag $(GOOGLE_OTEL_VERSION). If it looks good, push it to the remote by running: git push origin $(GOOGLE_OTEL_VERSION)"
 
 .PHONY: target-all-modules
 target-all-modules: go.work

--- a/cmd/distrogen/templates/Makefile.go.tmpl
+++ b/cmd/distrogen/templates/Makefile.go.tmpl
@@ -126,9 +126,9 @@ $(COLLECTOR_BINARY_NAME): ocb-generate
 .PHONY: collector-package-list
 collector-package-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
-		GOWORK=off go list -deps -f {{`'{{ .ImportPath }} {{ .Module }}'`}} ./... > ../packages.txt
-	grep -v '<nil>' packages.txt | sort -u > packages.txt
-	rm -rf $(COLLECTOR_BUILD_TEMP_DIR)
+		GOWORK=off go list -deps -f '{{`{{ .ImportPath }}`}} {{`{{ .Module }}`}}' ./... |\
+		grep -v '<nil>' |\
+		sort -u > ../packages.txt
 
 # Delete any existing built collector binary.
 .PHONY: clean-collector

--- a/cmd/distrogen/testdata/generator/basic/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/basic/golden/Makefile
@@ -124,9 +124,9 @@ $(COLLECTOR_BINARY_NAME): ocb-generate
 .PHONY: collector-package-list
 collector-package-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
-		GOWORK=off go list -deps -f '{{ .ImportPath }} {{ .Module }}' ./... > ../packages.txt
-	grep -v '<nil>' packages.txt | sort -u > packages.txt
-	rm -rf $(COLLECTOR_BUILD_TEMP_DIR)
+		GOWORK=off go list -deps -f '{{ .ImportPath }} {{ .Module }}' ./... |\
+		grep -v '<nil>' |\
+		sort -u > ../packages.txt
 
 # Delete any existing built collector binary.
 .PHONY: clean-collector

--- a/cmd/distrogen/testdata/generator/build_container/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/build_container/golden/Makefile
@@ -124,9 +124,9 @@ $(COLLECTOR_BINARY_NAME): ocb-generate
 .PHONY: collector-package-list
 collector-package-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
-		GOWORK=off go list -deps -f '{{ .ImportPath }} {{ .Module }}' ./... > ../packages.txt
-	grep -v '<nil>' packages.txt | sort -u > packages.txt
-	rm -rf $(COLLECTOR_BUILD_TEMP_DIR)
+		GOWORK=off go list -deps -f '{{ .ImportPath }} {{ .Module }}' ./... |\
+		grep -v '<nil>' |\
+		sort -u > ../packages.txt
 
 # Delete any existing built collector binary.
 .PHONY: clean-collector

--- a/cmd/distrogen/testdata/generator/custom_templates_subdir/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/custom_templates_subdir/golden/Makefile
@@ -124,9 +124,9 @@ $(COLLECTOR_BINARY_NAME): ocb-generate
 .PHONY: collector-package-list
 collector-package-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
-		GOWORK=off go list -deps -f '{{ .ImportPath }} {{ .Module }}' ./... > ../packages.txt
-	grep -v '<nil>' packages.txt | sort -u > packages.txt
-	rm -rf $(COLLECTOR_BUILD_TEMP_DIR)
+		GOWORK=off go list -deps -f '{{ .ImportPath }} {{ .Module }}' ./... |\
+		grep -v '<nil>' |\
+		sort -u > ../packages.txt
 
 # Delete any existing built collector binary.
 .PHONY: clean-collector

--- a/cmd/distrogen/testdata/generator/no_docker_repo/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/no_docker_repo/golden/Makefile
@@ -123,9 +123,9 @@ $(COLLECTOR_BINARY_NAME): ocb-generate
 .PHONY: collector-package-list
 collector-package-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
-		GOWORK=off go list -deps -f '{{ .ImportPath }} {{ .Module }}' ./... > ../packages.txt
-	grep -v '<nil>' packages.txt | sort -u > packages.txt
-	rm -rf $(COLLECTOR_BUILD_TEMP_DIR)
+		GOWORK=off go list -deps -f '{{ .ImportPath }} {{ .Module }}' ./... |\
+		grep -v '<nil>' |\
+		sort -u > ../packages.txt
 
 # Delete any existing built collector binary.
 .PHONY: clean-collector

--- a/google-built-opentelemetry-collector/Makefile
+++ b/google-built-opentelemetry-collector/Makefile
@@ -123,9 +123,9 @@ $(COLLECTOR_BINARY_NAME): ocb-generate
 .PHONY: collector-package-list
 collector-package-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
-		GOWORK=off go list -deps -f '{{ .ImportPath }} {{ .Module }}' ./... > ../packages.txt
-	grep -v '<nil>' packages.txt | sort -u > packages.txt
-	rm -rf $(COLLECTOR_BUILD_TEMP_DIR)
+		GOWORK=off go list -deps -f '{{ .ImportPath }} {{ .Module }}' ./... |\
+		grep -v '<nil>' |\
+		sort -u > ../packages.txt
 
 # Delete any existing built collector binary.
 .PHONY: clean-collector

--- a/otelopscol/Makefile
+++ b/otelopscol/Makefile
@@ -123,9 +123,9 @@ $(COLLECTOR_BINARY_NAME): ocb-generate
 .PHONY: collector-package-list
 collector-package-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
-		GOWORK=off go list -deps -f '{{ .ImportPath }} {{ .Module }}' ./... > ../packages.txt
-	grep -v '<nil>' packages.txt | sort -u > packages.txt
-	rm -rf $(COLLECTOR_BUILD_TEMP_DIR)
+		GOWORK=off go list -deps -f '{{ .ImportPath }} {{ .Module }}' ./... |\
+		grep -v '<nil>' |\
+		sort -u > ../packages.txt
 
 # Delete any existing built collector binary.
 .PHONY: clean-collector


### PR DESCRIPTION
Doing some Makefile cleanups that have been needed for a bit.

* Changed the `:=` evaluators for target variables that call shell programs. This was causing make tab complete to lag.
* Fixed the `tag-repo` target to use `distrogen -query`
* Fixed `collector-package-list` target in distro Makefile template