### PR TITLE
Remove Ubuntu 24.10 Oracular

### DIFF
--- a/distros.yaml
+++ b/distros.yaml
@@ -13,22 +13,6 @@
 # limitations under the License.
 
 targets:
-  oracular:
-    package_extension:
-      deb
-    architectures:
-      x86_64:
-        test_distros:
-          representative:
-          - ubuntu-os-cloud:ubuntu-2410-amd64
-          exhaustive:
-          - ubuntu-os-cloud:ubuntu-minimal-2410-amd64
-      aarch64:
-        test_distros:
-          representative:
-          - ubuntu-os-cloud:ubuntu-2410-arm64
-          exhaustive:
-          - ubuntu-os-cloud:ubuntu-minimal-2410-arm64
   bookworm:
     package_extension:
       deb


### PR DESCRIPTION
Oracular is EOL.