### PR TITLE
Revert "[gce_testing] Migrate use of `gsutil` to `gcloud storage`."

### DIFF
--- a/integration_test/gce-testing-internal/gce/gce_testing.go
+++ b/integration_test/gce-testing-internal/gce/gce_testing.go
@@ -943,8 +943,11 @@ func UploadContent(ctx context.Context, logger *log.Logger, vm *VM, content io.R
 		_, err = RunRemotely(ctx, logger, vm, fmt.Sprintf(`New-Item -Path "%s" -ItemType File -Force ;Read-GcsObject -Force -Bucket "%s" -ObjectName "%s" -OutFile "%s"`, remotePath, object.BucketName(), object.ObjectName(), remotePath))
 		return err
 	}
+	if err := InstallGsutilIfNeeded(ctx, logger, vm); err != nil {
+		return err
+	}
 	objectPath := fmt.Sprintf("gs://%s/%s", object.BucketName(), object.ObjectName())
-	_, err = RunRemotely(ctx, logger, vm, fmt.Sprintf("sudo gcloud storage cp '%s' '%s'", objectPath, remotePath))
+	_, err = RunRemotely(ctx, logger, vm, fmt.Sprintf("sudo gsutil cp '%s' '%s'", objectPath, remotePath))
 	return err
 }
 
@@ -1936,7 +1939,7 @@ func InstallGrpcurlIfNeeded(ctx context.Context, logger *log.Logger, vm *VM) err
 		}
 
 		logger.Printf("grpcurl not found, installing it...")
-		installCmd := `gcloud storage cp gs://ops-agents-public-buckets-vendored-deps/mirrored-content/grpcurl/v1.8.6/grpcurl_1.8.6_windows_x86_64.zip C:\agentPlugin;Expand-Archive -Path "C:\agentPlugin\grpcurl_1.8.6_windows_x86_64.zip" -DestinationPath "C:\" -Force;ls "C:\"`
+		installCmd := `gsutil cp gs://ops-agents-public-buckets-vendored-deps/mirrored-content/grpcurl/v1.8.6/grpcurl_1.8.6_windows_x86_64.zip C:\agentPlugin;Expand-Archive -Path "C:\agentPlugin\grpcurl_1.8.6_windows_x86_64.zip" -DestinationPath "C:\" -Force;ls "C:\"`
 
 		_, err := RunRemotely(ctx, logger, vm, installCmd)
 		return err
@@ -1953,9 +1956,98 @@ func InstallGrpcurlIfNeeded(ctx context.Context, logger *log.Logger, vm *VM) err
 		arch = "arm64"
 	}
 
-	installCmd := fmt.Sprintf("sudo gcloud storage cp gs://ops-agents-public-buckets-vendored-deps/mirrored-content/grpcurl/v1.8.6/grpcurl_1.8.6_linux_%s.tar.gz /tmp/agentPlugin && sudo tar -xzf /tmp/agentPlugin/grpcurl_1.8.6_linux_%s.tar.gz --no-overwrite-dir -C /usr/local/bin", arch, arch)
+	installCmd := fmt.Sprintf("sudo gsutil cp gs://ops-agents-public-buckets-vendored-deps/mirrored-content/grpcurl/v1.8.6/grpcurl_1.8.6_linux_%s.tar.gz /tmp/agentPlugin && sudo tar -xzf /tmp/agentPlugin/grpcurl_1.8.6_linux_%s.tar.gz --no-overwrite-dir -C /usr/local/bin", arch, arch)
 	installCmd = `set -ex
 ` + installCmd
+	_, err := RunRemotely(ctx, logger, vm, installCmd)
+	return err
+}
+
+// InstallGsutilIfNeeded installs gsutil on instances that don't already have
+// it installed. This is only currently the case for some old versions of SUSE.
+func InstallGsutilIfNeeded(ctx context.Context, logger *log.Logger, vm *VM) error {
+	if IsWindows(vm.ImageSpec) {
+		return nil
+	}
+	if _, err := RunRemotely(ctx, logger, vm, "sudo gsutil --version"); err == nil {
+		// Success, no need to install gsutil.
+		return nil
+	}
+	logger.Printf("gsutil not found, installing it...")
+
+	// SUSE seems to be the only distro without gsutil, so what follows is all
+	// very SUSE-specific.
+	if !IsSUSEVM(vm) {
+		return installErr("gsutil", vm.OS.ID)
+	}
+
+	gcloudArch := "x86_64"
+	if IsARM(vm.ImageSpec) {
+		gcloudArch = "arm"
+	}
+	gcloudPkg := "google-cloud-cli-453.0.0-linux-" + gcloudArch + ".tar.gz"
+	installFromTarball := `
+curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/` + gcloudPkg + `
+INSTALL_DIR="$(readlink --canonicalize .)"
+(
+	INSTALL_LOG="$(mktemp)"
+	# This command produces a lot of console spam, so we only display that
+	# output if there is a problem.
+	sudo tar -xf ` + gcloudPkg + ` -C ${INSTALL_DIR}
+	sudo --preserve-env ${INSTALL_DIR}/google-cloud-sdk/install.sh -q &>"${INSTALL_LOG}" || \
+		EXIT_CODE=$?
+	if [[ "${EXIT_CODE-}" ]]; then
+		cat "${INSTALL_LOG}"
+		exit "${EXIT_CODE}"
+	fi
+)`
+	installCmd := `set -ex
+` + installFromTarball + `
+
+# Upgrade to the latest version
+sudo ${INSTALL_DIR}/google-cloud-sdk/bin/gcloud components update --quiet
+
+sudo ln -s ${INSTALL_DIR}/google-cloud-sdk/bin/gsutil /usr/bin/gsutil
+`
+	// b/308962066: The GCloud CLI ARM Linux tarballs do not have bundled Python
+	// and the GCloud CLI requires Python >= 3.8. Install Python311 for ARM VMs
+	if IsARM(vm.ImageSpec) {
+		// This is what's used on openSUSE.
+		repoSetupCmd := "sudo zypper --non-interactive refresh"
+		if strings.Contains(vm.ImageSpec, "sles-12") {
+			return installErr("gsutil", vm.ImageSpec)
+		}
+		// For SLES 15 ARM: use a vendored repo to reduce flakiness of the
+		// external repos. See http://go/sdi/releases/build-test-release/vendored
+		// for details.
+		if strings.Contains(vm.ImageSpec, "sles-15") {
+			repoSetupCmd = `sudo zypper --non-interactive addrepo -g -t YUM https://us-yum.pkg.dev/projects/cloud-ops-agents-artifacts-dev/google-cloud-monitoring-sles15-aarch64-test-vendor test-vendor
+sudo rpm --import https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+sudo zypper --non-interactive refresh test-vendor`
+		}
+
+		installCmd = `set -ex
+` + repoSetupCmd + `
+sudo zypper --non-interactive install python311 python3-certifi
+
+# On SLES 15 and OpenSUSE Leap arm, python3 is Python 3.6. Tell gsutil/gcloud to use python3.11.
+export CLOUDSDK_PYTHON=/usr/bin/python3.11
+
+` + installFromTarball + `
+
+# Upgrade to the latest version
+sudo CLOUDSDK_PYTHON=/usr/bin/python3.11 ${INSTALL_DIR}/google-cloud-sdk/bin/gcloud components update --quiet
+
+# Make a "gsutil" bash script in /usr/bin that runs the copy of gsutil that
+# was installed into $INSTALL_DIR with CLOUDSDK_PYTHON set.
+sudo tee /usr/bin/gsutil > /dev/null << EOF
+#!/usr/bin/env bash
+CLOUDSDK_PYTHON=/usr/bin/python3.11 ${INSTALL_DIR}/google-cloud-sdk/bin/gsutil "\$@"
+EOF
+sudo chmod a+x /usr/bin/gsutil
+`
+	}
+
 	_, err := RunRemotely(ctx, logger, vm, installCmd)
 	return err
 }

--- a/integration_test/smoke_test/smoke_test.go
+++ b/integration_test/smoke_test/smoke_test.go
@@ -22,7 +22,7 @@ ZONES: comma-separated list of what zones to run in.
 PROJECT: GCP project to run in.
 IMAGE_SPECS: comma-separated list of image specs, see gce_testing.go for details.
 OTELCOL_CONFIGS_DIR: path to config files for otelcol to use for testing.
-_BUILD_ARTIFACTS_PACKAGE_GCS: gcloud storage URI for a directory containing otelcol-google
+_BUILD_ARTIFACTS_PACKAGE_GCS: gsutil URI for a directory containing otelcol-google
 package files. Should start with 'gs://'.
 */
 
@@ -178,7 +178,7 @@ func installWindowsPackageFromGCS(ctx context.Context, logger *log.Logger, vm *g
 	if _, err := gce.RunRemotely(ctx, logger, vm, "New-Item -ItemType directory -Path C:\\collectorUpload"); err != nil {
 		return err
 	}
-	if _, err := gce.RunRemotely(ctx, logger, vm, fmt.Sprintf("gcloud storage cp -r %s/*.goo C:\\collectorUpload", gcsPath)); err != nil {
+	if _, err := gce.RunRemotely(ctx, logger, vm, fmt.Sprintf("gsutil cp -r %s/*.goo C:\\collectorUpload", gcsPath)); err != nil {
 		return fmt.Errorf("error copying down collector package from GCS: %v", err)
 	}
 	if _, err := gce.RunRemotely(ctx, logger, vm, "googet -noconfirm -verbose install -reinstall (Get-ChildItem C:\\collectorUpload\\*.goo | Select-Object -Expand FullName)"); err != nil {
@@ -195,6 +195,9 @@ func installPackageFromGCS(ctx context.Context, logger *log.Logger, vm *gce.VM, 
 		return installWindowsPackageFromGCS(ctx, logger, vm, gcsPath)
 	}
 	if _, err := gce.RunRemotely(ctx, logger, vm, "mkdir -p /tmp/collectorUpload"); err != nil {
+		return err
+	}
+	if err := gce.InstallGsutilIfNeeded(ctx, logger, vm); err != nil {
 		return err
 	}
 
@@ -217,7 +220,7 @@ func installPackageFromGCS(ctx context.Context, logger *log.Logger, vm *gce.VM, 
 		ext = ".rpm"
 	}
 	pkgSelector := gcsPath + "/*" + arch + ext
-	if _, err := gce.RunRemotely(ctx, logger, vm, "sudo gcloud storage cp -r "+pkgSelector+" /tmp/collectorUpload"); err != nil {
+	if _, err := gce.RunRemotely(ctx, logger, vm, "sudo gsutil cp -r "+pkgSelector+" /tmp/collectorUpload"); err != nil {
 		return fmt.Errorf("error copying down collector package from GCS: %v", err)
 	}
 	// Print the contents of /tmp/collectorUpload into the logs.
@@ -290,7 +293,7 @@ func setupOtelCollectorFrom(ctx context.Context, logger *log.Logger, vm *gce.VM,
 		time.Sleep(10 * time.Second)
 
 		return nil
-	} // End windows handling.
+	}  // End windows handling.
 
 	defaultConfigPath := collectorConfigPath(vm.ImageSpec)
 	if err := gce.UploadContent(ctx, logger, vm, strings.NewReader(config), defaultConfigPath); err != nil {


### PR DESCRIPTION
Reverts GoogleCloudPlatform/opentelemetry-operations-collector#456

I've realized that `sles-12`, `sles-15`, `windows-2019` and possibly other images don't have `gcloud` intalled and/or configured at startup. I will need to create a function like `InstallGcloudIfNeeded`. I rather do this in the same PR, since we may need a several testing iterations to get it successfully working.