### PR TITLE
FIX: Remove undefined make rule

### DIFF
--- a/cmd/distrogen/templates/project/Makefile.go.tmpl
+++ b/cmd/distrogen/templates/project/Makefile.go.tmpl
@@ -10,7 +10,7 @@ SPEC_FILE = {{ .Spec.Path }}
 #############
 
 .PHONY: dev-setup
-dev-setup: install-distrogen workspace setup-hooks
+dev-setup: workspace setup-hooks
 
 .PHONY: setup-hooks
 setup-hooks:

--- a/cmd/distrogen/testdata/generator/project/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/project/golden/Makefile
@@ -10,7 +10,7 @@ SPEC_FILE = spec.yaml
 #############
 
 .PHONY: dev-setup
-dev-setup: install-distrogen workspace setup-hooks
+dev-setup: workspace setup-hooks
 
 .PHONY: setup-hooks
 setup-hooks:


### PR DESCRIPTION
`install-distrogen` was no longer defined but still declared. This PR removes any mention of it left.