### PR TITLE
Update `otelopscol` to opentelemetry release `v1.36.0/v0.130.0`.

### DIFF
--- a/otelopscol/Makefile
+++ b/otelopscol/Makefile
@@ -2,7 +2,7 @@
 
 # Variables filled in from distro specification
 VERSION ?= 
-OTEL_VERSION ?= 0.126.0
+OTEL_VERSION ?= 0.130.0
 OTEL_VERSION_TAG = v$(OTEL_VERSION)
 COLLECTOR_BINARY_NAME = otelopscol
 COLLECTOR_BUILD_TEMP_DIR = $(PWD)/_build

--- a/otelopscol/build.ps1
+++ b/otelopscol/build.ps1
@@ -43,7 +43,7 @@ $goBinDir="$toolsDir\go\bin"
 $goBin="$goBinDir\go"
 
 # Download OCB.
-$installOcbCommand="`$env:GOBIN='$toolsDir'; `$env:CGO_ENABLED=0; $goBin install -trimpath -ldflags='-s -w' go.opentelemetry.io/collector/cmd/builder@v0.126.0"
+$installOcbCommand="`$env:GOBIN='$toolsDir'; `$env:CGO_ENABLED=0; $goBin install -trimpath -ldflags='-s -w' go.opentelemetry.io/collector/cmd/builder@v0.130.0"
 powershell.exe -Command $installOcbCommand
 $ocbBin="$toolsDir\builder.exe"
 

--- a/otelopscol/manifest.yaml
+++ b/otelopscol/manifest.yaml
@@ -8,78 +8,78 @@ dist:
   output_path: ./_build
 
 receivers:
-- gomod: github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/receiver/dcgmreceiver v0.126.0
+- gomod: github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/receiver/dcgmreceiver v0.130.0
   path: ../components/otelopscol/receiver/dcgmreceiver
-- gomod: github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/receiver/mongodbreceiver v0.126.0
+- gomod: github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/receiver/mongodbreceiver v0.130.0
   path: ../components/otelopscol/receiver/mongodbreceiver
-- gomod: github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/receiver/nvmlreceiver v0.126.0
+- gomod: github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/receiver/nvmlreceiver v0.130.0
   path: ../components/otelopscol/receiver/nvmlreceiver
-- gomod: github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/receiver/varnishreceiver v0.126.0
+- gomod: github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/receiver/varnishreceiver v0.130.0
   path: ../components/otelopscol/receiver/varnishreceiver
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.126.0
-- gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.126.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.130.0
+- gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.130.0
 
 processors:
-- gomod: github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/processor/agentmetricsprocessor v0.126.0
+- gomod: github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/processor/agentmetricsprocessor v0.130.0
   path: ../components/otelopscol/processor/agentmetricsprocessor
-- gomod: github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/processor/casttosumprocessor v0.126.0
+- gomod: github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/processor/casttosumprocessor v0.130.0
   path: ../components/otelopscol/processor/casttosumprocessor
-- gomod: github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/processor/modifyscopeprocessor v0.126.0
+- gomod: github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/processor/modifyscopeprocessor v0.130.0
   path: ../components/otelopscol/processor/modifyscopeprocessor
-- gomod: github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/processor/normalizesumsprocessor v0.126.0
+- gomod: github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/processor/normalizesumsprocessor v0.130.0
   path: ../components/otelopscol/processor/normalizesumsprocessor
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.126.0
-- gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.126.0
-- gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.126.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.130.0
+- gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.130.0
+- gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.130.0
 
 exporters:
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.126.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.126.0
-- gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.126.0
-- gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.126.0
-- gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.126.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.130.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.130.0
+- gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.130.0
+- gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.130.0
+- gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.130.0
 
 extensions:
-- gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.126.0
+- gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.130.0
 
 connectors:
 
 providers:
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/googlesecretmanagerprovider v0.126.0
-- gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.32.0
-- gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.32.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/googlesecretmanagerprovider v0.130.0
+- gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.36.0
+- gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.36.0
 
 replaces:
 

--- a/otelopscol/spec.yaml
+++ b/otelopscol/spec.yaml
@@ -5,9 +5,9 @@ description: OpenTelemetry Collector binary used by the Ops Agent
 blurb: ""
 build_container: ubuntu
 version: ""
-opentelemetry_version: 0.126.0
-opentelemetry_contrib_version: 0.126.0
-opentelemetry_stable_version: 1.32.0
+opentelemetry_version: 0.130.0
+opentelemetry_contrib_version: 0.130.0
+opentelemetry_stable_version: 1.36.0
 go_version: 1.23.2
 binary_name: otelopscol
 build_tags: gpu

--- a/specs/otelopscol.yaml
+++ b/specs/otelopscol.yaml
@@ -14,8 +14,8 @@
 
 name: otelopscol
 description: "OpenTelemetry Collector binary used by the Ops Agent"
-opentelemetry_version: 0.126.0
-opentelemetry_stable_version: 1.32.0
+opentelemetry_version: 0.130.0
+opentelemetry_stable_version: 1.36.0
 binary_name: otelopscol
 build_container: ubuntu
 collector_cgo: true


### PR DESCRIPTION
Updating `otelopscol` distribution to opentelemetry release `v1.36.0/v0.130.0`. Followed instructions in https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/docs/dev/update-otel.md .

See details : 
- https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.130.0
- https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.130.0