### PR TITLE
GBOC: Add PRW exporter

### DIFF
--- a/google-built-opentelemetry-collector/README.md
+++ b/google-built-opentelemetry-collector/README.md
@@ -79,6 +79,7 @@ The Google-Built OpenTelemetry Collector is an open-source, production-ready bui
 | otlp | [docs](https://www.github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter/README.md) |
 | otlphttp | [docs](https://www.github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter/README.md) |
 | prometheus | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusexporter/README.md) |
+| prometheusremotewrite | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusremotewriteexporter/README.md) |
 
 
 ## Extensions

--- a/google-built-opentelemetry-collector/manifest.yaml
+++ b/google-built-opentelemetry-collector/manifest.yaml
@@ -68,6 +68,7 @@ exporters:
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.135.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter v0.135.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.135.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.135.0
 - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.135.0
 - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.135.0
 - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.135.0

--- a/google-built-opentelemetry-collector/spec.yaml
+++ b/google-built-opentelemetry-collector/spec.yaml
@@ -76,6 +76,7 @@ components:
         - googleservicecontrol
         - googlecloudpubsub
         - prometheus
+        - prometheusremotewrite
     connectors:
         - forward
         - count

--- a/specs/google-built-opentelemetry-collector.yaml
+++ b/specs/google-built-opentelemetry-collector.yaml
@@ -100,6 +100,7 @@ components:
     - googleservicecontrol
     - googlecloudpubsub
     - prometheus
+    - prometheusremotewrite
 
   extensions:
     - zpages


### PR DESCRIPTION
This PR adds the Prometheus Remote Write exporter to GBOC.