### PR TITLE
distrogen: Add build-win target to Makefile template

### DIFF
--- a/cmd/distrogen/templates/distribution/Makefile.go.tmpl
+++ b/cmd/distrogen/templates/distribution/Makefile.go.tmpl
@@ -7,6 +7,7 @@ VERSION = {{ .Version }}
 OTEL_VERSION = {{ .OpenTelemetryVersion }}
 OTEL_VERSION_TAG = v$(OTEL_VERSION)
 COLLECTOR_BINARY_NAME = {{ .BinaryName }}
+COLLECTOR_BINARY_NAME_EXE = $(COLLECTOR_BINARY_NAME).exe
 COLLECTOR_BUILD_TEMP_DIR = $(PWD)/{{ .Constants.TempOCBDirname }}
 COLLECTOR_BUILD_DIR = $(PWD)/{{ .OCBOutputDir }}
 COLLECTOR_CGO = {{ if .CollectorCGO }}1{{else}}0{{end}}
@@ -40,6 +41,9 @@ SET_COSIGN_BIN_PATH ?= PATH="$(TOOLS_DIR):$$PATH"
 
 .PHONY: build
 build: $(COLLECTOR_BINARY_NAME)
+
+.PHONY: build-win
+build-win: $(COLLECTOR_BINARY_NAME_EXE)
 
 .PHONY: image
 image: image-build image-push
@@ -156,6 +160,20 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 			.
 	$(MAKE) clean-build-temp-dir
 
+# Build a Windows collector binary.
+# Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
+$(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
+	cd $(COLLECTOR_BUILD_DIR) && \
+		GOWORK=off \
+		CGO_ENABLED=0 \
+		GOOS=windows GOARCH=$(TARGETARCH) \
+		$(GO_BIN) build \
+			-buildvcs=$(COLLECTOR_BUILDVCS) \
+			-tags=$(COLLECTOR_BUILD_TAGS) \
+			-o ../{{ .BinaryName }}.exe \
+			.
+	$(MAKE) clean-build-temp-dir
+
 .PHONY: collector-module-list
 collector-module-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
@@ -166,7 +184,7 @@ collector-module-list: ocb-generate
 # Delete any existing built collector binary.
 .PHONY: clean-collector
 clean-collector: clean-build-temp-dir
-	rm -f $(COLLECTOR_BINARY_NAME)
+	rm -f $(COLLECTOR_BINARY_NAME) $(COLLECTOR_BINARY_NAME_EXE)
 
 .PHONY: clean-build-temp-dir
 clean-build-temp-dir:

--- a/cmd/distrogen/testdata/generator/distribution/basic/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/basic/golden/Makefile
@@ -7,6 +7,7 @@ VERSION = 0.121.0
 OTEL_VERSION = 0.121.0
 OTEL_VERSION_TAG = v$(OTEL_VERSION)
 COLLECTOR_BINARY_NAME = otelcol-basic
+COLLECTOR_BINARY_NAME_EXE = $(COLLECTOR_BINARY_NAME).exe
 COLLECTOR_BUILD_TEMP_DIR = $(PWD)/_build
 COLLECTOR_BUILD_DIR = $(PWD)/_build
 COLLECTOR_CGO = 0
@@ -38,6 +39,9 @@ SET_COSIGN_BIN_PATH ?= PATH="$(TOOLS_DIR):$$PATH"
 
 .PHONY: build
 build: $(COLLECTOR_BINARY_NAME)
+
+.PHONY: build-win
+build-win: $(COLLECTOR_BINARY_NAME_EXE)
 
 .PHONY: image
 image: image-build image-push
@@ -146,6 +150,20 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 			.
 	$(MAKE) clean-build-temp-dir
 
+# Build a Windows collector binary.
+# Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
+$(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
+	cd $(COLLECTOR_BUILD_DIR) && \
+		GOWORK=off \
+		CGO_ENABLED=0 \
+		GOOS=windows GOARCH=$(TARGETARCH) \
+		$(GO_BIN) build \
+			-buildvcs=$(COLLECTOR_BUILDVCS) \
+			-tags=$(COLLECTOR_BUILD_TAGS) \
+			-o ../otelcol-basic.exe \
+			.
+	$(MAKE) clean-build-temp-dir
+
 .PHONY: collector-module-list
 collector-module-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
@@ -156,7 +174,7 @@ collector-module-list: ocb-generate
 # Delete any existing built collector binary.
 .PHONY: clean-collector
 clean-collector: clean-build-temp-dir
-	rm -f $(COLLECTOR_BINARY_NAME)
+	rm -f $(COLLECTOR_BINARY_NAME) $(COLLECTOR_BINARY_NAME_EXE)
 
 .PHONY: clean-build-temp-dir
 clean-build-temp-dir:

--- a/cmd/distrogen/testdata/generator/distribution/boringcrypto/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/boringcrypto/golden/Makefile
@@ -7,6 +7,7 @@ VERSION = 0.121.0
 OTEL_VERSION = 0.121.0
 OTEL_VERSION_TAG = v$(OTEL_VERSION)
 COLLECTOR_BINARY_NAME = otelcol-basic
+COLLECTOR_BINARY_NAME_EXE = $(COLLECTOR_BINARY_NAME).exe
 COLLECTOR_BUILD_TEMP_DIR = $(PWD)/_build
 COLLECTOR_BUILD_DIR = $(PWD)/_build
 COLLECTOR_CGO = 1
@@ -38,6 +39,9 @@ SET_COSIGN_BIN_PATH ?= PATH="$(TOOLS_DIR):$$PATH"
 
 .PHONY: build
 build: $(COLLECTOR_BINARY_NAME)
+
+.PHONY: build-win
+build-win: $(COLLECTOR_BINARY_NAME_EXE)
 
 .PHONY: image
 image: image-build image-push
@@ -147,6 +151,20 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 			.
 	$(MAKE) clean-build-temp-dir
 
+# Build a Windows collector binary.
+# Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
+$(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
+	cd $(COLLECTOR_BUILD_DIR) && \
+		GOWORK=off \
+		CGO_ENABLED=0 \
+		GOOS=windows GOARCH=$(TARGETARCH) \
+		$(GO_BIN) build \
+			-buildvcs=$(COLLECTOR_BUILDVCS) \
+			-tags=$(COLLECTOR_BUILD_TAGS) \
+			-o ../otelcol-basic.exe \
+			.
+	$(MAKE) clean-build-temp-dir
+
 .PHONY: collector-module-list
 collector-module-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
@@ -157,7 +175,7 @@ collector-module-list: ocb-generate
 # Delete any existing built collector binary.
 .PHONY: clean-collector
 clean-collector: clean-build-temp-dir
-	rm -f $(COLLECTOR_BINARY_NAME)
+	rm -f $(COLLECTOR_BINARY_NAME) $(COLLECTOR_BINARY_NAME_EXE)
 
 .PHONY: clean-build-temp-dir
 clean-build-temp-dir:

--- a/cmd/distrogen/testdata/generator/distribution/build_container/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/build_container/golden/Makefile
@@ -7,6 +7,7 @@ VERSION = 0.121.0
 OTEL_VERSION = 0.121.0
 OTEL_VERSION_TAG = v$(OTEL_VERSION)
 COLLECTOR_BINARY_NAME = otelcol-basic
+COLLECTOR_BINARY_NAME_EXE = $(COLLECTOR_BINARY_NAME).exe
 COLLECTOR_BUILD_TEMP_DIR = $(PWD)/_build
 COLLECTOR_BUILD_DIR = $(PWD)/_build
 COLLECTOR_CGO = 1
@@ -38,6 +39,9 @@ SET_COSIGN_BIN_PATH ?= PATH="$(TOOLS_DIR):$$PATH"
 
 .PHONY: build
 build: $(COLLECTOR_BINARY_NAME)
+
+.PHONY: build-win
+build-win: $(COLLECTOR_BINARY_NAME_EXE)
 
 .PHONY: image
 image: image-build image-push
@@ -146,6 +150,20 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 			.
 	$(MAKE) clean-build-temp-dir
 
+# Build a Windows collector binary.
+# Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
+$(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
+	cd $(COLLECTOR_BUILD_DIR) && \
+		GOWORK=off \
+		CGO_ENABLED=0 \
+		GOOS=windows GOARCH=$(TARGETARCH) \
+		$(GO_BIN) build \
+			-buildvcs=$(COLLECTOR_BUILDVCS) \
+			-tags=$(COLLECTOR_BUILD_TAGS) \
+			-o ../otelcol-basic.exe \
+			.
+	$(MAKE) clean-build-temp-dir
+
 .PHONY: collector-module-list
 collector-module-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
@@ -156,7 +174,7 @@ collector-module-list: ocb-generate
 # Delete any existing built collector binary.
 .PHONY: clean-collector
 clean-collector: clean-build-temp-dir
-	rm -f $(COLLECTOR_BINARY_NAME)
+	rm -f $(COLLECTOR_BINARY_NAME) $(COLLECTOR_BINARY_NAME_EXE)
 
 .PHONY: clean-build-temp-dir
 clean-build-temp-dir:

--- a/cmd/distrogen/testdata/generator/distribution/custom_templates_subdir/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/custom_templates_subdir/golden/Makefile
@@ -7,6 +7,7 @@ VERSION = 0.121.0
 OTEL_VERSION = 0.121.0
 OTEL_VERSION_TAG = v$(OTEL_VERSION)
 COLLECTOR_BINARY_NAME = otelcol-basic
+COLLECTOR_BINARY_NAME_EXE = $(COLLECTOR_BINARY_NAME).exe
 COLLECTOR_BUILD_TEMP_DIR = $(PWD)/_build
 COLLECTOR_BUILD_DIR = $(PWD)/_build
 COLLECTOR_CGO = 0
@@ -38,6 +39,9 @@ SET_COSIGN_BIN_PATH ?= PATH="$(TOOLS_DIR):$$PATH"
 
 .PHONY: build
 build: $(COLLECTOR_BINARY_NAME)
+
+.PHONY: build-win
+build-win: $(COLLECTOR_BINARY_NAME_EXE)
 
 .PHONY: image
 image: image-build image-push
@@ -146,6 +150,20 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 			.
 	$(MAKE) clean-build-temp-dir
 
+# Build a Windows collector binary.
+# Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
+$(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
+	cd $(COLLECTOR_BUILD_DIR) && \
+		GOWORK=off \
+		CGO_ENABLED=0 \
+		GOOS=windows GOARCH=$(TARGETARCH) \
+		$(GO_BIN) build \
+			-buildvcs=$(COLLECTOR_BUILDVCS) \
+			-tags=$(COLLECTOR_BUILD_TAGS) \
+			-o ../otelcol-basic.exe \
+			.
+	$(MAKE) clean-build-temp-dir
+
 .PHONY: collector-module-list
 collector-module-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
@@ -156,7 +174,7 @@ collector-module-list: ocb-generate
 # Delete any existing built collector binary.
 .PHONY: clean-collector
 clean-collector: clean-build-temp-dir
-	rm -f $(COLLECTOR_BINARY_NAME)
+	rm -f $(COLLECTOR_BINARY_NAME) $(COLLECTOR_BINARY_NAME_EXE)
 
 .PHONY: clean-build-temp-dir
 clean-build-temp-dir:

--- a/cmd/distrogen/testdata/generator/distribution/go_proxy/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/go_proxy/golden/Makefile
@@ -7,6 +7,7 @@ VERSION = 0.121.0
 OTEL_VERSION = 0.121.0
 OTEL_VERSION_TAG = v$(OTEL_VERSION)
 COLLECTOR_BINARY_NAME = otelcol-basic
+COLLECTOR_BINARY_NAME_EXE = $(COLLECTOR_BINARY_NAME).exe
 COLLECTOR_BUILD_TEMP_DIR = $(PWD)/_build
 COLLECTOR_BUILD_DIR = $(PWD)/_build
 COLLECTOR_CGO = 0
@@ -38,6 +39,9 @@ SET_COSIGN_BIN_PATH ?= PATH="$(TOOLS_DIR):$$PATH"
 
 .PHONY: build
 build: $(COLLECTOR_BINARY_NAME)
+
+.PHONY: build-win
+build-win: $(COLLECTOR_BINARY_NAME_EXE)
 
 .PHONY: image
 image: image-build image-push
@@ -146,6 +150,20 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 			.
 	$(MAKE) clean-build-temp-dir
 
+# Build a Windows collector binary.
+# Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
+$(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
+	cd $(COLLECTOR_BUILD_DIR) && \
+		GOWORK=off \
+		CGO_ENABLED=0 \
+		GOOS=windows GOARCH=$(TARGETARCH) \
+		$(GO_BIN) build \
+			-buildvcs=$(COLLECTOR_BUILDVCS) \
+			-tags=$(COLLECTOR_BUILD_TAGS) \
+			-o ../otelcol-basic.exe \
+			.
+	$(MAKE) clean-build-temp-dir
+
 .PHONY: collector-module-list
 collector-module-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
@@ -156,7 +174,7 @@ collector-module-list: ocb-generate
 # Delete any existing built collector binary.
 .PHONY: clean-collector
 clean-collector: clean-build-temp-dir
-	rm -f $(COLLECTOR_BINARY_NAME)
+	rm -f $(COLLECTOR_BINARY_NAME) $(COLLECTOR_BINARY_NAME_EXE)
 
 .PHONY: clean-build-temp-dir
 clean-build-temp-dir:

--- a/cmd/distrogen/testdata/generator/distribution/no_docker_repo/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/no_docker_repo/golden/Makefile
@@ -7,6 +7,7 @@ VERSION = 0.121.0
 OTEL_VERSION = 0.121.0
 OTEL_VERSION_TAG = v$(OTEL_VERSION)
 COLLECTOR_BINARY_NAME = otelcol-basic
+COLLECTOR_BINARY_NAME_EXE = $(COLLECTOR_BINARY_NAME).exe
 COLLECTOR_BUILD_TEMP_DIR = $(PWD)/_build
 COLLECTOR_BUILD_DIR = $(PWD)/_build
 COLLECTOR_CGO = 0
@@ -37,6 +38,9 @@ SET_COSIGN_BIN_PATH ?= PATH="$(TOOLS_DIR):$$PATH"
 
 .PHONY: build
 build: $(COLLECTOR_BINARY_NAME)
+
+.PHONY: build-win
+build-win: $(COLLECTOR_BINARY_NAME_EXE)
 
 .PHONY: image
 image: image-build image-push
@@ -145,6 +149,20 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 			.
 	$(MAKE) clean-build-temp-dir
 
+# Build a Windows collector binary.
+# Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
+$(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
+	cd $(COLLECTOR_BUILD_DIR) && \
+		GOWORK=off \
+		CGO_ENABLED=0 \
+		GOOS=windows GOARCH=$(TARGETARCH) \
+		$(GO_BIN) build \
+			-buildvcs=$(COLLECTOR_BUILDVCS) \
+			-tags=$(COLLECTOR_BUILD_TAGS) \
+			-o ../otelcol-basic.exe \
+			.
+	$(MAKE) clean-build-temp-dir
+
 .PHONY: collector-module-list
 collector-module-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
@@ -155,7 +173,7 @@ collector-module-list: ocb-generate
 # Delete any existing built collector binary.
 .PHONY: clean-collector
 clean-collector: clean-build-temp-dir
-	rm -f $(COLLECTOR_BINARY_NAME)
+	rm -f $(COLLECTOR_BINARY_NAME) $(COLLECTOR_BINARY_NAME_EXE)
 
 .PHONY: clean-build-temp-dir
 clean-build-temp-dir:

--- a/cmd/distrogen/testdata/generator/distribution/permanent_ocb_dir/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/permanent_ocb_dir/golden/Makefile
@@ -7,6 +7,7 @@ VERSION = 0.121.0
 OTEL_VERSION = 0.121.0
 OTEL_VERSION_TAG = v$(OTEL_VERSION)
 COLLECTOR_BINARY_NAME = otelcol-basic
+COLLECTOR_BINARY_NAME_EXE = $(COLLECTOR_BINARY_NAME).exe
 COLLECTOR_BUILD_TEMP_DIR = $(PWD)/_build
 COLLECTOR_BUILD_DIR = $(PWD)/generated_collector
 COLLECTOR_CGO = 0
@@ -37,6 +38,9 @@ SET_COSIGN_BIN_PATH ?= PATH="$(TOOLS_DIR):$$PATH"
 
 .PHONY: build
 build: $(COLLECTOR_BINARY_NAME)
+
+.PHONY: build-win
+build-win: $(COLLECTOR_BINARY_NAME_EXE)
 
 .PHONY: image
 image: image-build image-push
@@ -147,6 +151,20 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 			.
 	$(MAKE) clean-build-temp-dir
 
+# Build a Windows collector binary.
+# Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
+$(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
+	cd $(COLLECTOR_BUILD_DIR) && \
+		GOWORK=off \
+		CGO_ENABLED=0 \
+		GOOS=windows GOARCH=$(TARGETARCH) \
+		$(GO_BIN) build \
+			-buildvcs=$(COLLECTOR_BUILDVCS) \
+			-tags=$(COLLECTOR_BUILD_TAGS) \
+			-o ../otelcol-basic.exe \
+			.
+	$(MAKE) clean-build-temp-dir
+
 .PHONY: collector-module-list
 collector-module-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
@@ -157,7 +175,7 @@ collector-module-list: ocb-generate
 # Delete any existing built collector binary.
 .PHONY: clean-collector
 clean-collector: clean-build-temp-dir
-	rm -f $(COLLECTOR_BINARY_NAME)
+	rm -f $(COLLECTOR_BINARY_NAME) $(COLLECTOR_BINARY_NAME_EXE)
 
 .PHONY: clean-build-temp-dir
 clean-build-temp-dir:

--- a/cmd/distrogen/testdata/generator/distribution/vendor_dependencies/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/vendor_dependencies/golden/Makefile
@@ -7,6 +7,7 @@ VERSION = 0.121.0
 OTEL_VERSION = 0.121.0
 OTEL_VERSION_TAG = v$(OTEL_VERSION)
 COLLECTOR_BINARY_NAME = otelcol-basic
+COLLECTOR_BINARY_NAME_EXE = $(COLLECTOR_BINARY_NAME).exe
 COLLECTOR_BUILD_TEMP_DIR = $(PWD)/_build
 COLLECTOR_BUILD_DIR = $(PWD)/generated_collector
 COLLECTOR_CGO = 0
@@ -37,6 +38,9 @@ SET_COSIGN_BIN_PATH ?= PATH="$(TOOLS_DIR):$$PATH"
 
 .PHONY: build
 build: $(COLLECTOR_BINARY_NAME)
+
+.PHONY: build-win
+build-win: $(COLLECTOR_BINARY_NAME_EXE)
 
 .PHONY: image
 image: image-build image-push
@@ -147,6 +151,20 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 			.
 	$(MAKE) clean-build-temp-dir
 
+# Build a Windows collector binary.
+# Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
+$(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
+	cd $(COLLECTOR_BUILD_DIR) && \
+		GOWORK=off \
+		CGO_ENABLED=0 \
+		GOOS=windows GOARCH=$(TARGETARCH) \
+		$(GO_BIN) build \
+			-buildvcs=$(COLLECTOR_BUILDVCS) \
+			-tags=$(COLLECTOR_BUILD_TAGS) \
+			-o ../otelcol-basic.exe \
+			.
+	$(MAKE) clean-build-temp-dir
+
 .PHONY: collector-module-list
 collector-module-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
@@ -157,7 +175,7 @@ collector-module-list: ocb-generate
 # Delete any existing built collector binary.
 .PHONY: clean-collector
 clean-collector: clean-build-temp-dir
-	rm -f $(COLLECTOR_BINARY_NAME)
+	rm -f $(COLLECTOR_BINARY_NAME) $(COLLECTOR_BINARY_NAME_EXE)
 
 .PHONY: clean-build-temp-dir
 clean-build-temp-dir:

--- a/google-built-opentelemetry-collector/Makefile
+++ b/google-built-opentelemetry-collector/Makefile
@@ -7,6 +7,7 @@ VERSION = 0.151.0
 OTEL_VERSION = 0.151.0
 OTEL_VERSION_TAG = v$(OTEL_VERSION)
 COLLECTOR_BINARY_NAME = otelcol-google
+COLLECTOR_BINARY_NAME_EXE = $(COLLECTOR_BINARY_NAME).exe
 COLLECTOR_BUILD_TEMP_DIR = $(PWD)/_build
 COLLECTOR_BUILD_DIR = $(PWD)/generated_collector
 COLLECTOR_CGO = 1
@@ -37,6 +38,9 @@ SET_COSIGN_BIN_PATH ?= PATH="$(TOOLS_DIR):$$PATH"
 
 .PHONY: build
 build: $(COLLECTOR_BINARY_NAME)
+
+.PHONY: build-win
+build-win: $(COLLECTOR_BINARY_NAME_EXE)
 
 .PHONY: image
 image: image-build image-push
@@ -148,6 +152,20 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 			.
 	$(MAKE) clean-build-temp-dir
 
+# Build a Windows collector binary.
+# Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
+$(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
+	cd $(COLLECTOR_BUILD_DIR) && \
+		GOWORK=off \
+		CGO_ENABLED=0 \
+		GOOS=windows GOARCH=$(TARGETARCH) \
+		$(GO_BIN) build \
+			-buildvcs=$(COLLECTOR_BUILDVCS) \
+			-tags=$(COLLECTOR_BUILD_TAGS) \
+			-o ../otelcol-google.exe \
+			.
+	$(MAKE) clean-build-temp-dir
+
 .PHONY: collector-module-list
 collector-module-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
@@ -158,7 +176,7 @@ collector-module-list: ocb-generate
 # Delete any existing built collector binary.
 .PHONY: clean-collector
 clean-collector: clean-build-temp-dir
-	rm -f $(COLLECTOR_BINARY_NAME)
+	rm -f $(COLLECTOR_BINARY_NAME) $(COLLECTOR_BINARY_NAME_EXE)
 
 .PHONY: clean-build-temp-dir
 clean-build-temp-dir:

--- a/otelopscol/Makefile
+++ b/otelopscol/Makefile
@@ -7,6 +7,7 @@ VERSION = v0.151.0
 OTEL_VERSION = 0.151.0
 OTEL_VERSION_TAG = v$(OTEL_VERSION)
 COLLECTOR_BINARY_NAME = otelopscol
+COLLECTOR_BINARY_NAME_EXE = $(COLLECTOR_BINARY_NAME).exe
 COLLECTOR_BUILD_TEMP_DIR = $(PWD)/_build
 COLLECTOR_BUILD_DIR = $(PWD)/_build
 COLLECTOR_CGO = 1
@@ -37,6 +38,9 @@ SET_COSIGN_BIN_PATH ?= PATH="$(TOOLS_DIR):$$PATH"
 
 .PHONY: build
 build: $(COLLECTOR_BINARY_NAME)
+
+.PHONY: build-win
+build-win: $(COLLECTOR_BINARY_NAME_EXE)
 
 .PHONY: image
 image: image-build image-push
@@ -145,6 +149,20 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 			.
 	$(MAKE) clean-build-temp-dir
 
+# Build a Windows collector binary.
+# Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
+$(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
+	cd $(COLLECTOR_BUILD_DIR) && \
+		GOWORK=off \
+		CGO_ENABLED=0 \
+		GOOS=windows GOARCH=$(TARGETARCH) \
+		$(GO_BIN) build \
+			-buildvcs=$(COLLECTOR_BUILDVCS) \
+			-tags=$(COLLECTOR_BUILD_TAGS) \
+			-o ../otelopscol.exe \
+			.
+	$(MAKE) clean-build-temp-dir
+
 .PHONY: collector-module-list
 collector-module-list: ocb-generate
 	cd $(COLLECTOR_BUILD_TEMP_DIR) && \
@@ -155,7 +173,7 @@ collector-module-list: ocb-generate
 # Delete any existing built collector binary.
 .PHONY: clean-collector
 clean-collector: clean-build-temp-dir
-	rm -f $(COLLECTOR_BINARY_NAME)
+	rm -f $(COLLECTOR_BINARY_NAME) $(COLLECTOR_BINARY_NAME_EXE)
 
 .PHONY: clean-build-temp-dir
 clean-build-temp-dir:


### PR DESCRIPTION
This pull request adds support for building a Windows collector binary to the generated Makefile template in `distrogen`. 

Specifically, it introduces a new `build-win` target and a corresponding build rule for a Windows executable (`.exe`) with the following characteristics:
- Hardcodes `GOOS=windows` for the target operating system.
- Disables CGO (`CGO_ENABLED=0`).
- Excludes BoringCrypto configuration (BoringCrypto is not supported or required for the Windows target build).
- Excludes any `ldflags` arguments from the build command.
- Updates the `clean-collector` target to also clean up the `.exe` binary.
- Regenerates and updates the golden test files for all affected distribution test scenarios using `go test ./cmd/distrogen/... -update`.
