### PR TITLE
[otelopscol] Add `tcplogreceiver` to otelopscol.

### DIFF
--- a/otelopscol/README.md
+++ b/otelopscol/README.md
@@ -36,6 +36,7 @@
 | sqlquery | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sqlqueryreceiver/README.md) |
 | sqlserver | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sqlserverreceiver/README.md) |
 | syslog | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/syslogreceiver/README.md) |
+| tcplog | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/tcplogreceiver/README.md) |
 | varnish | [docs](No docs linked for component) |
 | windowseventlog | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/windowseventlogreceiver/README.md) |
 | windowsperfcounters | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/windowsperfcountersreceiver/README.md) |

--- a/otelopscol/manifest.yaml
+++ b/otelopscol/manifest.yaml
@@ -40,6 +40,7 @@ receivers:
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver v0.136.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver v0.136.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.136.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver v0.136.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.136.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver v0.136.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.136.0

--- a/otelopscol/spec.yaml
+++ b/otelopscol/spec.yaml
@@ -38,6 +38,7 @@ components:
         - sqlquery
         - sqlserver
         - syslog
+        - tcplog
         - windowseventlog
         - windowsperfcounters
         - zookeeper

--- a/specs/otelopscol.yaml
+++ b/specs/otelopscol.yaml
@@ -49,6 +49,7 @@ components:
     - sqlquery
     - sqlserver
     - syslog
+    - tcplog
     - windowseventlog
     - windowsperfcounters
     # Within this repo


### PR DESCRIPTION
Add `tcplogreceiver` to support `tcp` receiver in Ops Agent.

b/463384965