### PR TITLE
Fix upload step error by including only package files, not folders

### DIFF
--- a/kokoro/scripts/build/publish_packages.sh
+++ b/kokoro/scripts/build/publish_packages.sh
@@ -25,7 +25,9 @@ set -o pipefail
 BUCKET="gs://${_GOOGLE_OTEL_STAGING_BUCKET}/google-otel-packages/${KOKORO_BUILD_ID}"
 BUCKET_WITH_SLASH="${BUCKET}/"
 
-gcloud storage cp "${KOKORO_GFILE_DIR}"/dist/* "${BUCKET_WITH_SLASH}"
+gcloud storage cp "${KOKORO_GFILE_DIR}"/dist/*.deb "${BUCKET_WITH_SLASH}"
+gcloud storage cp "${KOKORO_GFILE_DIR}"/dist/*.rpm "${BUCKET_WITH_SLASH}"
+gcloud storage cp "${KOKORO_GFILE_DIR}"/dist/*.goo "${BUCKET_WITH_SLASH}"
 
 LOCATION=us
 DESCRIPTION="Staging repository for GBOC Linux Packages"


### PR DESCRIPTION
We're seeing an upload step failure due to gcloud barfing when told to upload a folder (containing an .exe, which we don't want to upload anyway). Skip the folder by selecting only deb/rpm/goo files to upload.