### PR TITLE
[gce-testing] Downgrade installed `gcloud` in Rocky Linux 9 ARM due to python bug. 

### DIFF
--- a/integration_test/gce-testing-internal/gce/gce_testing.go
+++ b/integration_test/gce-testing-internal/gce/gce_testing.go
@@ -1982,8 +1982,9 @@ func InstallGcloudIfNeeded(ctx context.Context, logger *log.Logger, vm *VM) erro
 	if isRockyLinux9(vm.ImageSpec) && IsARM(vm.ImageSpec) {
 		// Downgrade "gcloud" in rocky linux 9 arm due to bug with default python 3.9.
 		// https://github.com/googleapis/python-api-core/issues/857
-		_, err := RunRemotely(ctx, logger, vm, "sudo dnf install google-cloud-cli-540.0.0-1 -y")
-		return err
+		if _, err := RunRemotely(ctx, logger, vm, "sudo dnf install google-cloud-cli-540.0.0-1 -y"); err != nil {
+			return err
+		}
 	}
 	if err := verifyGcloudInstallation(ctx, logger, vm); err == nil {
 		// Success, no need to install gcloud.


### PR DESCRIPTION
Downgrade the installed `gcloud` version in Rocky Linux 9 ARM due to a bug with the default installed python 3.9 version.

Some details : 
- Bug : https://github.com/googleapis/python-api-core/issues/857
- ARM `gcloud` doesn't come with bundled python : b/308962066

b/462768459