### PR TITLE
Add Windows Services

### DIFF
--- a/google-built-opentelemetry-collector/goo/maint.ps1
+++ b/google-built-opentelemetry-collector/goo/maint.ps1
@@ -27,8 +27,13 @@ $envFromMatch = {
      Where-Object -Property Name -eq $match.Groups[1].Value).Value
 }
 $InstallDir = [regex]::Replace($InstallDir,'^<([^>]+)>',$envFromMatch)
-
 $configFilePath = "$InstallDir\config.yaml"
+$serviceName = "otelcol-google"
+
+function Set-ServiceConfig {
+    & sc.exe failure $serviceName reset= 60 actions= restart/1000/restart/2000
+    & sc.exe config $serviceName depend= "rpcss" start= delayed-auto
+}
 
 if ($Action -eq "install") {
     if (-not(Test-Path -Path $configFilePath -PathType Leaf)) {
@@ -39,10 +44,25 @@ if ($Action -eq "install") {
          catch {
              throw $_.Exception.Message
          }
-     }
-     else {
-         Write-Host "Keep [$configFilePath] as-is because a file with that name already exists."
-     }
-     # Sleep for 5s before installing services to allow previous service deletion to complete.
-     Start-Sleep -s 5
+    }
+    else {
+        Write-Host "Keep [$configFilePath] as-is because a file with that name already exists."
+    }
+    New-EventLog -LogName Application -Source $serviceName
+    if (-not (Get-Service $serviceName -ErrorAction SilentlyContinue)) {
+        New-Service -DisplayName "Google-Built OpenTelemetry Collector" `
+                    -Name $serviceName `
+                    -BinaryPathName "`"${InstallDir}\bin\otelcol-google.exe`" --config=`"${configFilePath}`"" `
+                    -StartupType Automatic `
+                    -Description "OpenTelemetry Collector Built By Google"
+        Set-ServiceConfig
+        Start-Service $serviceName -Verbose -ErrorAction Stop
+    }
+    else {
+        Set-ServiceConfig
+    }
+}
+elseif ($Action -eq "uninstall") {
+    Stop-Service -Force $serviceName
+    & sc.exe delete $serviceName
 }

--- a/google-built-opentelemetry-collector/goo/otelcol.goospec
+++ b/google-built-opentelemetry-collector/goo/otelcol.goospec
@@ -4,7 +4,7 @@
 {{$GOARCH := .GOARCH -}}
 {{$INSTALL_DIR := or (.INSTALL_DIR) "<ProgramFiles>/Google/OpenTelemetry Collector" -}}
 {
-  "name": "google-built-opentelemetry-collector",
+  "name": "otelcol-google",
   "version": "{{$PKG_VERSION}}",
   "arch": "{{$ARCH}}",
   "authors": "Google Cloud Platform",

--- a/integration_test/smoke_test/go.mod
+++ b/integration_test/smoke_test/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 toolchain go1.24.3
 
-require github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20251222203343-1635e8bc87b0
+require github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260119145159-eff68fc7b8ef
 
 require (
 	cel.dev/expr v0.20.0 // indirect

--- a/integration_test/smoke_test/go.sum
+++ b/integration_test/smoke_test/go.sum
@@ -22,8 +22,8 @@ cloud.google.com/go/trace v1.11.6 h1:2O2zjPzqPYAHrn3OKl029qlqG6W8ZdYaOWRyr8NgMT4
 cloud.google.com/go/trace v1.11.6/go.mod h1:GA855OeDEBiBMzcckLPE2kDunIpC72N+Pq8WFieFjnI=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20251222203343-1635e8bc87b0 h1:zb5s1Fj3k9wFXfooSCl+8uGL85Ep2xTiSiwIBI+3/hE=
-github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20251222203343-1635e8bc87b0/go.mod h1:hmqK+hsg2z+Xo/Yz16sNxb6TZX+q0KxKsrgYzdpV0P8=
+github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260119145159-eff68fc7b8ef h1:v2hZ/3wkAB/9TvEqqE3zjlVsqozs4rzZ4zqvW/9YPLQ=
+github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260119145159-eff68fc7b8ef/go.mod h1:hmqK+hsg2z+Xo/Yz16sNxb6TZX+q0KxKsrgYzdpV0P8=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0 h1:ErKg/3iS1AKcTkf3yixlZ54f9U1rljCkQyEXWUnIUxc=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0/go.mod h1:yAZHSGnqScoU556rBOVkwLze6WP5N+U11RHuWaGVxwY=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.51.0 h1:fYE9p3esPxA/C0rQ0AHhP0drtPXDRhaWiwg1DPqO7IU=

--- a/templates/google-built-opentelemetry-collector/goo/maint.ps1.go.tmpl
+++ b/templates/google-built-opentelemetry-collector/goo/maint.ps1.go.tmpl
@@ -27,8 +27,13 @@ $envFromMatch = {
      Where-Object -Property Name -eq $match.Groups[1].Value).Value
 }
 $InstallDir = [regex]::Replace($InstallDir,'^<([^>]+)>',$envFromMatch)
-
 $configFilePath = "$InstallDir\config.yaml"
+$serviceName = "{{ .BinaryName }}"
+
+function Set-ServiceConfig {
+    & sc.exe failure $serviceName reset= 60 actions= restart/1000/restart/2000
+    & sc.exe config $serviceName depend= "rpcss" start= delayed-auto
+}
 
 if ($Action -eq "install") {
     if (-not(Test-Path -Path $configFilePath -PathType Leaf)) {
@@ -39,10 +44,25 @@ if ($Action -eq "install") {
          catch {
              throw $_.Exception.Message
          }
-     }
-     else {
-         Write-Host "Keep [$configFilePath] as-is because a file with that name already exists."
-     }
-     # Sleep for 5s before installing services to allow previous service deletion to complete.
-     Start-Sleep -s 5
+    }
+    else {
+        Write-Host "Keep [$configFilePath] as-is because a file with that name already exists."
+    }
+    New-EventLog -LogName Application -Source $serviceName
+    if (-not (Get-Service $serviceName -ErrorAction SilentlyContinue)) {
+        New-Service -DisplayName "{{ .DisplayName }}" `
+                    -Name $serviceName `
+                    -BinaryPathName "`"${InstallDir}\bin\{{ .BinaryName }}.exe`" --config=`"${configFilePath}`"" `
+                    -StartupType Automatic `
+                    -Description "{{ .Description }}"
+        Set-ServiceConfig
+        Start-Service $serviceName -Verbose -ErrorAction Stop
+    }
+    else {
+        Set-ServiceConfig
+    }
+}
+elseif ($Action -eq "uninstall") {
+    Stop-Service -Force $serviceName
+    & sc.exe delete $serviceName
 }

--- a/templates/google-built-opentelemetry-collector/goo/otelcol.goospec.go.tmpl
+++ b/templates/google-built-opentelemetry-collector/goo/otelcol.goospec.go.tmpl
@@ -4,7 +4,7 @@
 {{`{{$GOARCH := .GOARCH -}}`}}
 {{`{{$INSTALL_DIR := or (.INSTALL_DIR) "<ProgramFiles>/Google/OpenTelemetry Collector" -}}`}}
 {
-  "name": "{{ .Name }}",
+  "name": "{{ .BinaryName }}",
   "version": "{{`{{$PKG_VERSION}}`}}",
   "arch": "{{`{{$ARCH}}`}}",
   "authors": "Google Cloud Platform",


### PR DESCRIPTION
This adds Windows Services for GBOC when running in package mode. This was tested offline by doing a package build, uploading the package to a private bucket, and running the smoke tests in Kokoro using that bucket.

This also renames the package on Windows from `google-built-opentelemetry-collector` to `otelcol-google` so that it's consistent with Linux.