### PR TITLE
distrogen: dynamic query of distrogen_version from spec file

### DIFF
--- a/cmd/distrogen/templates/project/Makefile.go.tmpl
+++ b/cmd/distrogen/templates/project/Makefile.go.tmpl
@@ -11,12 +11,14 @@ SPEC_FILE = {{ .Spec.Path }}
 
 TOOLS_DIR ?= $(PWD)/.tools
 DISTROGEN_BIN ?= $(TOOLS_DIR)/distrogen
+DISTROGEN_QUERY = $(if $(wildcard $(DISTROGEN_BIN)),$(DISTROGEN_BIN),distrogen) query --spec $(SPEC_FILE) --field
+DISTROGEN_VERSION ?= $(shell $(DISTROGEN_QUERY) distrogen_version)
 MDATAGEN_BIN ?= $(TOOLS_DIR)/mdatagen
 DISTRO_DIR = $(PWD)/{{ .Spec.Name }}
 
 $(DISTROGEN_BIN):
 	$(MAKE) tools-dir
-	GOBIN=$(TOOLS_DIR) go install github.com/GoogleCloudPlatform/opentelemetry-operations-collector/cmd/distrogen@$(shell cat .distrogen/VERSION)
+	GOBIN=$(TOOLS_DIR) go install github.com/GoogleCloudPlatform/opentelemetry-operations-collector/cmd/distrogen@$(DISTROGEN_VERSION)
 
 $(MDATAGEN_BIN):
 	$(MAKE) tools-dir
@@ -38,7 +40,6 @@ distrogen: $(DISTROGEN_BIN)
 
 COMPONENT_DIR = components
 
-DISTROGEN_QUERY = $(DISTROGEN_BIN) query --spec $(SPEC_FILE) --field
 
 .PHONY: update-otel-components
 update-otel-components: $(DISTROGEN_BIN) $(MDATAGEN_BIN) workspace-update

--- a/cmd/distrogen/testdata/generator/project/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/project/golden/Makefile
@@ -11,12 +11,14 @@ SPEC_FILE = spec.yaml
 
 TOOLS_DIR ?= $(PWD)/.tools
 DISTROGEN_BIN ?= $(TOOLS_DIR)/distrogen
+DISTROGEN_QUERY = $(if $(wildcard $(DISTROGEN_BIN)),$(DISTROGEN_BIN),distrogen) query --spec $(SPEC_FILE) --field
+DISTROGEN_VERSION ?= $(shell $(DISTROGEN_QUERY) distrogen_version)
 MDATAGEN_BIN ?= $(TOOLS_DIR)/mdatagen
 DISTRO_DIR = $(PWD)/basic-distro
 
 $(DISTROGEN_BIN):
 	$(MAKE) tools-dir
-	GOBIN=$(TOOLS_DIR) go install github.com/GoogleCloudPlatform/opentelemetry-operations-collector/cmd/distrogen@$(shell cat .distrogen/VERSION)
+	GOBIN=$(TOOLS_DIR) go install github.com/GoogleCloudPlatform/opentelemetry-operations-collector/cmd/distrogen@$(DISTROGEN_VERSION)
 
 $(MDATAGEN_BIN):
 	$(MAKE) tools-dir
@@ -38,7 +40,6 @@ distrogen: $(DISTROGEN_BIN)
 
 COMPONENT_DIR = components
 
-DISTROGEN_QUERY = $(DISTROGEN_BIN) query --spec $(SPEC_FILE) --field
 
 .PHONY: update-otel-components
 update-otel-components: $(DISTROGEN_BIN) $(MDATAGEN_BIN) workspace-update


### PR DESCRIPTION
This PR refactors the generated project `Makefile` template to dynamically retrieve the correct `distrogen` version from the project's `spec.yaml` file. This removes the dependency on `.distrogen/VERSION` for checking the required version and instead makes the specification file the single source of truth.
