### PR TITLE
distrogen: Remove unintentional double-generate

### DIFF
--- a/cmd/distrogen/main.go
+++ b/cmd/distrogen/main.go
@@ -145,7 +145,7 @@ func (cmd *generateCommand) Run() error {
 		return err
 	}
 
-	return generator.Generate()
+	return nil
 }
 
 type queryCommand struct {


### PR DESCRIPTION
In the recent distrogen update PR, this command was changed to run `generator.Generate()` again at the end of the command. This isn't intentional; the move is the final operation.

Arguably, the golden tests should be reworked to go through the subcommand codepath rather than directly through the generator.