### PR TITLE
Update BUILD_CONTAINER and CERT_CONTAINER

### DIFF
--- a/docs/dev/update-otel.md
+++ b/docs/dev/update-otel.md
@@ -11,6 +11,7 @@ Updating the OpenTelemetry version for a distribution requires updating the spec
 1. Run `make gen-<distribution>`.
 1. Change to the distribution directory.
 1. Run `make build` in the distribution directory to ensure the build still works after the update.
+1. GOOGLERS ONLY: Update the containers used in the Kokoro build config. You will need to search for the most up-to-date bookworm tag for the `CERT_CONTAINER` in Airlock, and for the desired Go version for the `boringcrypto` `BUILD_CONTAINER` by pasting the image URL into your browser (non-Googlers will get an authentication error attempting this).
 
 ## Updating Contrib Version
 

--- a/kokoro/config/build/build_image.gcl
+++ b/kokoro/config/build/build_image.gcl
@@ -12,12 +12,12 @@ config build = common.build {
     {
       key = 'BUILD_CONTAINER'
       value =
-          'us-docker.pkg.dev/google.com/api-project-999119582588/go-boringcrypto-internal/golang@sha256:5e292c54d2d37534a367761cbc0b69b81d717c730f824e0f7abdcd54133e43f1'
+          'us-docker.pkg.dev/google.com/api-project-999119582588/go-boringcrypto-internal/golang@sha256:b9b992fbef86e816ebac77aa06d28a5c92c6619cc0ed3548df91cccf3328e9ca'
     },
     {
       key = 'CERT_CONTAINER'
       value =
-          'us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/golang@sha256:6e867e7a9b18808f61e7f1e8815535199f526bb227be340be6547f239a94228b'
+          'us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/debian@sha256:d831b7eb45a3add91c74e1750f8eb8ece1709a8811a50fded5b46dc18880ec38'
     },
   ]
  // I'm not sure why, but this build doesn't seem to need container_properties;


### PR DESCRIPTION
This PR updates the `BUILD_CONTAINER` to use a new container that has Go 1.25.5 in it. The `CERT_CONTAINER` is now changed to use a plain bookworm container, because it doesn't use Go.