### PR TITLE
Fix otlp trace doc templates

### DIFF
--- a/templates/google-built-opentelemetry-collector/docs/examples/configuration/config-standard.yaml.go.tmpl
+++ b/templates/google-built-opentelemetry-collector/docs/examples/configuration/config-standard.yaml.go.tmpl
@@ -67,6 +67,12 @@ processors:
       - set(attributes["exported_project_id"], attributes["project_id"])
       - delete_key(attributes, "project_id")
 
+  transform/set_project_id:
+    error_mode: ignore
+    trace_statements:
+    - set(resource.attributes["gcp.project_id"], resource.attributes["gcp.project.id"]) where resource.attributes["gcp.project.id"] != nil
+    - set(resource.attributes["gcp.project_id"], resource.attributes["cloud.account.id"]) where resource.attributes["gcp.project_id"] == nil and resource.attributes["cloud.account.id"] != nil
+
 exporters:
   # The googlecloud exporter will export telemetry to different
   # Google Cloud services:
@@ -87,6 +93,14 @@ exporters:
   # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlemanagedprometheusexporter
   googlemanagedprometheus:
 
+  # The otlp exporter is used to send traces to Google Cloud Trace using OTLP gRPC
+  otlp:
+    endpoint: telemetry.googleapis.com:443
+    compression: none
+    balancer_name: pick_first
+    auth:
+      authenticator: googleclientauth
+
 extensions:
   # Opens an endpoint on 13133 that can be used to check the
   # status of the collector. Since this does not configure the
@@ -100,10 +114,12 @@ extensions:
   # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension
   health_check:
     endpoint: 0.0.0.0:13133
+  googleclientauth:
 
 service:
   extensions:
   - health_check
+  - googleclientauth
   pipelines:
     logs:
       receivers:
@@ -130,9 +146,10 @@ service:
       processors:
       - resourcedetection
       - memory_limiter
+      - transform/set_project_id
       - batch
       exporters:
-      - googlecloud
+      - otlp
   # Internal telemetry for the collector supports both push and pull-based telemetry data transmission.
   # Leveraging the pre-configured OTLP receiver eliminates the need for an additional port.
   #

--- a/templates/google-built-opentelemetry-collector/docs/examples/deployment/cos/cloud-init-config-example.yaml.go.tmpl
+++ b/templates/google-built-opentelemetry-collector/docs/examples/deployment/cos/cloud-init-config-example.yaml.go.tmpl
@@ -72,6 +72,12 @@ write_files:
           - set(attributes["exported_project_id"], attributes["project_id"])
           - delete_key(attributes, "project_id")
 
+      transform/set_project_id:
+        error_mode: ignore
+        trace_statements:
+        - set(resource.attributes["gcp.project_id"], resource.attributes["gcp.project.id"]) where resource.attributes["gcp.project.id"] != nil
+        - set(resource.attributes["gcp.project_id"], resource.attributes["cloud.account.id"]) where resource.attributes["gcp.project_id"] == nil and resource.attributes["cloud.account.id"] != nil
+
     exporters:
       # The googlecloud exporter will export telemetry to different
       # Google Cloud services:
@@ -92,7 +98,20 @@ write_files:
       # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlemanagedprometheusexporter
       googlemanagedprometheus:
 
+      # The otlp exporter is used to send traces to Google Cloud Trace using OTLP gRPC
+      otlp:
+        endpoint: telemetry.googleapis.com:443
+        compression: none
+        balancer_name: pick_first
+        auth:
+          authenticator: googleclientauth
+
+    extensions:
+      googleclientauth:
+
     service:
+      extensions:
+      - googleclientauth
       pipelines:
         logs:
           receivers:
@@ -119,9 +138,10 @@ write_files:
           processors:
           - resourcedetection
           - memory_limiter
+          - transform/set_project_id
           - batch
           exporters:
-          - googlecloud
+          - otlp
       # Internal telemetry for the collector supports both push and pull-based telemetry data transmission.
       # Leveraging the pre-configured OTLP receiver eliminates the need for an additional port.
       #


### PR DESCRIPTION
Because the `--compare` feature was broken, the previous PR went through when it only edited the generated copies of the docs and not the templates they are generated from. This PR matches the templates to the generated copies so that the comparison from generation will continue to work as intended.