### PR TITLE
Revert boringcrypto support in binaries

### DIFF
--- a/cmd/distrogen/templates/distribution/.goreleaser.yaml.go.tmpl
+++ b/cmd/distrogen/templates/distribution/.goreleaser.yaml.go.tmpl
@@ -5,46 +5,25 @@ snapshot:
   version_template: {{ .Version }}
 
 env:
+  - LD_FLAGS=-s -w
+  - CGO_ENABLED=0 # TODO: CGO is not supported in goreleaser yet.
+  - BUILD_FLAGS=-trimpath
   - GOWORK=off
-  - CGO_ENABLED=0
 
 builds:
   - id: {{ .BinaryName }}-linux
-    {{- if .CollectorCGO }}
-    env:
-    - CGO_ENABLED=1
-    {{ if .BoringCrypto -}}
-    - GOEXPERIMENT=boringcrypto
-    {{- end }}
-    {{- end }}
     goos:
       - linux
     goarch:
       - amd64
       - arm64
-    {{ if .BoringCrypto -}}
-    overrides:
-      - goos: linux
-        goarch: arm64
-        env:
-          - CC=aarch64-linux-gnu-gcc
-      - goos: linux
-        goarch: amd64
-        env:
-          - CC=x86_64-linux-gnu-gcc
-    {{- end }}
+    binary: {{ .BinaryName }}
+    dir: _build
     ldflags:
-      - "-s"
-      - "-w"
-      {{- if .BoringCrypto }}
-      - "-linkmode=external"
-      - "-extldflags=-static"
-      {{- end }}
+      - "-s -w"
     flags:
       - "-trimpath"
       - "-buildvcs=false"
-    binary: {{ .BinaryName }}
-    dir: _build
 
   - id: {{ .BinaryName }}-windows
     goos:
@@ -52,13 +31,12 @@ builds:
     goarch:
       - amd64
     binary: {{ .BinaryName }}
+    dir: _build
     ldflags:
-      - "-s"
-      - "-w"
+      - "-s -w"
     flags:
       - "-trimpath"
       - "-buildvcs=false"
-    dir: _build
 
 nfpms:
   - package_name: {{ .BinaryName }}

--- a/cmd/distrogen/templates/distribution/Dockerfile.goreleaser_releaser.go.tmpl
+++ b/cmd/distrogen/templates/distribution/Dockerfile.goreleaser_releaser.go.tmpl
@@ -11,10 +11,19 @@
 # The whole project is copied to the container in case you provide
 # any custom components contained within your full project structure.
 ARG PROJECT_ROOT="."
+{{ if eq .BuildContainer "debian" -}}
 ARG BUILD_CONTAINER="debian"
 FROM ${BUILD_CONTAINER} AS build
 
-RUN apt-get update && apt-get install -y make curl git{{ if .CollectorCGO }} build-essential{{ end }}{{ if .BoringCrypto }} gcc-aarch64-linux-gnu libc6-dev-arm64-cross{{ end }}
+RUN apt-get update && apt-get install -y make curl git{{ if .CollectorCGO }} build-essential{{ end }}
+
+{{ else -}}
+ARG BUILD_CONTAINER="alpine"
+FROM ${BUILD_CONTAINER} AS build
+
+RUN apk --update add make curl git{{ if .CollectorCGO }} alpine-sdk{{ end }}
+
+{{ end -}}
 
 ARG PROJECT_ROOT
 COPY ${PROJECT_ROOT} /

--- a/cmd/distrogen/testdata/generator/distribution/basic/golden/.goreleaser.yaml
+++ b/cmd/distrogen/testdata/generator/distribution/basic/golden/.goreleaser.yaml
@@ -5,8 +5,10 @@ snapshot:
   version_template: 0.121.0
 
 env:
+  - LD_FLAGS=-s -w
+  - CGO_ENABLED=0 # TODO: CGO is not supported in goreleaser yet.
+  - BUILD_FLAGS=-trimpath
   - GOWORK=off
-  - CGO_ENABLED=0
 
 builds:
   - id: otelcol-basic-linux
@@ -15,15 +17,13 @@ builds:
     goarch:
       - amd64
       - arm64
-    
+    binary: otelcol-basic
+    dir: _build
     ldflags:
-      - "-s"
-      - "-w"
+      - "-s -w"
     flags:
       - "-trimpath"
       - "-buildvcs=false"
-    binary: otelcol-basic
-    dir: _build
 
   - id: otelcol-basic-windows
     goos:
@@ -31,13 +31,12 @@ builds:
     goarch:
       - amd64
     binary: otelcol-basic
+    dir: _build
     ldflags:
-      - "-s"
-      - "-w"
+      - "-s -w"
     flags:
       - "-trimpath"
       - "-buildvcs=false"
-    dir: _build
 
 nfpms:
   - package_name: otelcol-basic

--- a/cmd/distrogen/testdata/generator/distribution/build_container/golden/.goreleaser.yaml
+++ b/cmd/distrogen/testdata/generator/distribution/build_container/golden/.goreleaser.yaml
@@ -5,28 +5,25 @@ snapshot:
   version_template: 0.121.0
 
 env:
+  - LD_FLAGS=-s -w
+  - CGO_ENABLED=0 # TODO: CGO is not supported in goreleaser yet.
+  - BUILD_FLAGS=-trimpath
   - GOWORK=off
-  - CGO_ENABLED=0
 
 builds:
   - id: otelcol-basic-linux
-    env:
-    - CGO_ENABLED=1
-    
     goos:
       - linux
     goarch:
       - amd64
       - arm64
-    
+    binary: otelcol-basic
+    dir: _build
     ldflags:
-      - "-s"
-      - "-w"
+      - "-s -w"
     flags:
       - "-trimpath"
       - "-buildvcs=false"
-    binary: otelcol-basic
-    dir: _build
 
   - id: otelcol-basic-windows
     goos:
@@ -34,13 +31,12 @@ builds:
     goarch:
       - amd64
     binary: otelcol-basic
+    dir: _build
     ldflags:
-      - "-s"
-      - "-w"
+      - "-s -w"
     flags:
       - "-trimpath"
       - "-buildvcs=false"
-    dir: _build
 
 nfpms:
   - package_name: otelcol-basic

--- a/cmd/distrogen/testdata/generator/distribution/custom_templates_subdir/golden/.goreleaser.yaml
+++ b/cmd/distrogen/testdata/generator/distribution/custom_templates_subdir/golden/.goreleaser.yaml
@@ -5,8 +5,10 @@ snapshot:
   version_template: 0.121.0
 
 env:
+  - LD_FLAGS=-s -w
+  - CGO_ENABLED=0 # TODO: CGO is not supported in goreleaser yet.
+  - BUILD_FLAGS=-trimpath
   - GOWORK=off
-  - CGO_ENABLED=0
 
 builds:
   - id: otelcol-basic-linux
@@ -15,15 +17,13 @@ builds:
     goarch:
       - amd64
       - arm64
-    
+    binary: otelcol-basic
+    dir: _build
     ldflags:
-      - "-s"
-      - "-w"
+      - "-s -w"
     flags:
       - "-trimpath"
       - "-buildvcs=false"
-    binary: otelcol-basic
-    dir: _build
 
   - id: otelcol-basic-windows
     goos:
@@ -31,13 +31,12 @@ builds:
     goarch:
       - amd64
     binary: otelcol-basic
+    dir: _build
     ldflags:
-      - "-s"
-      - "-w"
+      - "-s -w"
     flags:
       - "-trimpath"
       - "-buildvcs=false"
-    dir: _build
 
 nfpms:
   - package_name: otelcol-basic

--- a/cmd/distrogen/testdata/generator/distribution/go_proxy/golden/.goreleaser.yaml
+++ b/cmd/distrogen/testdata/generator/distribution/go_proxy/golden/.goreleaser.yaml
@@ -5,8 +5,10 @@ snapshot:
   version_template: 0.121.0
 
 env:
+  - LD_FLAGS=-s -w
+  - CGO_ENABLED=0 # TODO: CGO is not supported in goreleaser yet.
+  - BUILD_FLAGS=-trimpath
   - GOWORK=off
-  - CGO_ENABLED=0
 
 builds:
   - id: otelcol-basic-linux
@@ -15,15 +17,13 @@ builds:
     goarch:
       - amd64
       - arm64
-    
+    binary: otelcol-basic
+    dir: _build
     ldflags:
-      - "-s"
-      - "-w"
+      - "-s -w"
     flags:
       - "-trimpath"
       - "-buildvcs=false"
-    binary: otelcol-basic
-    dir: _build
 
   - id: otelcol-basic-windows
     goos:
@@ -31,13 +31,12 @@ builds:
     goarch:
       - amd64
     binary: otelcol-basic
+    dir: _build
     ldflags:
-      - "-s"
-      - "-w"
+      - "-s -w"
     flags:
       - "-trimpath"
       - "-buildvcs=false"
-    dir: _build
 
 nfpms:
   - package_name: otelcol-basic

--- a/cmd/distrogen/testdata/generator/distribution/no_docker_repo/golden/.goreleaser.yaml
+++ b/cmd/distrogen/testdata/generator/distribution/no_docker_repo/golden/.goreleaser.yaml
@@ -5,8 +5,10 @@ snapshot:
   version_template: 0.121.0
 
 env:
+  - LD_FLAGS=-s -w
+  - CGO_ENABLED=0 # TODO: CGO is not supported in goreleaser yet.
+  - BUILD_FLAGS=-trimpath
   - GOWORK=off
-  - CGO_ENABLED=0
 
 builds:
   - id: otelcol-basic-linux
@@ -15,15 +17,13 @@ builds:
     goarch:
       - amd64
       - arm64
-    
+    binary: otelcol-basic
+    dir: _build
     ldflags:
-      - "-s"
-      - "-w"
+      - "-s -w"
     flags:
       - "-trimpath"
       - "-buildvcs=false"
-    binary: otelcol-basic
-    dir: _build
 
   - id: otelcol-basic-windows
     goos:
@@ -31,13 +31,12 @@ builds:
     goarch:
       - amd64
     binary: otelcol-basic
+    dir: _build
     ldflags:
-      - "-s"
-      - "-w"
+      - "-s -w"
     flags:
       - "-trimpath"
       - "-buildvcs=false"
-    dir: _build
 
 nfpms:
   - package_name: otelcol-basic

--- a/google-built-opentelemetry-collector/.goreleaser.yaml
+++ b/google-built-opentelemetry-collector/.goreleaser.yaml
@@ -5,38 +5,25 @@ snapshot:
   version_template: 0.144.0
 
 env:
+  - LD_FLAGS=-s -w
+  - CGO_ENABLED=0 # TODO: CGO is not supported in goreleaser yet.
+  - BUILD_FLAGS=-trimpath
   - GOWORK=off
-  - CGO_ENABLED=0
 
 builds:
   - id: otelcol-google-linux
-    env:
-    - CGO_ENABLED=1
-    - GOEXPERIMENT=boringcrypto
     goos:
       - linux
     goarch:
       - amd64
       - arm64
-    overrides:
-      - goos: linux
-        goarch: arm64
-        env:
-          - CC=aarch64-linux-gnu-gcc
-      - goos: linux
-        goarch: amd64
-        env:
-          - CC=x86_64-linux-gnu-gcc
+    binary: otelcol-google
+    dir: _build
     ldflags:
-      - "-s"
-      - "-w"
-      - "-linkmode=external"
-      - "-extldflags=-static"
+      - "-s -w"
     flags:
       - "-trimpath"
       - "-buildvcs=false"
-    binary: otelcol-google
-    dir: _build
 
   - id: otelcol-google-windows
     goos:
@@ -44,13 +31,12 @@ builds:
     goarch:
       - amd64
     binary: otelcol-google
+    dir: _build
     ldflags:
-      - "-s"
-      - "-w"
+      - "-s -w"
     flags:
       - "-trimpath"
       - "-buildvcs=false"
-    dir: _build
 
 nfpms:
   - package_name: otelcol-google

--- a/google-built-opentelemetry-collector/Dockerfile.goreleaser_releaser
+++ b/google-built-opentelemetry-collector/Dockerfile.goreleaser_releaser
@@ -14,7 +14,7 @@ ARG PROJECT_ROOT="."
 ARG BUILD_CONTAINER="debian"
 FROM ${BUILD_CONTAINER} AS build
 
-RUN apt-get update && apt-get install -y make curl git build-essential gcc-aarch64-linux-gnu libc6-dev-arm64-cross
+RUN apt-get update && apt-get install -y make curl git build-essential
 
 ARG PROJECT_ROOT
 COPY ${PROJECT_ROOT} /

--- a/otelopscol/.goreleaser.yaml
+++ b/otelopscol/.goreleaser.yaml
@@ -5,28 +5,25 @@ snapshot:
   version_template: v0.145.0
 
 env:
+  - LD_FLAGS=-s -w
+  - CGO_ENABLED=0 # TODO: CGO is not supported in goreleaser yet.
+  - BUILD_FLAGS=-trimpath
   - GOWORK=off
-  - CGO_ENABLED=0
 
 builds:
   - id: otelopscol-linux
-    env:
-    - CGO_ENABLED=1
-    
     goos:
       - linux
     goarch:
       - amd64
       - arm64
-    
+    binary: otelopscol
+    dir: _build
     ldflags:
-      - "-s"
-      - "-w"
+      - "-s -w"
     flags:
       - "-trimpath"
       - "-buildvcs=false"
-    binary: otelopscol
-    dir: _build
 
   - id: otelopscol-windows
     goos:
@@ -34,13 +31,12 @@ builds:
     goarch:
       - amd64
     binary: otelopscol
+    dir: _build
     ldflags:
-      - "-s"
-      - "-w"
+      - "-s -w"
     flags:
       - "-trimpath"
       - "-buildvcs=false"
-    dir: _build
 
 nfpms:
   - package_name: otelopscol


### PR DESCRIPTION
The build gives the following error that I should have noticed while verifying locally but was obscured by other `goreleaser` logs:
```
warning: Using 'getgrouplist' in statically linked applications requires
at runtime the shared libraries from the glibc version used for linking
```
This is because of the inability to use `libnss` in a statically linked application.

The issue this warning is referring to has not yet come to fruition to our knowledge in the image releases of GBOC which are statically linked to BoringCrypto. The error would likely manifest this error because `gcr.io/distroless/static` (the base image) doesn't come with any dynamic dependencies. I'm uneasy about whether this is enough of a signal to say we can safely introduce this to the package releases though, so for now I am reverting this feature to restore our build pipelines.