### PR TITLE
Fix windows build for otelopscol

### DIFF
--- a/otelopscol/build.ps1
+++ b/otelopscol/build.ps1
@@ -110,6 +110,20 @@ function Generate-CollectorSource {
     Run-Command $ocbGenerateCommand
 }
 
+function Set-BuildEnvironment {
+    Write-Host "Temporarily updating PATH for build and ensuring GCC is present..."
+    $originalPath = $env:Path
+    $env:Path = "C:\msys64\usr\bin;C:\msys64\mingw64\bin;$originalPath"
+
+    if (-not (Test-Path "C:\msys64\mingw64\bin\gcc.exe")) {
+        Write-Host "Installing MINGW GCC..."
+        Run-Command "pacman -S --noconfirm mingw-w64-x86_64-gcc"
+    } else {
+        Write-Host "MINGW GCC already installed"
+    }
+    return $originalPath
+}
+
 function Build-WindowsCollector {
     param (
         [string]$goBin,
@@ -117,17 +131,9 @@ function Build-WindowsCollector {
         [string]$outDir
     )
 
-    $startEnvPath = $env:Path
+    $originalPath = $null
     try {
-        Write-Host "Temporarily updating PATH for build..."
-        $env:Path = "C:\msys64\usr\bin;C:\msys64\mingw64\bin;$startEnvPath"
-
-        if (-not (Test-Path "C:\msys64\mingw64\bin\gcc.exe")) {
-            Write-Host "Installing MINGW GCC..."
-            Run-Command "pacman -S --noconfirm mingw-w64-x86_64-gcc"
-        } else {
-            Write-Host "MINGW GCC already installed"
-        }
+        $originalPath = Set-BuildEnvironment
 
         Write-Host "Building the collector..."
         $ldFlags = "-s -w"
@@ -147,8 +153,10 @@ function Build-WindowsCollector {
         Write-Host "Build complete."
     }
     finally {
-        Write-Host "Restoring original PATH."
-        $env:Path = $startEnvPath
+        if ($originalPath) {
+            Write-Host "Restoring original PATH."
+            $env:Path = $originalPath
+        }
     }
 }
 

--- a/templates/otelopscol/build.ps1.go.tmpl
+++ b/templates/otelopscol/build.ps1.go.tmpl
@@ -110,6 +110,20 @@ function Generate-CollectorSource {
     Run-Command $ocbGenerateCommand
 }
 
+function Set-BuildEnvironment {
+    Write-Host "Temporarily updating PATH for build and ensuring GCC is present..."
+    $originalPath = $env:Path
+    $env:Path = "C:\msys64\usr\bin;C:\msys64\mingw64\bin;$originalPath"
+
+    if (-not (Test-Path "C:\msys64\mingw64\bin\gcc.exe")) {
+        Write-Host "Installing MINGW GCC..."
+        Run-Command "pacman -S --noconfirm mingw-w64-x86_64-gcc"
+    } else {
+        Write-Host "MINGW GCC already installed"
+    }
+    return $originalPath
+}
+
 function Build-WindowsCollector {
     param (
         [string]$goBin,
@@ -117,17 +131,9 @@ function Build-WindowsCollector {
         [string]$outDir
     )
 
-    $startEnvPath = $env:Path
+    $originalPath = $null
     try {
-        Write-Host "Temporarily updating PATH for build..."
-        $env:Path = "C:\msys64\usr\bin;C:\msys64\mingw64\bin;$startEnvPath"
-
-        if (-not (Test-Path "C:\msys64\mingw64\bin\gcc.exe")) {
-            Write-Host "Installing MINGW GCC..."
-            Run-Command "pacman -S --noconfirm mingw-w64-x86_64-gcc"
-        } else {
-            Write-Host "MINGW GCC already installed"
-        }
+        $originalPath = Set-BuildEnvironment
 
         Write-Host "Building the collector..."
         $ldFlags = "-s -w"
@@ -147,8 +153,10 @@ function Build-WindowsCollector {
         Write-Host "Build complete."
     }
     finally {
-        Write-Host "Restoring original PATH."
-        $env:Path = $startEnvPath
+        if ($originalPath) {
+            Write-Host "Restoring original PATH."
+            $env:Path = $originalPath
+        }
     }
 }
 


### PR DESCRIPTION
Updating build.ps1 script with some QoL changes and error handling
* Use go from GO_BIN_PATH instead of always installing it
* Do not try to install tools if they are already present
* Check for step success and exit early in case of failure
* Make sure to restore the path in all cases