### PR TITLE
[gce_testing] Migrate use of `gsutil` to `gcloud storage`.

### DIFF
--- a/integration_test/smoke_test/smoke_test.go
+++ b/integration_test/smoke_test/smoke_test.go
@@ -22,7 +22,7 @@ ZONES: comma-separated list of what zones to run in.
 PROJECT: GCP project to run in.
 IMAGE_SPECS: comma-separated list of image specs, see gce_testing.go for details.
 OTELCOL_CONFIGS_DIR: path to config files for otelcol to use for testing.
-_BUILD_ARTIFACTS_PACKAGE_GCS: gsutil URI for a directory containing otelcol-google
+_BUILD_ARTIFACTS_PACKAGE_GCS: gcloud storage URI for a directory containing otelcol-google
 package files. Should start with 'gs://'.
 */
 
@@ -178,7 +178,7 @@ func installWindowsPackageFromGCS(ctx context.Context, logger *log.Logger, vm *g
 	if _, err := gce.RunRemotely(ctx, logger, vm, "New-Item -ItemType directory -Path C:\\collectorUpload"); err != nil {
 		return err
 	}
-	if _, err := gce.RunRemotely(ctx, logger, vm, fmt.Sprintf("gsutil cp -r %s/*.goo C:\\collectorUpload", gcsPath)); err != nil {
+	if _, err := gce.RunRemotely(ctx, logger, vm, fmt.Sprintf("gcloud storage cp -r %s/*.goo C:\\collectorUpload", gcsPath)); err != nil {
 		return fmt.Errorf("error copying down collector package from GCS: %v", err)
 	}
 	if _, err := gce.RunRemotely(ctx, logger, vm, "googet -noconfirm -verbose install -reinstall (Get-ChildItem C:\\collectorUpload\\*.goo | Select-Object -Expand FullName)"); err != nil {
@@ -195,9 +195,6 @@ func installPackageFromGCS(ctx context.Context, logger *log.Logger, vm *gce.VM, 
 		return installWindowsPackageFromGCS(ctx, logger, vm, gcsPath)
 	}
 	if _, err := gce.RunRemotely(ctx, logger, vm, "mkdir -p /tmp/collectorUpload"); err != nil {
-		return err
-	}
-	if err := gce.InstallGsutilIfNeeded(ctx, logger, vm); err != nil {
 		return err
 	}
 
@@ -220,7 +217,7 @@ func installPackageFromGCS(ctx context.Context, logger *log.Logger, vm *gce.VM, 
 		ext = ".rpm"
 	}
 	pkgSelector := gcsPath + "/*" + arch + ext
-	if _, err := gce.RunRemotely(ctx, logger, vm, "sudo gsutil cp -r "+pkgSelector+" /tmp/collectorUpload"); err != nil {
+	if _, err := gce.RunRemotely(ctx, logger, vm, "sudo gcloud storage cp -r "+pkgSelector+" /tmp/collectorUpload"); err != nil {
 		return fmt.Errorf("error copying down collector package from GCS: %v", err)
 	}
 	// Print the contents of /tmp/collectorUpload into the logs.
@@ -293,7 +290,7 @@ func setupOtelCollectorFrom(ctx context.Context, logger *log.Logger, vm *gce.VM,
 		time.Sleep(10 * time.Second)
 
 		return nil
-	}  // End windows handling.
+	} // End windows handling.
 
 	defaultConfigPath := collectorConfigPath(vm.ImageSpec)
 	if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(config), defaultConfigPath); err != nil {


### PR DESCRIPTION
Since `gcloud storage` is now GA [^1] it is recommended to stop using `gsutil`. This may alleviate/fix some test flakes that occur when `gsutil` is installed or executed.

[^1]: https://docs.cloud.google.com/storage/docs/gsutil-transition-to-gcloud