### PR TITLE
collector-package-list generates modules instead

### DIFF
--- a/cmd/distrogen/templates/Makefile.go.tmpl
+++ b/cmd/distrogen/templates/Makefile.go.tmpl
@@ -123,8 +123,8 @@ $(COLLECTOR_BINARY_NAME): ocb-generate
 			.
 	$(MAKE) clean-build-dir
 
-.PHONY: collector-package-list
-collector-package-list: ocb-generate
+.PHONY: collector-module-list
+collector-module-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
 		GOWORK=off go list -deps -f '{{`{{ .Module }}`}}' ./... |\
 		grep -v '<nil>' |\

--- a/cmd/distrogen/testdata/generator/basic/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/basic/golden/Makefile
@@ -121,8 +121,8 @@ $(COLLECTOR_BINARY_NAME): ocb-generate
 			.
 	$(MAKE) clean-build-dir
 
-.PHONY: collector-package-list
-collector-package-list: ocb-generate
+.PHONY: collector-module-list
+collector-module-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
 		GOWORK=off go list -deps -f '{{ .Module }}' ./... |\
 		grep -v '<nil>' |\

--- a/cmd/distrogen/testdata/generator/build_container/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/build_container/golden/Makefile
@@ -121,8 +121,8 @@ $(COLLECTOR_BINARY_NAME): ocb-generate
 			.
 	$(MAKE) clean-build-dir
 
-.PHONY: collector-package-list
-collector-package-list: ocb-generate
+.PHONY: collector-module-list
+collector-module-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
 		GOWORK=off go list -deps -f '{{ .Module }}' ./... |\
 		grep -v '<nil>' |\

--- a/cmd/distrogen/testdata/generator/custom_templates_subdir/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/custom_templates_subdir/golden/Makefile
@@ -121,8 +121,8 @@ $(COLLECTOR_BINARY_NAME): ocb-generate
 			.
 	$(MAKE) clean-build-dir
 
-.PHONY: collector-package-list
-collector-package-list: ocb-generate
+.PHONY: collector-module-list
+collector-module-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
 		GOWORK=off go list -deps -f '{{ .Module }}' ./... |\
 		grep -v '<nil>' |\

--- a/cmd/distrogen/testdata/generator/no_docker_repo/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/no_docker_repo/golden/Makefile
@@ -120,8 +120,8 @@ $(COLLECTOR_BINARY_NAME): ocb-generate
 			.
 	$(MAKE) clean-build-dir
 
-.PHONY: collector-package-list
-collector-package-list: ocb-generate
+.PHONY: collector-module-list
+collector-module-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
 		GOWORK=off go list -deps -f '{{ .Module }}' ./... |\
 		grep -v '<nil>' |\

--- a/google-built-opentelemetry-collector/Makefile
+++ b/google-built-opentelemetry-collector/Makefile
@@ -120,8 +120,8 @@ $(COLLECTOR_BINARY_NAME): ocb-generate
 			.
 	$(MAKE) clean-build-dir
 
-.PHONY: collector-package-list
-collector-package-list: ocb-generate
+.PHONY: collector-module-list
+collector-module-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
 		GOWORK=off go list -deps -f '{{ .Module }}' ./... |\
 		grep -v '<nil>' |\

--- a/otelopscol/Makefile
+++ b/otelopscol/Makefile
@@ -120,8 +120,8 @@ $(COLLECTOR_BINARY_NAME): ocb-generate
 			.
 	$(MAKE) clean-build-dir
 
-.PHONY: collector-package-list
-collector-package-list: ocb-generate
+.PHONY: collector-module-list
+collector-module-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
 		GOWORK=off go list -deps -f '{{ .Module }}' ./... |\
 		grep -v '<nil>' |\


### PR DESCRIPTION
The ask way back when was for a list of all *packages*, but currently the need for this list is all *modules*. This PR renames `collector-package-list` to `collector-module-list` and changes the recipe to generate a list of all modules instead.