### PR TITLE
[otelopscol] Add `fluentforward` and `syslog` to otelopscol.

### DIFF
--- a/otelopscol/README.md
+++ b/otelopscol/README.md
@@ -16,6 +16,7 @@
 | elasticsearch | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/elasticsearchreceiver/README.md) |
 | filelog | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver/README.md) |
 | flinkmetrics | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/flinkmetricsreceiver/README.md) |
+| fluentforward | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/fluentforwardreceiver/README.md) |
 | hostmetrics | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver/README.md) |
 | iis | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/iisreceiver/README.md) |
 | jmx | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/jmxreceiver/README.md) |
@@ -34,6 +35,7 @@
 | saphana | [docs](No docs linked for component) |
 | sqlquery | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sqlqueryreceiver/README.md) |
 | sqlserver | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sqlserverreceiver/README.md) |
+| syslog | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/syslogreceiver/README.md) |
 | varnish | [docs](No docs linked for component) |
 | windowseventlog | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/windowseventlogreceiver/README.md) |
 | windowsperfcounters | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/windowsperfcountersreceiver/README.md) |

--- a/otelopscol/manifest.yaml
+++ b/otelopscol/manifest.yaml
@@ -23,6 +23,7 @@ receivers:
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver v0.136.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.136.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver v0.136.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.136.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.136.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver v0.136.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver v0.136.0
@@ -38,6 +39,7 @@ receivers:
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver v0.136.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver v0.136.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver v0.136.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.136.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.136.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver v0.136.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.136.0

--- a/otelopscol/spec.yaml
+++ b/otelopscol/spec.yaml
@@ -22,6 +22,7 @@ components:
         - elasticsearch
         - filelog
         - flinkmetrics
+        - fluentforward
         - hostmetrics
         - iis
         - jmx
@@ -36,6 +37,7 @@ components:
         - saphana
         - sqlquery
         - sqlserver
+        - syslog
         - windowseventlog
         - windowsperfcounters
         - zookeeper

--- a/specs/otelopscol.yaml
+++ b/specs/otelopscol.yaml
@@ -33,6 +33,7 @@ components:
     - elasticsearch
     - filelog
     - flinkmetrics
+    - fluentforward
     - hostmetrics
     - iis
     - jmx
@@ -47,6 +48,7 @@ components:
     - saphana
     - sqlquery
     - sqlserver
+    - syslog
     - windowseventlog
     - windowsperfcounters
     # Within this repo


### PR DESCRIPTION
Add `fluentforward` and `syslog` to otelopscol to support `fluent_forward`, `syslog` and `tcp` receivers in Ops Agent.

b/460810179 , b/417699527