### PR TITLE
Remove references to opencenus from gboc config

### DIFF
--- a/google-built-opentelemetry-collector/config.yaml
+++ b/google-built-opentelemetry-collector/config.yaml
@@ -22,9 +22,6 @@ receivers:
       http:
         endpoint: 0.0.0.0:4318
 
-  opencensus:
-    endpoint: 0.0.0.0:55678
-
   # Collect own metrics
   prometheus:
     config:
@@ -60,12 +57,12 @@ service:
   pipelines:
 
     traces:
-      receivers: [otlp, opencensus, jaeger, zipkin]
+      receivers: [otlp, jaeger, zipkin]
       processors: [batch]
       exporters: [debug]
 
     metrics:
-      receivers: [otlp, opencensus, prometheus]
+      receivers: [otlp, prometheus]
       processors: [batch]
       exporters: [debug]
 


### PR DESCRIPTION
Previous PR added didn't remove it from the GBOC config.yaml due to a merge error.