### PR TITLE
Explicitly set config directory permissions

### DIFF
--- a/google-built-opentelemetry-collector/Dockerfile.image_with_gcloud.build
+++ b/google-built-opentelemetry-collector/Dockerfile.image_with_gcloud.build
@@ -27,6 +27,10 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN make GO_BIN_DIR=/usr/local/go/bin -f pull_modules_from_ar_repos.mk aoss-build
 
+RUN mkdir --mode=0755 /etc/otelcol-google
+RUN cp /google-built-opentelemetry-collector/config.yaml /etc/otelcol-google/config.yaml
+RUN chmod 0644 /etc/otelcol-google/config.yaml
+
 FROM ${CERT_CONTAINER} AS certs
 RUN rm -f /etc/apt/sources.list.d/* /etc/apt/sources.list
 RUN echo 'deb https://us-apt.pkg.dev/remote/artifact-foundry-prod/debian-3p-remote-bookworm bookworm main' | tee -a  /etc/apt/sources.list.d/artifact-registry.list
@@ -39,7 +43,7 @@ USER ${USER_UID}
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build --chmod=755 /google-built-opentelemetry-collector/otelcol-google /otelcol-google
-COPY --from=build --chmod=644 /google-built-opentelemetry-collector/config.yaml /etc/otelcol-google/config.yaml
+COPY --from=build /etc/otelcol-google /etc/otelcol-google
 
 ENTRYPOINT ["/otelcol-google", "--feature-gates=exporter.googlemanagedprometheus.intToDouble,exporter.googlecloud.CustomMonitoredResources"]
 CMD ["--config=/etc/otelcol-google/config.yaml"]

--- a/google-built-opentelemetry-collector/config.yaml
+++ b/google-built-opentelemetry-collector/config.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This file is the same as what is provided in the upstream otelcol and otelcol-contrib distribution container.
-# https://github.com/open-telemetry/opentelemetry-collector-releases/blob/8e11cfc9f1e0bd78e6a26140849c357ab3f0e4db/distributions/otelcol/config.yaml
+# https://github.com/open-telemetry/opentelemetry-collector-releases/blob/6722b0720b1249fde53c819b423db9e797a7c0b6/distributions/otelcol/config.yaml
 #
 # To limit exposure to denial of service attacks, change the host in endpoints below from 0.0.0.0 to a specific network interface.
 # See https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md#safeguards-against-denial-of-service-attacks

--- a/templates/google-built-opentelemetry-collector/Dockerfile.image_with_gcloud.build.go.tmpl
+++ b/templates/google-built-opentelemetry-collector/Dockerfile.image_with_gcloud.build.go.tmpl
@@ -36,6 +36,10 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN make GO_BIN_DIR=/usr/local/go/bin -f pull_modules_from_ar_repos.mk aoss-build
 
+RUN mkdir --mode=0755 /etc/{{ .BinaryName }}
+RUN cp /{{ .Name }}/config.yaml /etc/{{ .BinaryName }}/config.yaml
+RUN chmod 0644 /etc/{{ .BinaryName }}/config.yaml
+
 FROM ${CERT_CONTAINER} AS certs
 RUN rm -f /etc/apt/sources.list.d/* /etc/apt/sources.list
 RUN echo 'deb https://us-apt.pkg.dev/remote/artifact-foundry-prod/debian-3p-remote-bookworm bookworm main' | tee -a  /etc/apt/sources.list.d/artifact-registry.list
@@ -48,7 +52,7 @@ USER ${USER_UID}
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build --chmod=755 /{{ .Name }}/{{ .BinaryName }} /{{ .BinaryName }}
-COPY --from=build --chmod=644 /{{ .Name }}/config.yaml /etc/{{ .BinaryName }}/config.yaml
+COPY --from=build /etc/{{ .BinaryName }} /etc/{{ .BinaryName }}
 
 ENTRYPOINT ["/{{ .BinaryName }}"{{ $length := len .FeatureGates }}{{ if gt $length 0 }}, "--feature-gates={{ .FeatureGates.Render }}"{{ end }}]
 CMD ["--config=/etc/{{ .BinaryName }}/config.yaml"]


### PR DESCRIPTION
Previously the `/etc/otelcol-google` directory was being created implicitly by Docker with the `COPY --from=build --chmod=644 ... /etc/otelcol-google/config.yaml` directive. For reasons I can't figure out yet, the intermediate `/etc/otelcol-google` directory is sometimes created with execute bits set and sometimes not. We see a different result with local builds vs. kokoro builds for instance.

Explicitly creating the intermediate directory and setting the correct execute bits should work across all build environments.

Tested and verified offline