### PR TITLE
Disable flaky RHUI repos even more than previously believed

### DIFF
--- a/integration_test/gce-testing-internal/gce/gce_testing.go
+++ b/integration_test/gce-testing-internal/gce/gce_testing.go
@@ -1306,7 +1306,7 @@ func verifyVMCreation(ctx context.Context, logger *log.Logger, vm *VM) error {
 	// Removing flaky rhui repositories due to b/265341502
 	if IsRHEL(vm.ImageSpec) {
 		if _, err := RunRemotely(ctx,
-			logger, vm, `sudo yum -y --disablerepo=rhui-rhel* install dnf-plugins-core && sudo yum config-manager --disable "rhui-rhel*"`); err != nil {
+			logger, vm, `sudo yum -y --disablerepo=rhui-* install dnf-plugins-core && sudo yum config-manager --disable "rhui-*"`); err != nil {
 			return fmt.Errorf("disabling flaky repos failed: %w", err)
 		}
 	}


### PR DESCRIPTION
We previously only noticed repos prefixed by `rhui-rhel`, but recently we saw a bunch of failures on something called
`rhui-codeready-builder-for-rhel-10-x86_64-rhui-debug-rpms`, so let's just disable all of the `rhui` repos.

Being tested in https://github.com/GoogleCloudPlatform/ops-agent/pull/2237