### PR TITLE
Add `interval` and `deltatocumulative` processors to otelopscol.

### DIFF
--- a/otelopscol/README.md
+++ b/otelopscol/README.md
@@ -48,9 +48,11 @@
 | batch | [docs](https://www.github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor/README.md) |
 | casttosum | [docs](No docs linked for component) |
 | cumulativetodelta | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cumulativetodeltaprocessor/README.md) |
+| deltatocumulative | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/deltatocumulativeprocessor/README.md) |
 | deltatorate | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/deltatorateprocessor/README.md) |
 | filter | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor/README.md) |
 | groupbyattrs | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/groupbyattrsprocessor/README.md) |
+| interval | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/intervalprocessor/README.md) |
 | logstransform | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/logstransformprocessor/README.md) |
 | memorylimiter | [docs](https://www.github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor/README.md) |
 | metricstarttime | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstarttimeprocessor/README.md) |

--- a/otelopscol/manifest.yaml
+++ b/otelopscol/manifest.yaml
@@ -53,9 +53,11 @@ processors:
 - gomod: github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/processor/transformprocessor v0.133.0
   path: ../components/otelopscol/processor/transformprocessor
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.133.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor v0.133.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor v0.133.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.133.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.133.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor v0.133.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor v0.133.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor v0.133.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.133.0

--- a/otelopscol/spec.yaml
+++ b/otelopscol/spec.yaml
@@ -47,9 +47,11 @@ components:
         - otlpjsonfile
     processors:
         - cumulativetodelta
+        - deltatocumulative
         - deltatorate
         - filter
         - groupbyattrs
+        - interval
         - logstransform
         - metricstransform
         - resourcedetection

--- a/specs/otelopscol.yaml
+++ b/specs/otelopscol.yaml
@@ -59,9 +59,11 @@ components:
     - otlpjsonfile
   processors:
     - cumulativetodelta
+    - deltatocumulative
     - deltatorate
     - filter
     - groupbyattrs
+    - interval
     - logstransform
     - metricstransform
     - resourcedetection


### PR DESCRIPTION
Add `interval` and `deltatocumulative` processors to otelopscol.

Context : b/415094454