### PR TITLE
goopack: Use better make target deps

### DIFF
--- a/google-built-opentelemetry-collector/goopack.mk
+++ b/google-built-opentelemetry-collector/goopack.mk
@@ -5,8 +5,10 @@ GOOPACK_ARCH ?= x86_64
 GOOPACK_GOARCH ?= amd64
 GOOPACK_DEST ?= googet
 
+COLLECTOR_WINDOWS ?= dist/otelcol-google-windows_windows_amd64_v1/otelcol-google.exe
+
 .PHONY: goo-package
-goo-package: $(GOOPACK_BIN) goreleaser-release
+goo-package: $(GOOPACK_BIN) $(COLLECTOR_WINDOWS)
 	mkdir -p $(GOOPACK_DEST) && \
 		$(GOOPACK_BIN) -output_dir $(GOOPACK_DEST) \
 			-var:PKG_VERSION=0.127.0 \
@@ -14,6 +16,9 @@ goo-package: $(GOOPACK_BIN) goreleaser-release
 			-var:GOOS=windows \
 			-var:GOARCH=$(GOOPACK_GOARCH) \
 			goo/otelcol.goospec
+
+$(COLLECTOR_WINDOWS):
+	$(MAKE) goreleaser-release
 
 .PHONY: goopack
 goopack: $(GOOPACK_BIN)

--- a/templates/google-built-opentelemetry-collector/goopack.mk.go.tmpl
+++ b/templates/google-built-opentelemetry-collector/goopack.mk.go.tmpl
@@ -5,8 +5,10 @@ GOOPACK_ARCH ?= x86_64
 GOOPACK_GOARCH ?= amd64
 GOOPACK_DEST ?= googet
 
+COLLECTOR_WINDOWS ?= dist/{{ .BinaryName }}-windows_windows_amd64_v1/{{ .BinaryName }}.exe
+
 .PHONY: goo-package
-goo-package: $(GOOPACK_BIN) goreleaser-release
+goo-package: $(GOOPACK_BIN) $(COLLECTOR_WINDOWS)
 	mkdir -p $(GOOPACK_DEST) && \
 		$(GOOPACK_BIN) -output_dir $(GOOPACK_DEST) \
 			-var:PKG_VERSION={{ .Version }} \
@@ -14,6 +16,9 @@ goo-package: $(GOOPACK_BIN) goreleaser-release
 			-var:GOOS=windows \
 			-var:GOARCH=$(GOOPACK_GOARCH) \
 			goo/otelcol.goospec
+
+$(COLLECTOR_WINDOWS):
+	$(MAKE) goreleaser-release
 
 .PHONY: goopack
 goopack: $(GOOPACK_BIN)


### PR DESCRIPTION
This PR improves the `goopack.mk` `goo-package` target by using the output location of the windows binary as a target to evaluate if goreleaser-release has to be run.

To verify, I ran the `goo-package` target twice to verify that it correctly evaluates the dependency.

```shell
braydonk@bk:~/Git/opentelemetry-operations-collector/google-built-opentelemetry-collector$ make -f goopack.mk goo-package
Installing go1.24.3 at /usr/local/google/home/braydonk/Git/opentelemetry-operations-collector/google-built-opentelemetry-collector/.tools
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    75  100    75    0     0    341      0 --:--:-- --:--:-- --:--:--   340
100 74.9M  100 74.9M    0     0  81.5M      0 --:--:-- --:--:-- --:--:-- 81.5M
Installing goopack at /usr/local/google/home/braydonk/Git/opentelemetry-operations-collector/google-built-opentelemetry-collector/.tools
make goreleaser-release
make[1]: Entering directory '/usr/local/google/home/braydonk/Git/opentelemetry-operations-collector/google-built-opentelemetry-collector'
Installing ocb at /usr/local/google/home/braydonk/Git/opentelemetry-operations-collector/google-built-opentelemetry-collector/.tools
Installing goreleaser at /usr/local/google/home/braydonk/Git/opentelemetry-operations-collector/google-built-opentelemetry-collector/.tools
PATH="/usr/local/google/home/braydonk/Git/opentelemetry-operations-collector/google-built-opentelemetry-collector/.tools/go/bin:$PATH" /usr/local/google/home/braydonk/Git/opentelemetry-operations-collector/google-built-opentelemetry-collector/.tools/ocb --skip-compilation --verbose --config manifest.yaml
2025-05-28T18:23:42.922Z        INFO    internal/command.go:99  OpenTelemetry Collector Builder {"version": "v0.127.0"}
2025-05-28T18:23:42.922Z        INFO    internal/command.go:104 Using config file       {"path": "manifest.yaml"}
2025-05-28T18:23:42.924Z        INFO    builder/config.go:160   Using go        {"go-executable": "/usr/local/google/home/braydonk/Git/opentelemetry-operations-collector/google-built-opentelemetry-collector/.tools/go/bin/go"}
2025-05-28T18:23:42.934Z        INFO    builder/main.go:99      Sources created {"path": "./_build"}
2025-05-28T18:23:42.934Z        INFO    builder/main.go:36      Running go subcommand.  {"arguments": ["mod", "tidy", "-compat=1.23"]}
2025-05-28T18:23:43.473Z        INFO    builder/main.go:201     Getting go modules
2025-05-28T18:23:43.473Z        INFO    builder/main.go:36      Running go subcommand.  {"arguments": ["mod", "download"]}
2025-05-28T18:23:43.689Z        INFO    builder/main.go:106     Generating source codes only, the distribution will not be compiled.
PATH="/usr/local/google/home/braydonk/Git/opentelemetry-operations-collector/google-built-opentelemetry-collector/.tools/go/bin:$PATH" /usr/local/google/home/braydonk/Git/opentelemetry-operations-collector/google-built-opentelemetry-collector/.tools/goreleaser release --snapshot --clean
  • skipping announce, publish, and validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=25cc3e156999e40717c99544232c1eacf396f480 branch=master current_tag=v0.127.0 previous_tag=v0.126.0 dirty=true
    • pipe skipped or partially skipped              reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=0.127.0
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       binary=dist/otelcol-google-linux_linux_amd64_v1/otelcol-google
    • building                                       binary=dist/otelcol-google-windows_windows_amd64_v1/otelcol-google.exe
    • building                                       binary=dist/otelcol-google-linux_linux_arm64_v8.0/otelcol-google
  • archives
    • archiving                                      name=dist/opentelemetry-operations-collector_0.127.0_windows_amd64.tar.gz
    • archiving                                      name=dist/opentelemetry-operations-collector_0.127.0_linux_amd64.tar.gz
    • archiving                                      name=dist/opentelemetry-operations-collector_0.127.0_linux_arm64.tar.gz
    • took: 23s
  • linux packages
    • creating                                       package=otelcol-google format=rpm arch=amd64v1 file=dist/otelcol-google_0.127.0_linux_amd64.rpm
    • creating                                       package=otelcol-google format=deb arch=amd64v1 file=dist/otelcol-google_0.127.0_linux_amd64.deb
    • creating                                       package=otelcol-google format=deb arch=arm64v8.0 file=dist/otelcol-google_0.127.0_linux_arm64.deb
    • creating                                       package=otelcol-google format=rpm arch=arm64v8.0 file=dist/otelcol-google_0.127.0_linux_arm64.rpm
  • calculating checksums
  • writing artifacts metadata
  • release succeeded after 40s
  • thanks for using GoReleaser!
# I love umask it's my favourite
chmod -R o+r ./dist
make[1]: Leaving directory '/usr/local/google/home/braydonk/Git/opentelemetry-operations-collector/google-built-opentelemetry-collector'
mkdir -p googet && \
        /usr/local/google/home/braydonk/Git/opentelemetry-operations-collector/google-built-opentelemetry-collector/.tools/goopack -output_dir googet \
                -var:PKG_VERSION=0.127.0 \
                -var:ARCH=x86_64 \
                -var:GOOS=windows \
                -var:GOARCH=amd64 \
                goo/otelcol.goospec
braydonk@bk:~/Git/opentelemetry-operations-collector/google-built-opentelemetry-collector$ make -f goopack.mk goo-package
mkdir -p googet && \
        /usr/local/google/home/braydonk/Git/opentelemetry-operations-collector/google-built-opentelemetry-collector/.tools/goopack -output_dir googet \
                -var:PKG_VERSION=0.127.0 \
                -var:ARCH=x86_64 \
                -var:GOOS=windows \
                -var:GOARCH=amd64 \
                goo/otelcol.goospec
braydonk@bk:~/Git/opentelemetry-operations-collector/google-built-opentelemetry-collector$ 
```