### PR TITLE
distrogen: Fix mdatagen installation

### DIFF
--- a/cmd/distrogen/project.go
+++ b/cmd/distrogen/project.go
@@ -54,6 +54,11 @@ func (pg *ProjectGenerator) Generate() error {
 		logger.Debug("failed to get component templates", "err", err)
 		return err
 	}
+	scriptTemplateSet, err := GetScriptTemplateSet(pg, pg.FileMode)
+	if err != nil {
+		logger.Debug("failed to get script templates", "err", err)
+		return err
+	}
 
 	crg := NewComponentsRegistryGenerator()
 
@@ -63,17 +68,21 @@ func (pg *ProjectGenerator) Generate() error {
 		crg.Path = generatePath
 	}
 
-	generateMakePath := filepath.Join(generatePath, "make")
-
 	if err := crg.Generate(); err != nil {
 		return err
 	}
+
+	generateMakePath := filepath.Join(generatePath, "make")
+	generateScriptsPath := filepath.Join(generatePath, "scripts")
 
 	var dirErrors []error
 	if err := os.MkdirAll(generateMakePath, pg.FileMode); err != nil {
 		dirErrors = append(dirErrors, err)
 	}
 	if err := os.MkdirAll(filepath.Join(generatePath, "templates"), pg.FileMode); err != nil {
+		dirErrors = append(dirErrors, err)
+	}
+	if err := os.MkdirAll(generateScriptsPath, pg.FileMode); err != nil {
 		dirErrors = append(dirErrors, err)
 	}
 	if _, err := os.Create(filepath.Join(generatePath, "templates", EMPTY_FILE_NAME)); err != nil {
@@ -85,6 +94,9 @@ func (pg *ProjectGenerator) Generate() error {
 	}
 
 	if err := GenerateTemplateSet(generateMakePath, makeTemplates); err != nil {
+		return err
+	}
+	if err := GenerateTemplateSet(generateScriptsPath, scriptTemplateSet); err != nil {
 		return err
 	}
 	if err := GenerateTemplateSet(filepath.Join(generatePath, "."), projectTemplates); err != nil {

--- a/cmd/distrogen/templates.go
+++ b/cmd/distrogen/templates.go
@@ -43,6 +43,9 @@ var embeddedMakeTemplatesFS embed.FS
 //go:embed templates/project/*
 var embeddedProjectTemplatesFS embed.FS
 
+//go:embed templates/scripts/*
+var embeddedScriptsTemplatesFS embed.FS
+
 // TemplateFile is the information about a template file
 // that will be rendered for a distribution.
 type TemplateFile struct {
@@ -220,6 +223,14 @@ func GetProjectTemplateSet(templateContext any, fileMode fs.FileMode) (TemplateS
 
 func GetDistrogenTemplateSet(templateContext any, fileMode fs.FileMode) (TemplateSet, error) {
 	embedFSSub, err := fs.Sub(embeddedProjectTemplatesFS, filepath.Join("templates", "project", ".distrogen"))
+	if err != nil {
+		return nil, err
+	}
+	return getEmbeddedTemplateSet(templateContext, embedFSSub, fileMode)
+}
+
+func GetScriptTemplateSet(templateContext any, fileMode fs.FileMode) (TemplateSet, error) {
+	embedFSSub, err := fs.Sub(embeddedScriptsTemplatesFS, filepath.Join("templates", "scripts"))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/distrogen/templates/component/go.mod.go.tmpl
+++ b/cmd/distrogen/templates/component/go.mod.go.tmpl
@@ -1,3 +1,3 @@
 module {{ .ModuleURL }}
 
-go {{ .Spec.GoVersion }}
+go {{ .Spec.GoMajorVersion }}

--- a/cmd/distrogen/templates/components/Makefile.go.tmpl
+++ b/cmd/distrogen/templates/components/Makefile.go.tmpl
@@ -1,14 +1,7 @@
-TOOLS_DIR = $(PWD)/.tools
-MDATAGEN_BIN = $(TOOLS_DIR)/mdatagen
-
 .PHONY: update-components
 update-components: export OTEL_VERSION := $(OTEL_VERSION)
 update-components: export OTEL_CONTRIB_VERSION := $(OTEL_CONTRIB_VERSION)
-update-components: update-deps tidy-components update-mdatagen generate-components
-
-.PHONY: update-mdatagen
-update-mdatagen: tools-dir
-	GOBIN=$(TOOLS_DIR) go install go.opentelemetry.io/collector/cmd/mdatagen@$(OTEL_VERSION)
+update-components: update-deps tidy-components generate-components
 
 .PHONY: update-deps
 update-deps:
@@ -33,13 +26,5 @@ ifndef TARGET
 else
 	go list -f '{{`{{ .Dir }}`}}' -m | grep ".*$(PWD).*" | grep -v ".*internal/tools.*" |\
 		GOWORK=off \
-		PATH="$(TOOLS_DIR):${PATH}" \
 		xargs -t -I '{}' $(MAKE) -C {} $(TARGET)
 endif
-
-# This is a PHONY target cause if you make it as a normal recipe
-# it gets very confused because the creation date of the .tools
-# directory is newer than the tools inside it.
-.PHONY: tools-dir
-tools-dir:
-	@mkdir -p $(TOOLS_DIR)

--- a/cmd/distrogen/templates/project/Makefile.go.tmpl
+++ b/cmd/distrogen/templates/project/Makefile.go.tmpl
@@ -5,6 +5,9 @@ MAKEFLAGS += --no-print-directory
 
 SPEC_FILE = {{ .Spec.Path }}
 
+OTEL_VERSION = {{ .Spec.OpenTelemetryVersion }}
+OTEL_CONTRIB_VERSION = {{ .Spec.OpenTelemetryContribVersion }}
+
 #############
 # Development
 #############
@@ -28,9 +31,15 @@ presubmit: misspell lint
 
 TOOLS_DIR ?= $(PWD)/.tools
 DISTROGEN_BIN ?= $(TOOLS_DIR)/distrogen
+MDATAGEN_BIN ?= $(TOOLS_DIR)/mdatagen
 
-$(DISTROGEN_BIN): tools-dir
+$(DISTROGEN_BIN):
+	$(MAKE) tools-dir
 	GOBIN=$(TOOLS_DIR) go install github.com/GoogleCloudPlatform/opentelemetry-operations-collector/cmd/distrogen@$(shell cat .distrogen/VERSION)
+
+$(MDATAGEN_BIN):
+	$(MAKE) tools-dir
+	GOBIN=$(TOOLS_DIR) bash ./scripts/download_mdatagen.sh v$(OTEL_VERSION)
 
 # This is a PHONY target cause if you make it as a normal recipe
 # it gets very confused because the creation date of the .tools
@@ -42,19 +51,15 @@ tools-dir:
 .PHONY: distrogen
 distrogen: $(DISTROGEN_BIN)
 
-
 ##########################
 # Updating OTel Components
 ##########################
 
 .PHONY: update-otel-components
 
-update-otel-components: COMPONENT_DIR := components
-update-otel-components: DISTROGEN_QUERY := $(DISTROGEN_BIN) query --spec $(SPEC_FILE) --field
-update-otel-components: export OTEL_VERSION = v$(shell $(DISTROGEN_QUERY) opentelemetry_version)
-update-otel-components: export OTEL_CONTRIB_VERSION = v$(shell $(DISTROGEN_QUERY) opentelemetry_contrib_version)
-update-otel-components: go.work
-	cd $(COMPONENT_DIR) && PATH="$(TOOLS_DIR):${PATH}" $(MAKE) update-components
+update-otel-components: workspace-update $(MDATAGEN_BIN)
+	export PATH="$(TOOLS_DIR):${PATH}" && cd components &&\
+	$(MAKE) OTEL_VERSION=v$(OTEL_VERSION) OTEL_CONTRIB_VERSION=v$(OTEL_CONTRIB_VERSION) update-components
 
 .PHONY: test-otel-components
 
@@ -93,14 +98,6 @@ test-all:
 tidy-all:
 	TARGET="tidy" $(MAKE) target-all-modules
 
-.PHONY: test-distrogen
-test-distrogen:
-	@go test ./cmd/distrogen
-
-.PHONY: distrogen-golden-update
-distrogen-golden-update:
-	@go test ./cmd/distrogen -update
-
 ###########
 # Workspace
 ###########
@@ -109,11 +106,12 @@ ALL_DIRECTORIES = find . -type d  -print0
 EXCLUDE_TOOLS_DIRS = grep -z -v ".*\.tools.*"
 EXCLUDE_BUILD_DIRS = grep -z -v -e ".*_build.*" -e ".*dist.*"
 
-.PHONY: workspace
-workspace: go.work
-
 go.work:
 	go work init
+	$(MAKE) workspace-update
+
+.PHONY: workspace-update
+workspace-update: go.work
 	$(ALL_DIRECTORIES) |\
 	$(EXCLUDE_TOOLS_DIRS) |\
 	$(EXCLUDE_BUILD_DIRS) |\
@@ -128,22 +126,13 @@ clean-workspace:
 # Utility
 #########
 
-# This target will tag the git repo using the OTel version. Eventually this may be
-# more sophisticated if we want to supply separate tags for every subcomponent. For
-# now it is pretty simply.
-.PHONY: tag-repo
-tag-repo: VERSION = v$(shell go run ./cmd/distrogen query -spec $(SPEC_FILE) -field version)
-tag-repo:
-	git tag -a $(VERSION) -m "Update to OpenTelemetry Collector version $(OTEL_VERSION)"
-	@echo "Created git tag $(VERSION). If it looks good, push it to the remote by running: git push origin $(VERSION)"
-
 .PHONY: target-all-modules
 target-all-modules: go.work
 ifndef TARGET
 	@echo "No TARGET defined."
 else
 	go list -f '{{`{{ .Dir }}`}}' -m | grep -v -e ".*/.tools.*" -e ".*integration_test/smoke_test.*" |\
-	GOWORK=off xargs -t -I '{}' $(MAKE) -C {} $(TARGET)
+	xargs -t -I '{}' $(MAKE) -C {} $(TARGET)
 endif
 
 .PHONY: update-go-module-in-all

--- a/cmd/distrogen/templates/scripts/download_mdatagen.sh.go.tmpl
+++ b/cmd/distrogen/templates/scripts/download_mdatagen.sh.go.tmpl
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# This script will download mdatagen at the otel version specified in the first argument.
+# This script is needed to circumvent this issue:
+# https://github.com/open-telemetry/opentelemetry-collector/issues/9281
+
+set -e
+
+OTEL_VERSION=$1
+
+if [[ -z "$OTEL_VERSION" ]]; then
+  echo "Please specify the OpenTelemetry Collector version to use."
+  exit 1
+fi
+
+TMP_DIR=$(mktemp -d)
+
+cd $TMP_DIR
+go mod init tempmod
+go get -u go.opentelemetry.io/collector/cmd/mdatagen@$OTEL_VERSION
+go install go.opentelemetry.io/collector/cmd/mdatagen
+
+rm -rf $TMP_DIR

--- a/cmd/distrogen/testdata/generator/project/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/project/golden/Makefile
@@ -5,6 +5,9 @@ MAKEFLAGS += --no-print-directory
 
 SPEC_FILE = spec.yaml
 
+OTEL_VERSION = 0.121.0
+OTEL_CONTRIB_VERSION = 0.121.0
+
 #############
 # Development
 #############
@@ -28,9 +31,15 @@ presubmit: misspell lint
 
 TOOLS_DIR ?= $(PWD)/.tools
 DISTROGEN_BIN ?= $(TOOLS_DIR)/distrogen
+MDATAGEN_BIN ?= $(TOOLS_DIR)/mdatagen
 
-$(DISTROGEN_BIN): tools-dir
+$(DISTROGEN_BIN):
+	$(MAKE) tools-dir
 	GOBIN=$(TOOLS_DIR) go install github.com/GoogleCloudPlatform/opentelemetry-operations-collector/cmd/distrogen@$(shell cat .distrogen/VERSION)
+
+$(MDATAGEN_BIN):
+	$(MAKE) tools-dir
+	GOBIN=$(TOOLS_DIR) bash ./scripts/download_mdatagen.sh v$(OTEL_VERSION)
 
 # This is a PHONY target cause if you make it as a normal recipe
 # it gets very confused because the creation date of the .tools
@@ -42,19 +51,15 @@ tools-dir:
 .PHONY: distrogen
 distrogen: $(DISTROGEN_BIN)
 
-
 ##########################
 # Updating OTel Components
 ##########################
 
 .PHONY: update-otel-components
 
-update-otel-components: COMPONENT_DIR := components
-update-otel-components: DISTROGEN_QUERY := $(DISTROGEN_BIN) query --spec $(SPEC_FILE) --field
-update-otel-components: export OTEL_VERSION = v$(shell $(DISTROGEN_QUERY) opentelemetry_version)
-update-otel-components: export OTEL_CONTRIB_VERSION = v$(shell $(DISTROGEN_QUERY) opentelemetry_contrib_version)
-update-otel-components: go.work
-	cd $(COMPONENT_DIR) && PATH="$(TOOLS_DIR):${PATH}" $(MAKE) update-components
+update-otel-components: workspace-update $(MDATAGEN_BIN)
+	export PATH="$(TOOLS_DIR):${PATH}" && cd components &&\
+	$(MAKE) OTEL_VERSION=v$(OTEL_VERSION) OTEL_CONTRIB_VERSION=v$(OTEL_CONTRIB_VERSION) update-components
 
 .PHONY: test-otel-components
 
@@ -93,14 +98,6 @@ test-all:
 tidy-all:
 	TARGET="tidy" $(MAKE) target-all-modules
 
-.PHONY: test-distrogen
-test-distrogen:
-	@go test ./cmd/distrogen
-
-.PHONY: distrogen-golden-update
-distrogen-golden-update:
-	@go test ./cmd/distrogen -update
-
 ###########
 # Workspace
 ###########
@@ -109,11 +106,12 @@ ALL_DIRECTORIES = find . -type d  -print0
 EXCLUDE_TOOLS_DIRS = grep -z -v ".*\.tools.*"
 EXCLUDE_BUILD_DIRS = grep -z -v -e ".*_build.*" -e ".*dist.*"
 
-.PHONY: workspace
-workspace: go.work
-
 go.work:
 	go work init
+	$(MAKE) workspace-update
+
+.PHONY: workspace-update
+workspace-update: go.work
 	$(ALL_DIRECTORIES) |\
 	$(EXCLUDE_TOOLS_DIRS) |\
 	$(EXCLUDE_BUILD_DIRS) |\
@@ -128,22 +126,13 @@ clean-workspace:
 # Utility
 #########
 
-# This target will tag the git repo using the OTel version. Eventually this may be
-# more sophisticated if we want to supply separate tags for every subcomponent. For
-# now it is pretty simply.
-.PHONY: tag-repo
-tag-repo: VERSION = v$(shell go run ./cmd/distrogen query -spec $(SPEC_FILE) -field version)
-tag-repo:
-	git tag -a $(VERSION) -m "Update to OpenTelemetry Collector version $(OTEL_VERSION)"
-	@echo "Created git tag $(VERSION). If it looks good, push it to the remote by running: git push origin $(VERSION)"
-
 .PHONY: target-all-modules
 target-all-modules: go.work
 ifndef TARGET
 	@echo "No TARGET defined."
 else
 	go list -f '{{ .Dir }}' -m | grep -v -e ".*/.tools.*" -e ".*integration_test/smoke_test.*" |\
-	GOWORK=off xargs -t -I '{}' $(MAKE) -C {} $(TARGET)
+	xargs -t -I '{}' $(MAKE) -C {} $(TARGET)
 endif
 
 .PHONY: update-go-module-in-all

--- a/cmd/distrogen/testdata/generator/project/golden/components/Makefile
+++ b/cmd/distrogen/testdata/generator/project/golden/components/Makefile
@@ -1,14 +1,7 @@
-TOOLS_DIR = $(PWD)/.tools
-MDATAGEN_BIN = $(TOOLS_DIR)/mdatagen
-
 .PHONY: update-components
 update-components: export OTEL_VERSION := $(OTEL_VERSION)
 update-components: export OTEL_CONTRIB_VERSION := $(OTEL_CONTRIB_VERSION)
-update-components: update-deps tidy-components update-mdatagen generate-components
-
-.PHONY: update-mdatagen
-update-mdatagen: tools-dir
-	GOBIN=$(TOOLS_DIR) go install go.opentelemetry.io/collector/cmd/mdatagen@$(OTEL_VERSION)
+update-components: update-deps tidy-components generate-components
 
 .PHONY: update-deps
 update-deps:
@@ -33,13 +26,5 @@ ifndef TARGET
 else
 	go list -f '{{ .Dir }}' -m | grep ".*$(PWD).*" | grep -v ".*internal/tools.*" |\
 		GOWORK=off \
-		PATH="$(TOOLS_DIR):${PATH}" \
 		xargs -t -I '{}' $(MAKE) -C {} $(TARGET)
 endif
-
-# This is a PHONY target cause if you make it as a normal recipe
-# it gets very confused because the creation date of the .tools
-# directory is newer than the tools inside it.
-.PHONY: tools-dir
-tools-dir:
-	@mkdir -p $(TOOLS_DIR)

--- a/cmd/distrogen/testdata/generator/project/golden/scripts/download_mdatagen.sh
+++ b/cmd/distrogen/testdata/generator/project/golden/scripts/download_mdatagen.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# This script will download mdatagen at the otel version specified in the first argument.
+# This script is needed to circumvent this issue:
+# https://github.com/open-telemetry/opentelemetry-collector/issues/9281
+
+set -e
+
+OTEL_VERSION=$1
+
+if [[ -z "$OTEL_VERSION" ]]; then
+  echo "Please specify the OpenTelemetry Collector version to use."
+  exit 1
+fi
+
+TMP_DIR=$(mktemp -d)
+
+cd $TMP_DIR
+go mod init tempmod
+go get -u go.opentelemetry.io/collector/cmd/mdatagen@$OTEL_VERSION
+go install go.opentelemetry.io/collector/cmd/mdatagen
+
+rm -rf $TMP_DIR


### PR DESCRIPTION
This PR fixes mdatagen installation. It also fixes some bugs I found along the way, mainly related to running targets for all otel components.

For reference: the original mdatagen installation method is busted because of https://github.com/open-telemetry/opentelemetry-collector/issues/9281