### PR TITLE
Update exhaustive opensuse-leap images

### DIFF
--- a/distros.yaml
+++ b/distros.yaml
@@ -129,16 +129,14 @@ targets:
           exhaustive:
           - suse-sap-cloud:sles-15-sp6-sap
           - opensuse-cloud:opensuse-leap
-          - opensuse-cloud=opensuse-leap-15-5-v20250110-x86-64
-          - opensuse-cloud=opensuse-leap-15-6-v20250130-x86-64
+          - opensuse-cloud=opensuse-leap-15-6-v20251017-x86-64
       aarch64:
         test_distros:
           representative:
           - suse-cloud:sles-15-arm64
           exhaustive:
           - opensuse-cloud:opensuse-leap-arm64
-          - opensuse-cloud=opensuse-leap-15-5-v20250110-arm64
-          - opensuse-cloud=opensuse-leap-15-6-v20250130-arm64
+          - opensuse-cloud=opensuse-leap-15-6-v20251017-arm64
   windows:
     package_extension:
       goo


### PR DESCRIPTION
Fixes b/454876455

These old `opensuse-leap` images have been removed. Found the new images via:
```
$ gcloud compute images list --project opensuse-cloud --no-standard-images
NAME                                 PROJECT         FAMILY               DEPRECATED  STATUS
opensuse-leap-15-6-v20251017-arm64   opensuse-cloud  opensuse-leap-arm64              READY
opensuse-leap-15-6-v20251017-x86-64  opensuse-cloud  opensuse-leap                    READY
```