### PR TITLE
Update RHUI repo flake workaround for RHEL 8+

### DIFF
--- a/integration_test/gce-testing-internal/gce/gce_testing.go
+++ b/integration_test/gce-testing-internal/gce/gce_testing.go
@@ -1306,10 +1306,10 @@ func verifyVMCreation(ctx context.Context, logger *log.Logger, vm *VM) error {
 		}
 	}
 
-	// Removing flaky rhel-7 repositories due to b/265341502
-	if isRHEL7SAPHA(vm.ImageSpec) {
+	// Removing flaky rhui repositories due to b/265341502
+	if IsRHEL(vm.ImageSpec) {
 		if _, err := RunRemotely(ctx,
-			logger, vm, `sudo yum -y --disablerepo=rhui-rhel*-7-* install yum-utils && sudo yum-config-manager --disable "rhui-rhel*-7-*"`); err != nil {
+			logger, vm, `sudo yum -y --disablerepo=rhui-rhel* install dnf-plugins-core && sudo yum config-manager --disable "rhui-rhel*"`); err != nil {
 			return fmt.Errorf("disabling flaky repos failed: %w", err)
 		}
 	}


### PR DESCRIPTION
An Ops Agent test run passed all RHEL tests against this branch: https://github.com/GoogleCloudPlatform/ops-agent/pull/2213.