### PR TITLE
Update DLVM image

### DIFF
--- a/distros.yaml
+++ b/distros.yaml
@@ -33,7 +33,6 @@ targets:
         test_distros:
           representative:
           - debian-cloud:debian-11
-          - ml-images:common-gpu-debian-11-py310
   centos8:
     package_extension:
       rpm
@@ -82,6 +81,7 @@ targets:
           - ubuntu-os-cloud:ubuntu-2404-lts-amd64
           exhaustive:
           - ubuntu-os-cloud:ubuntu-minimal-2404-lts-amd64
+          - ml-images:common-cu128-ubuntu-2404-nvidia-570
       aarch64:
         test_distros:
           representative:


### PR DESCRIPTION
Debian-based DLVM images are deprecated. Also moving to `exhaustive` because we don't specifically have GPU tests right now. http://b/498959379