### PR TITLE
Adding googleclientauthextension extension to Ops Agent

### DIFF
--- a/otelopscol/README.md
+++ b/otelopscol/README.md
@@ -76,6 +76,7 @@
 
 | Component Name | Documentation |
 | -------------- | ------------- |
+| googleclientauth | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/googleclientauthextension/README.md) |
 | zpages | [docs](https://www.github.com/open-telemetry/opentelemetry-collector/tree/main/extension/zpagesextension/README.md) |
 
 

--- a/otelopscol/manifest.yaml
+++ b/otelopscol/manifest.yaml
@@ -73,6 +73,7 @@ exporters:
 - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.130.0
 
 extensions:
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension v0.130.0
 - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.130.0
 
 connectors:

--- a/otelopscol/spec.yaml
+++ b/otelopscol/spec.yaml
@@ -69,6 +69,7 @@ components:
         - otlphttp
     extensions:
         - zpages
+        - googleclientauth
     providers:
         - googlesecretmanager
         - file

--- a/specs/otelopscol.yaml
+++ b/specs/otelopscol.yaml
@@ -80,6 +80,7 @@ components:
     - otlphttp
   extensions:
     - zpages
+    - googleclientauth
   providers:
     - googlesecretmanager
     - file


### PR DESCRIPTION
This dependency is required to make otelhttp work with Ops Agent.

b/435217364