### PR TITLE
Fix error handling in bat script

### DIFF
--- a/kokoro/scripts/build/sign_windows_binaries.bat
+++ b/kokoro/scripts/build/sign_windows_binaries.bat
@@ -12,8 +12,8 @@
 @REM See the License for the specific language governing permissions and
 @REM limitations under the License.
 
-ksigntool sign GOOGLE_EXTERNAL /v /debug /t http://timestamp.digicert.com "%KOKORO_GFILE_DIR%"\dist\otelcol-google-windows_windows_amd64_v1\*.exe
-
 @REM Copy input directory into the artifacts directory recursively.
 robocopy "%KOKORO_GFILE_DIR%"\dist "%KOKORO_ARTIFACTS_DIR%"\dist /E
+
+ksigntool sign GOOGLE_EXTERNAL /v /debug /t http://timestamp.digicert.com "%KOKORO_ARTIFACTS_DIR%"\dist\otelcol-google-windows_windows_amd64_v1\*.exe
 


### PR DESCRIPTION
This PR solves two problems:

1. robocopy sets exit code to 1 on success: https://stackoverflow.com/questions/56234411/robocopy-causes-exit1-on-success. This causes the whole script to have exit code 1 despite working fine: http://sponge2/fd04ab5b-fe1e-442b-9fd7-33cfbf0f941f
2. ksigntool errors were not being noticed. This was extra bad because it could lead to unsigned Windows binaries sneaking through our whole release process unnoticed.

By swapping the two steps, we can fix both problems.