### PR TITLE
GBOC: Add GCP PubSub components

### DIFF
--- a/google-built-opentelemetry-collector/README.md
+++ b/google-built-opentelemetry-collector/README.md
@@ -12,6 +12,7 @@ The Google-Built OpenTelemetry Collector is an open-source, production-ready bui
 | filelog | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver/README.md) |
 | fluentforward | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/fluentforwardreceiver/README.md) |
 | googlecloudmonitoring | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/googlecloudmonitoringreceiver/README.md) |
+| googlecloudpubsub | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/googlecloudpubsubreceiver/README.md) |
 | hostmetrics | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver/README.md) |
 | httpcheck | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/httpcheckreceiver/README.md) |
 | jaeger | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/jaegerreceiver/README.md) |
@@ -69,6 +70,7 @@ The Google-Built OpenTelemetry Collector is an open-source, production-ready bui
 | debug | [docs](https://www.github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/debugexporter/README.md) |
 | file | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/fileexporter/README.md) |
 | googlecloud | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudexporter/README.md) |
+| googlecloudpubsub | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudpubsubexporter/README.md) |
 | googlemanagedprometheus | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlemanagedprometheusexporter/README.md) |
 | googleservicecontrol | [docs](No docs linked for component) |
 | loadbalancing | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/loadbalancingexporter/README.md) |

--- a/google-built-opentelemetry-collector/manifest.yaml
+++ b/google-built-opentelemetry-collector/manifest.yaml
@@ -12,6 +12,7 @@ receivers:
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.135.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.135.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver v0.135.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver v0.135.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.135.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver v0.135.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.135.0
@@ -62,6 +63,7 @@ exporters:
   path: ../components/google-built-opentelemetry-collector/exporter/googleservicecontrolexporter
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.135.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.135.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter v0.135.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.135.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.135.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter v0.135.0

--- a/google-built-opentelemetry-collector/spec.yaml
+++ b/google-built-opentelemetry-collector/spec.yaml
@@ -13,8 +13,6 @@ binary_name: otelcol-google
 build_tags: ""
 boringcrypto: true
 docker_repo: ""
-component_module_base: "github.com/GoogleCloudPlatform/opentelemetry-operations-collector/google-built-opentelemetry-collector"
-distrogen_version: "v0.130.1-0.20250724183747-261516e1bff1"
 components:
     receivers:
         - otlp
@@ -40,6 +38,7 @@ components:
         - statsd
         - syslog
         - googlecloudmonitoring
+        - googlecloudpubsub
         - tcplog
     processors:
         - batch
@@ -75,6 +74,7 @@ components:
         - googlecloud
         - googlemanagedprometheus
         - googleservicecontrol
+        - googlecloudpubsub
         - prometheus
     connectors:
         - forward
@@ -115,3 +115,5 @@ feature_gates:
     - exporter.googlemanagedprometheus.intToDouble
     - exporter.googlecloud.CustomMonitoredResources
 collector_cgo: true
+component_module_base: ""
+distrogen_version: ""

--- a/specs/google-built-opentelemetry-collector.yaml
+++ b/specs/google-built-opentelemetry-collector.yaml
@@ -60,6 +60,7 @@ components:
     - statsd
     - syslog
     - googlecloudmonitoring
+    - googlecloudpubsub
     - tcplog
 
   processors:
@@ -97,6 +98,7 @@ components:
     - googlecloud
     - googlemanagedprometheus
     - googleservicecontrol
+    - googlecloudpubsub
     - prometheus
 
   extensions:


### PR DESCRIPTION
This PR adds the community-contributed GCP PubSub receiver and exporter to GBOC.