### PR TITLE
Fix predefined metrics vm/os/name metric label

### DIFF
--- a/samples/servicemetrics/hostmetrics_nondisk_metrics.yaml
+++ b/samples/servicemetrics/hostmetrics_nondisk_metrics.yaml
@@ -217,6 +217,10 @@ processors:
           enabled: false
         os.version:
           enabled: true
+        os.build.id:
+          enabled: true
+        os.name:
+          enabled: true
 
   metricstransform/ucp_internal_saasmanagement_hostmetrics_system:
     transforms:
@@ -233,11 +237,13 @@ processors:
     metric_statements:
     - context: datapoint
       statements:
-      - set(attributes["name"], resource.attributes["os.version"]) where metric.name == "saasmanagement.googleapis.com/instance/vm/os/name"
+      - set(attributes["name"], Format("%s_%s_%s", [resource.attributes["os.name"], resource.attributes["os.version"], resource.attributes["os.build.id"]])) where metric.name == "saasmanagement.googleapis.com/instance/vm/os/name"
       - set(value_int, 1) where metric.name == "saasmanagement.googleapis.com/instance/vm/os/name"
     - context: resource
       statements:
       - delete_key(attributes, "os.version")
+      - delete_key(attributes, "os.build.id")
+      - delete_key(attributes, "os.name")
 
 service:
   pipelines:


### PR DESCRIPTION
Update the predefined metric to `vm/os/name` match previous definition. 
[b/439928519](http://b/439928519)
