### PR TITLE
importing time/tzdata to prevent timezone problems.

### DIFF
--- a/components/otelopscol/processor/transformprocessor/factory.go
+++ b/components/otelopscol/processor/transformprocessor/factory.go
@@ -15,6 +15,8 @@
 package transformprocessor
 
 import (
+	_ "time/tzdata"
+
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/internal/ottlfuncs"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"


### PR DESCRIPTION
Importing time/tzdata to prevent timezone issues when the database is not available. This should not impact usage of other time mechanism since it has the lowest priority.

b/435664151

from https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/ottlfuncs#time

When loading location, this function will look for the IANA Time Zone database in the following locations in order:

a directory or uncompressed zip file named by the ZONEINFO environment variable
on a Unix system, the system standard installation location
$GOROOT/lib/time/zoneinfo.zip
the time/tzdata package, if it was imported.