### PR TITLE
Revert "Unnest windows binary path"

### DIFF
--- a/kokoro/scripts/build/build_packages.sh
+++ b/kokoro/scripts/build/build_packages.sh
@@ -23,11 +23,6 @@ unset GOROOT
 
 make goreleaser-release
 
-# Move the windows binary from:
-# dist/otelcol-google-windows_windows_amd64_v1/otelcol-google.exe ->
-# dist/otelcol-google.exe
-mv dist/*/*.exe dist
-
 # Put the output folder directly in KOKORO_ARTIFACTS_DIR instead of being deeply
 # nested within it.
 mv dist "${KOKORO_ARTIFACTS_DIR}"/dist

--- a/kokoro/scripts/build/sign_packages.sh
+++ b/kokoro/scripts/build/sign_packages.sh
@@ -29,5 +29,14 @@ chmod 666 "${PKG_DIR}"/*
   --job-dir=/escalated_sign_jobs -- \
   --loglevel=debug "${PKG_DIR}"/*.rpm
 
+ls -lR "${PKG_DIR}" || echo ls failed  # For debugging.
+
+# This build needs to pass through the windows .exe too, and
+# needs chmods to avoid "permission denied" Kokoro/rsync errors.
+chmod 777 "${PKG_DIR}"/*windows*/
+chmod 666 "${PKG_DIR}"/*windows*/*
+
+ls -lR "${PKG_DIR}" || echo ls failed  # For debugging.
+
 mv "${PKG_DIR}" "${KOKORO_ARTIFACTS_DIR}"
 

--- a/kokoro/scripts/build/sign_windows_binaries.bat
+++ b/kokoro/scripts/build/sign_windows_binaries.bat
@@ -12,7 +12,8 @@
 @REM See the License for the specific language governing permissions and
 @REM limitations under the License.
 
-mkdir "%KOKORO_ARTIFACTS_DIR%\dist"
-copy "%KOKORO_GFILE_DIR%"\dist\* "%KOKORO_ARTIFACTS_DIR%\dist"
+ksigntool sign GOOGLE_EXTERNAL /v /debug /t http://timestamp.digicert.com "%KOKORO_GFILE_DIR%"\dist\*\*.exe
 
-ksigntool sign GOOGLE_EXTERNAL /v /debug /t http://timestamp.digicert.com "%KOKORO_ARTIFACTS_DIR%"\dist\*.exe
+@REM Copy input directory into the artifacts directory recursively.
+robocopy "%KOKORO_GFILE_DIR%"\dist "%KOKORO_ARTIFACTS_DIR%"\dist /E
+


### PR DESCRIPTION
Reverts GoogleCloudPlatform/opentelemetry-operations-collector#321.

Due to how the packaging makefile works, it will be saner to roll this back and fix the signing script to expect the artifacts in a subdirectory.

Also add some chmods to linux signing script, otherwise we will be doomed to hit the same permission denied errors in the linux signing stage that I saw earlier.