### PR TITLE
Turn on arm64 tests by removing filtering based on ARCH

### DIFF
--- a/kokoro/config/test/smoke/release.gcl
+++ b/kokoro/config/test/smoke/release.gcl
@@ -3,10 +3,6 @@ import 'common.gcl' as common
 config build = common.smoke_test {
   params {
     environment {
-      // Eventually, this job will test all architectures simultaneously,
-      // but for now we limit to x86_64.
-      ARCH = 'x86_64'
-
       GOTESTSUM_RERUN_FAILS = '2'
 
       // The following SERVICE_EMAIL and TRANSFERS_BUCKET should only be used


### PR DESCRIPTION
I think I wrote this filtering back at the start of the project, before we realized how easy it would be to throw in arm64 support.

I tested this locally by running `bash go_test.sh` and looking at the resulting `IMAGE_SPECS` and it looks right (arm64 are included now).