### PR TITLE
[gce_testing] Create `findMatchingLogs` to return all found logs and create `QueryAllLogs`. 

### DIFF
--- a/integration_test/gce-testing-internal/gce/gce_testing.go
+++ b/integration_test/gce-testing-internal/gce/gce_testing.go
@@ -713,10 +713,7 @@ func AssertLogMissing(ctx context.Context, logger *log.Logger, vm *VM, logNameRe
 		// Success.
 		return nil
 	}
-	if err != nil {
-		return fmt.Errorf("AssertLogMissing() failed: %v", err)
-	}
-	return fmt.Errorf("AssertLogMissing() failed: no successful queries to the backend for log %s, exhausted retries", logNameRegex)
+	return fmt.Errorf("AssertLogMissing(log=%q): %v failed: no successful queries to the backend for log %s, exhausted retries", query, err, logNameRegex)
 }
 
 // CommandOutput holds the textual output from running a subprocess.


### PR DESCRIPTION
Update `hasMatchingLog` to return all found logs and create `QueryAllLogs`. 

Context : 
- Helpful to simplify some integration tests like https://github.com/GoogleCloudPlatform/ops-agent/pull/2166, we need to able to know how many logs did a query returned.