### PR TITLE
otelopscol: add pprofextension

### DIFF
--- a/otelopscol/README.md
+++ b/otelopscol/README.md
@@ -78,6 +78,7 @@
 | Component Name | Documentation |
 | -------------- | ------------- |
 | googleclientauth | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/googleclientauthextension/README.md) |
+| pprof | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/pprofextension/README.md) |
 | zpages | [docs](https://www.github.com/open-telemetry/opentelemetry-collector/tree/main/extension/zpagesextension/README.md) |
 
 

--- a/otelopscol/manifest.yaml
+++ b/otelopscol/manifest.yaml
@@ -74,6 +74,7 @@ exporters:
 
 extensions:
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension v0.133.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.133.0
 - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.133.0
 
 connectors:

--- a/otelopscol/spec.yaml
+++ b/otelopscol/spec.yaml
@@ -71,6 +71,7 @@ components:
     extensions:
         - zpages
         - googleclientauth
+        - pprof
     providers:
         - googlesecretmanager
         - file

--- a/specs/otelopscol.yaml
+++ b/specs/otelopscol.yaml
@@ -84,6 +84,7 @@ components:
   extensions:
     - zpages
     - googleclientauth
+    - pprof
   providers:
     - googlesecretmanager
     - file


### PR DESCRIPTION
This PR adds the `pprofextension` to `otelopscol`. This is in response to issues where customers have very strange failures and we can't get deeper debugging information. Whether we will engage this as a feature of the Ops Agent remains to be seen (probably unlikely) but if the component is part of the collector we can instruct customers to run the collector in particular ways to gather more data in extreme scenarios.