### PR TITLE
distrogen: fix clean-collector target dependency in Makefiles

### DIFF
--- a/cmd/distrogen/templates/distribution/Makefile.go.tmpl
+++ b/cmd/distrogen/templates/distribution/Makefile.go.tmpl
@@ -165,7 +165,7 @@ collector-module-list: ocb-generate
 
 # Delete any existing built collector binary.
 .PHONY: clean-collector
-clean-collector: clean-build-dir
+clean-collector: clean-build-temp-dir
 	rm -f $(COLLECTOR_BINARY_NAME)
 
 .PHONY: clean-build-temp-dir

--- a/cmd/distrogen/testdata/generator/distribution/basic/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/basic/golden/Makefile
@@ -155,7 +155,7 @@ collector-module-list: ocb-generate
 
 # Delete any existing built collector binary.
 .PHONY: clean-collector
-clean-collector: clean-build-dir
+clean-collector: clean-build-temp-dir
 	rm -f $(COLLECTOR_BINARY_NAME)
 
 .PHONY: clean-build-temp-dir

--- a/cmd/distrogen/testdata/generator/distribution/boringcrypto/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/boringcrypto/golden/Makefile
@@ -156,7 +156,7 @@ collector-module-list: ocb-generate
 
 # Delete any existing built collector binary.
 .PHONY: clean-collector
-clean-collector: clean-build-dir
+clean-collector: clean-build-temp-dir
 	rm -f $(COLLECTOR_BINARY_NAME)
 
 .PHONY: clean-build-temp-dir

--- a/cmd/distrogen/testdata/generator/distribution/build_container/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/build_container/golden/Makefile
@@ -155,7 +155,7 @@ collector-module-list: ocb-generate
 
 # Delete any existing built collector binary.
 .PHONY: clean-collector
-clean-collector: clean-build-dir
+clean-collector: clean-build-temp-dir
 	rm -f $(COLLECTOR_BINARY_NAME)
 
 .PHONY: clean-build-temp-dir

--- a/cmd/distrogen/testdata/generator/distribution/custom_templates_subdir/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/custom_templates_subdir/golden/Makefile
@@ -155,7 +155,7 @@ collector-module-list: ocb-generate
 
 # Delete any existing built collector binary.
 .PHONY: clean-collector
-clean-collector: clean-build-dir
+clean-collector: clean-build-temp-dir
 	rm -f $(COLLECTOR_BINARY_NAME)
 
 .PHONY: clean-build-temp-dir

--- a/cmd/distrogen/testdata/generator/distribution/go_proxy/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/go_proxy/golden/Makefile
@@ -155,7 +155,7 @@ collector-module-list: ocb-generate
 
 # Delete any existing built collector binary.
 .PHONY: clean-collector
-clean-collector: clean-build-dir
+clean-collector: clean-build-temp-dir
 	rm -f $(COLLECTOR_BINARY_NAME)
 
 .PHONY: clean-build-temp-dir

--- a/cmd/distrogen/testdata/generator/distribution/no_docker_repo/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/no_docker_repo/golden/Makefile
@@ -154,7 +154,7 @@ collector-module-list: ocb-generate
 
 # Delete any existing built collector binary.
 .PHONY: clean-collector
-clean-collector: clean-build-dir
+clean-collector: clean-build-temp-dir
 	rm -f $(COLLECTOR_BINARY_NAME)
 
 .PHONY: clean-build-temp-dir

--- a/cmd/distrogen/testdata/generator/distribution/permanent_ocb_dir/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/permanent_ocb_dir/golden/Makefile
@@ -156,7 +156,7 @@ collector-module-list: ocb-generate
 
 # Delete any existing built collector binary.
 .PHONY: clean-collector
-clean-collector: clean-build-dir
+clean-collector: clean-build-temp-dir
 	rm -f $(COLLECTOR_BINARY_NAME)
 
 .PHONY: clean-build-temp-dir

--- a/cmd/distrogen/testdata/generator/distribution/vendor_dependencies/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/vendor_dependencies/golden/Makefile
@@ -156,7 +156,7 @@ collector-module-list: ocb-generate
 
 # Delete any existing built collector binary.
 .PHONY: clean-collector
-clean-collector: clean-build-dir
+clean-collector: clean-build-temp-dir
 	rm -f $(COLLECTOR_BINARY_NAME)
 
 .PHONY: clean-build-temp-dir

--- a/google-built-opentelemetry-collector/Makefile
+++ b/google-built-opentelemetry-collector/Makefile
@@ -157,7 +157,7 @@ collector-module-list: ocb-generate
 
 # Delete any existing built collector binary.
 .PHONY: clean-collector
-clean-collector: clean-build-dir
+clean-collector: clean-build-temp-dir
 	rm -f $(COLLECTOR_BINARY_NAME)
 
 .PHONY: clean-build-temp-dir

--- a/otelopscol/Makefile
+++ b/otelopscol/Makefile
@@ -154,7 +154,7 @@ collector-module-list: ocb-generate
 
 # Delete any existing built collector binary.
 .PHONY: clean-collector
-clean-collector: clean-build-dir
+clean-collector: clean-build-temp-dir
 	rm -f $(COLLECTOR_BINARY_NAME)
 
 .PHONY: clean-build-temp-dir


### PR DESCRIPTION
Recently, in PR #543 (specifically in this change: https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/pull/543/changes#diff-4cfc8a8f61702232df601f8da8e46adcfaa02f6dd86d1da5ab4a6101f99d15cfL155-L156), the `clean-build-dir` target in the distribution Makefile template was renamed to `clean-build-temp-dir`, but the `clean-collector target`'s dependency on `clean-build-dir` was not updated. This caused running `make clean` to fail.

This commit fixes this by updating the template to `make clean-collector` depend on `clean-build-temp-dir`. All generated Makefiles and golden tests have been regenerated.