### PR TITLE
fix: Replace `gosnowflake v1.16.0` with `v1.15.0` due to panic failure.

### DIFF
--- a/otelopscol/manifest.yaml
+++ b/otelopscol/manifest.yaml
@@ -88,5 +88,5 @@ replaces:
 # Reference root module of repository to find dependency packages.
 - github.com/GoogleCloudPlatform/opentelemetry-operations-collector => ../../
 # Panic in gosnowflake v1.16.0. See https://github.com/snowflakedb/gosnowflake/issues/1533.
-- github.com/snowflakedb/gosnowflake/gosnowflake => github.com/snowflakedb/gosnowflake/gosnowflake v1.15.0
+- github.com/snowflakedb/gosnowflake => github.com/snowflakedb/gosnowflake v1.15.0
 

--- a/otelopscol/spec.yaml
+++ b/otelopscol/spec.yaml
@@ -80,7 +80,7 @@ replaces:
     - from: github.com/GoogleCloudPlatform/opentelemetry-operations-collector
       to: ../../
       reason: Reference root module of repository to find dependency packages.
-    - from: github.com/snowflakedb/gosnowflake/gosnowflake
-      to: github.com/snowflakedb/gosnowflake/gosnowflake v1.15.0
+    - from: github.com/snowflakedb/gosnowflake
+      to: github.com/snowflakedb/gosnowflake v1.15.0
       reason: Panic in gosnowflake v1.16.0. See https://github.com/snowflakedb/gosnowflake/issues/1533.
 feature_gates: []

--- a/specs/otelopscol.yaml
+++ b/specs/otelopscol.yaml
@@ -94,6 +94,6 @@ replaces:
   - from: github.com/GoogleCloudPlatform/opentelemetry-operations-collector
     to: ../../
     reason: Reference root module of repository to find dependency packages.
-  - from: github.com/snowflakedb/gosnowflake/gosnowflake
-    to: github.com/snowflakedb/gosnowflake/gosnowflake v1.15.0
+  - from: github.com/snowflakedb/gosnowflake
+    to: github.com/snowflakedb/gosnowflake v1.15.0
     reason: Panic in gosnowflake v1.16.0. See https://github.com/snowflakedb/gosnowflake/issues/1533.


### PR DESCRIPTION
These changes in otel `v0.133.0`are causing a failure when running `otelopscol` :
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/42099
- https://github.com/snowflakedb/gosnowflake/issues/1533

Fix : Replace/downgrade `gosnowflake` to `v1.15.0` to avoid failure while the fix is added upstream.
- Similar to : https://github.com/observIQ/bindplane-otel-collector/pull/2618
- Context : b/441997261

Failure : 
```
panic: runtime error: invalid memory address or nil pointer dereference
otelopscol[1833]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x5729fe]
otelopscol[1833]: goroutine 1 [running]:
otelopscol[1833]: regexp.(*Regexp).ReplaceAllString(0x0, {0xc0005e3ff0, 0xd}, {0x80856a9, 0xa})
otelopscol[1833]:         /usr/local/go/src/regexp/regexp.go:575 +0x5e
otelopscol[1833]: github.com/snowflakedb/gosnowflake.maskClientSecret(...)
otelopscol[1833]:         /root/go/pkg/mod/github.com/snowflakedb/gosnowflake@v1.16.0/secret_detector.go:56
otelopscol[1833]: github.com/snowflakedb/gosnowflake.maskSecrets({0xc0005e3ff0?, 0xc000b1f988?})
otelopscol[1833]:         /root/go/pkg/mod/github.com/snowflakedb/gosnowflake@v1.16.0/secret_detector.go:67 +0x39
otelopscol[1833]: github.com/snowflakedb/gosnowflake.(*sfTextFormatter).Format(0xc000a561e0, 0xc00067a380)
otelopscol[1833]:         /root/go/pkg/mod/github.com/snowflakedb/gosnowflake@v1.16.0/log.go:71 +0x25
otelopscol[1833]: github.com/sirupsen/logrus.(*Entry).write(0xc00067a380)
otelopscol[1833]:         /root/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:289 +0x95
otelopscol[1833]: github.com/sirupsen/logrus.(*Entry).log(0xc00067a310, 0x4, {0xc0005e3ff0, 0xd})
otelopscol[1833]:         /root/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:252 +0x425
otelopscol[1833]: github.com/sirupsen/logrus.(*Entry).Log(0xc00067a310, 0x4, {0xc0006e3a00?, 0xc000a51d18?, 0x10?})
otelopscol[1833]:         /root/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:304 +0x48
otelopscol[1833]: github.com/sirupsen/logrus.(*Logger).Log(0xc00062ba00, 0x4, {0xc0006e3a00, 0x1, 0x1})
otelopscol[1833]:         /root/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/logger.go:204 +0x58
otelopscol[1833]: github.com/sirupsen/logrus.(*Logger).Info(...)
otelopscol[1833]:         /root/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/logger.go:226
otelopscol[1833]: github.com/snowflakedb/gosnowflake.(*defaultLogger).Info(0xc000a51d00, {0xc0006e3a00, 0x1, 0x1})
otelopscol[1833]:         /root/go/pkg/mod/github.com/snowflakedb/gosnowflake@v1.16.0/log.go:254 +0x4c
otelopscol[1833]: github.com/snowflakedb/gosnowflake.defaultCrlOnDiskCacheDir()
otelopscol[1833]:         /root/go/pkg/mod/github.com/snowflakedb/gosnowflake@v1.16.0/crl.go:609 +0x7f
otelopscol[1833]: github.com/snowflakedb/gosnowflake.newCrlCacheCleaner()
otelopscol[1833]:         /root/go/pkg/mod/github.com/snowflakedb/gosnowflake@v1.16.0/crl.go:96 +0x1f3
otelopscol[1833]: github.com/snowflakedb/gosnowflake.init()
otelopscol[1833]:         /root/go/pkg/mod/github.com/snowflakedb/gosnowflake@v1.16.0/crl.go:57 +0x56e
systemd[1]: google-cloud-ops-agent-opentelemetry-collector.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
```