### PR TITLE
docs: update localhost examples with http scheme and insecure flag

### DIFF
--- a/google-built-opentelemetry-collector/README.md
+++ b/google-built-opentelemetry-collector/README.md
@@ -89,7 +89,7 @@ The Google-Built OpenTelemetry Collector is an open-source, production-ready bui
 | ack | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/ackextension/README.md) |
 | basicauth | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/basicauthextension/README.md) |
 | bearertokenauth | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/bearertokenauthextension/README.md) |
-| filestorage | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/README.md) |
+| filestorage | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage/README.md) |
 | googleclientauth | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/googleclientauthextension/README.md) |
 | headerssetter | [docs](https://www.github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/headerssetterextension/README.md) |
 | healthagent | [docs](No docs linked for component) |

--- a/google-built-opentelemetry-collector/docs/examples/configuration/config-standard.yaml
+++ b/google-built-opentelemetry-collector/docs/examples/configuration/config-standard.yaml
@@ -145,5 +145,5 @@ service:
             exporter:
               otlp:
                 protocol: grpc
-                endpoint: localhost:4317
+                endpoint: http://localhost:4317
                 insecure: true

--- a/google-built-opentelemetry-collector/docs/examples/deployment/cos/cloud-init-config-example.yaml
+++ b/google-built-opentelemetry-collector/docs/examples/deployment/cos/cloud-init-config-example.yaml
@@ -134,4 +134,5 @@ write_files:
                 exporter:
                   otlp:
                     protocol: grpc
-                    endpoint: localhost:4317
+                    endpoint: http://localhost:4317
+                    insecure: true

--- a/templates/google-built-opentelemetry-collector/docs/examples/configuration/config-standard.yaml.go.tmpl
+++ b/templates/google-built-opentelemetry-collector/docs/examples/configuration/config-standard.yaml.go.tmpl
@@ -145,5 +145,5 @@ service:
             exporter:
               otlp:
                 protocol: grpc
-                endpoint: localhost:4317
+                endpoint: http://localhost:4317
                 insecure: true

--- a/templates/google-built-opentelemetry-collector/docs/examples/deployment/cos/cloud-init-config-example.yaml.go.tmpl
+++ b/templates/google-built-opentelemetry-collector/docs/examples/deployment/cos/cloud-init-config-example.yaml.go.tmpl
@@ -134,4 +134,5 @@ write_files:
                 exporter:
                   otlp:
                     protocol: grpc
-                    endpoint: localhost:4317
+                    endpoint: http://localhost:4317
+                    insecure: true


### PR DESCRIPTION
## The Issue
Users following our current documentation have been encountering the following error:

```
transport: authentication handshake failed: tls: first record does not look like a TLS handshake
```

This specifically happens when users configure the endpoint as `localhost`. When provided without an explicit scheme, the periodic exporter defaults to secure mode and attempts a TLS handshake.

## The Fix
This PR updates the documentation examples to ensure the configuration is explicit and failsafe. I have adjusted the examples to:

1. **Add the scheme:** Changed `localhost` to `http://localhost`.
2. **Set the mode:** Explicitly added `insecure: true`.

Combining the `http://` scheme with the explicit insecure flag ensures the examples work out-of-the-box and clearly communicates the configuration's intent.