### PR TITLE
disable CGO unilaterally in goreleaser config

### DIFF
--- a/cmd/distrogen/templates/.goreleaser.yaml.go.tmpl
+++ b/cmd/distrogen/templates/.goreleaser.yaml.go.tmpl
@@ -6,7 +6,7 @@ snapshot:
 
 env:
   - LD_FLAGS=-s -w
-  - CGO_ENABLED={{ if .CollectorCGO }}1{{else}}0{{end}}
+  - CGO_ENABLED=0 # TODO: CGO is not supported in goreleaser yet.
   - BUILD_FLAGS=-trimpath
   - GOWORK=off
 

--- a/cmd/distrogen/testdata/generator/basic/golden/.goreleaser.yaml
+++ b/cmd/distrogen/testdata/generator/basic/golden/.goreleaser.yaml
@@ -6,7 +6,7 @@ snapshot:
 
 env:
   - LD_FLAGS=-s -w
-  - CGO_ENABLED=0
+  - CGO_ENABLED=0 # TODO: CGO is not supported in goreleaser yet.
   - BUILD_FLAGS=-trimpath
   - GOWORK=off
 

--- a/cmd/distrogen/testdata/generator/boringcrypto/golden/.goreleaser.yaml
+++ b/cmd/distrogen/testdata/generator/boringcrypto/golden/.goreleaser.yaml
@@ -6,7 +6,7 @@ snapshot:
 
 env:
   - LD_FLAGS=-s -w
-  - CGO_ENABLED=1
+  - CGO_ENABLED=0 # TODO: CGO is not supported in goreleaser yet.
   - BUILD_FLAGS=-trimpath
   - GOWORK=off
 

--- a/cmd/distrogen/testdata/generator/build_container/golden/.goreleaser.yaml
+++ b/cmd/distrogen/testdata/generator/build_container/golden/.goreleaser.yaml
@@ -6,7 +6,7 @@ snapshot:
 
 env:
   - LD_FLAGS=-s -w
-  - CGO_ENABLED=1
+  - CGO_ENABLED=0 # TODO: CGO is not supported in goreleaser yet.
   - BUILD_FLAGS=-trimpath
   - GOWORK=off
 

--- a/cmd/distrogen/testdata/generator/custom_templates_subdir/golden/.goreleaser.yaml
+++ b/cmd/distrogen/testdata/generator/custom_templates_subdir/golden/.goreleaser.yaml
@@ -6,7 +6,7 @@ snapshot:
 
 env:
   - LD_FLAGS=-s -w
-  - CGO_ENABLED=0
+  - CGO_ENABLED=0 # TODO: CGO is not supported in goreleaser yet.
   - BUILD_FLAGS=-trimpath
   - GOWORK=off
 

--- a/cmd/distrogen/testdata/generator/go_proxy/golden/.goreleaser.yaml
+++ b/cmd/distrogen/testdata/generator/go_proxy/golden/.goreleaser.yaml
@@ -6,7 +6,7 @@ snapshot:
 
 env:
   - LD_FLAGS=-s -w
-  - CGO_ENABLED=0
+  - CGO_ENABLED=0 # TODO: CGO is not supported in goreleaser yet.
   - BUILD_FLAGS=-trimpath
   - GOWORK=off
 

--- a/cmd/distrogen/testdata/generator/no_docker_repo/golden/.goreleaser.yaml
+++ b/cmd/distrogen/testdata/generator/no_docker_repo/golden/.goreleaser.yaml
@@ -6,7 +6,7 @@ snapshot:
 
 env:
   - LD_FLAGS=-s -w
-  - CGO_ENABLED=0
+  - CGO_ENABLED=0 # TODO: CGO is not supported in goreleaser yet.
   - BUILD_FLAGS=-trimpath
   - GOWORK=off
 

--- a/google-built-opentelemetry-collector/.goreleaser.yaml
+++ b/google-built-opentelemetry-collector/.goreleaser.yaml
@@ -6,7 +6,7 @@ snapshot:
 
 env:
   - LD_FLAGS=-s -w
-  - CGO_ENABLED=1
+  - CGO_ENABLED=0 # TODO: CGO is not supported in goreleaser yet.
   - BUILD_FLAGS=-trimpath
   - GOWORK=off
 

--- a/otelopscol/.goreleaser.yaml
+++ b/otelopscol/.goreleaser.yaml
@@ -6,7 +6,7 @@ snapshot:
 
 env:
   - LD_FLAGS=-s -w
-  - CGO_ENABLED=1
+  - CGO_ENABLED=0 # TODO: CGO is not supported in goreleaser yet.
   - BUILD_FLAGS=-trimpath
   - GOWORK=off
 


### PR DESCRIPTION
CGO support in goreleaser actually needs more thought due to being unable to directly control the presence of crossplatform compilers at this time. It needs more thought.

As a result, this PR universally disables CGO in `.goreleaser.yaml` regardless of what the user has requested in their spec.