### PR TITLE
Fix missed generate

### DIFF
--- a/google-built-opentelemetry-collector/docs/examples/configuration/config-standard.yaml
+++ b/google-built-opentelemetry-collector/docs/examples/configuration/config-standard.yaml
@@ -67,12 +67,6 @@ processors:
       - set(attributes["exported_project_id"], attributes["project_id"])
       - delete_key(attributes, "project_id")
 
-  transform/set_project_id:
-    error_mode: ignore
-    trace_statements:
-    - set(resource.attributes["gcp.project_id"], resource.attributes["gcp.project.id"]) where resource.attributes["gcp.project.id"] != nil
-    - set(resource.attributes["gcp.project_id"], resource.attributes["cloud.account.id"]) where resource.attributes["gcp.project_id"] == nil and resource.attributes["cloud.account.id"] != nil
-
 exporters:
   # The googlecloud exporter will export telemetry to different
   # Google Cloud services:
@@ -93,14 +87,6 @@ exporters:
   # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlemanagedprometheusexporter
   googlemanagedprometheus:
 
-  # The otlp exporter is used to send traces to Google Cloud Trace using OTLP gRPC
-  otlp:
-    endpoint: telemetry.googleapis.com:443
-    compression: none
-    balancer_name: pick_first
-    auth:
-      authenticator: googleclientauth
-
 extensions:
   # Opens an endpoint on 13133 that can be used to check the
   # status of the collector. Since this does not configure the
@@ -114,12 +100,10 @@ extensions:
   # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension
   health_check:
     endpoint: 0.0.0.0:13133
-  googleclientauth:
 
 service:
   extensions:
   - health_check
-  - googleclientauth
   pipelines:
     logs:
       receivers:
@@ -146,10 +130,9 @@ service:
       processors:
       - resourcedetection
       - memory_limiter
-      - transform/set_project_id
       - batch
       exporters:
-      - otlp
+      - googlecloud
   # Internal telemetry for the collector supports both push and pull-based telemetry data transmission.
   # Leveraging the pre-configured OTLP receiver eliminates the need for an additional port.
   #

--- a/google-built-opentelemetry-collector/docs/examples/deployment/cos/cloud-init-config-example.yaml
+++ b/google-built-opentelemetry-collector/docs/examples/deployment/cos/cloud-init-config-example.yaml
@@ -72,12 +72,6 @@ write_files:
           - set(attributes["exported_project_id"], attributes["project_id"])
           - delete_key(attributes, "project_id")
 
-      transform/set_project_id:
-        error_mode: ignore
-        trace_statements:
-        - set(resource.attributes["gcp.project_id"], resource.attributes["gcp.project.id"]) where resource.attributes["gcp.project.id"] != nil
-        - set(resource.attributes["gcp.project_id"], resource.attributes["cloud.account.id"]) where resource.attributes["gcp.project_id"] == nil and resource.attributes["cloud.account.id"] != nil
-
     exporters:
       # The googlecloud exporter will export telemetry to different
       # Google Cloud services:
@@ -98,20 +92,7 @@ write_files:
       # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlemanagedprometheusexporter
       googlemanagedprometheus:
 
-      # The otlp exporter is used to send traces to Google Cloud Trace using OTLP gRPC
-      otlp:
-        endpoint: telemetry.googleapis.com:443
-        compression: none
-        balancer_name: pick_first
-        auth:
-          authenticator: googleclientauth
-
-    extensions:
-      googleclientauth:
-
     service:
-      extensions:
-      - googleclientauth
       pipelines:
         logs:
           receivers:
@@ -138,10 +119,9 @@ write_files:
           processors:
           - resourcedetection
           - memory_limiter
-          - transform/set_project_id
           - batch
           exporters:
-          - otlp
+          - googlecloud
       # Internal telemetry for the collector supports both push and pull-based telemetry data transmission.
       # Leveraging the pre-configured OTLP receiver eliminates the need for an additional port.
       #


### PR DESCRIPTION
A previous PR missed the generation step for the GBOC distribution. This was missed while the `--compare` feature of distrogen was broken, meaning our comparison presubmit always passed.