### PR TITLE
Fix smoke tests

### DIFF
--- a/integration_test/otelcol_configs/smoke.yaml
+++ b/integration_test/otelcol_configs/smoke.yaml
@@ -59,18 +59,18 @@ service:
             exporter:
               otlp:
                 protocol: http/protobuf
-                endpoint: localhost:4317
+                endpoint: http://localhost:4317
     logs:
       processors:
       - batch:
           exporter:
             otlp:
               protocol: http/protobuf
-              endpoint: localhost:4317
+              endpoint: http://localhost:4317
     traces:
       processors:
       - batch:
           exporter:
             otlp:
               protocol: http/protobuf
-              endpoint: localhost:4317
+              endpoint: http://localhost:4317


### PR DESCRIPTION
As of OTel version 0.133.0 internal telemetry endpoint must have `http://` to use an insecure connection this broke our smoke tests.. https://github.com/open-telemetry/opentelemetry-collector/pull/13691
