### PR TITLE
distrogen: Pass GOPROXY to binary compilation recipes in Makefile template

### DIFF
--- a/cmd/distrogen/distribution.go
+++ b/cmd/distrogen/distribution.go
@@ -39,7 +39,7 @@ const (
 )
 
 const (
-	tempOCBDirname = "_build"
+	tempOCBDirname      = "_build"
 	permanentOCBDirname = "generated_collector"
 )
 
@@ -163,8 +163,8 @@ func (s *DistributionSpec) Query(field string) (string, error) {
 }
 
 var (
-	ErrSpecValidationBoringCryptoWithoutCGO    = errors.New("boringcrypto build is not possible with collector_cgo turned off")
-	ErrSpecValidationBoringCryptoWithoutDebian = errors.New("boringcrypto is only possible with the debian build container")
+	ErrSpecValidationBoringCryptoWithoutCGO        = errors.New("boringcrypto build is not possible with collector_cgo turned off")
+	ErrSpecValidationBoringCryptoWithoutDebian     = errors.New("boringcrypto is only possible with the debian build container")
 	ErrSpecValidationVendorDepsWithoutPermanentOCB = errors.New("vendor_dependencies is only possible with permanent_ocb_directory set to true")
 )
 

--- a/cmd/distrogen/project.go
+++ b/cmd/distrogen/project.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	DistrogenMetadataDir = ".distrogen"
+	DistrogenMetadataDir   = ".distrogen"
 	DefaultProjectFileMode = fs.ModePerm
 )
 
@@ -34,7 +34,7 @@ type ProjectGenerator struct {
 	FileMode   fs.FileMode
 	CustomPath string
 
-	cleanTools bool
+	cleanTools   bool
 	generatePath string
 }
 

--- a/cmd/distrogen/templates/distribution/Makefile.go.tmpl
+++ b/cmd/distrogen/templates/distribution/Makefile.go.tmpl
@@ -146,7 +146,7 @@ COLLECTOR_LD_FLAGS_STATIC_LINK ?= {{ if .BoringCrypto }}-linkmode=external -extl
 # Using OCB and the local manifest file, build a collector.
 $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
+		GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),) \
 		{{ if .BoringCrypto -}}
 		GOEXPERIMENT=boringcrypto \
 		{{ end -}}
@@ -164,7 +164,7 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 # Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
 $(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
+		GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),) \
 		CGO_ENABLED=0 \
 		GOOS=windows GOARCH=$(TARGETARCH) \
 		$(GO_BIN) build \

--- a/cmd/distrogen/testdata/generator/distribution/basic/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/basic/golden/Makefile
@@ -139,7 +139,7 @@ COLLECTOR_LD_FLAGS_STATIC_LINK ?=
 # Using OCB and the local manifest file, build a collector.
 $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
+		GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),) \
 		CGO_ENABLED=$(COLLECTOR_CGO) \
 		GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) \
 		$(GO_BIN) build \
@@ -154,7 +154,7 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 # Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
 $(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
+		GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),) \
 		CGO_ENABLED=0 \
 		GOOS=windows GOARCH=$(TARGETARCH) \
 		$(GO_BIN) build \

--- a/cmd/distrogen/testdata/generator/distribution/boringcrypto/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/boringcrypto/golden/Makefile
@@ -139,7 +139,7 @@ COLLECTOR_LD_FLAGS_STATIC_LINK ?= -linkmode=external -extldflags=-static
 # Using OCB and the local manifest file, build a collector.
 $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
+		GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),) \
 		GOEXPERIMENT=boringcrypto \
 		CGO_ENABLED=$(COLLECTOR_CGO) \
 		GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) \
@@ -155,7 +155,7 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 # Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
 $(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
+		GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),) \
 		CGO_ENABLED=0 \
 		GOOS=windows GOARCH=$(TARGETARCH) \
 		$(GO_BIN) build \

--- a/cmd/distrogen/testdata/generator/distribution/build_container/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/build_container/golden/Makefile
@@ -139,7 +139,7 @@ COLLECTOR_LD_FLAGS_STATIC_LINK ?=
 # Using OCB and the local manifest file, build a collector.
 $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
+		GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),) \
 		CGO_ENABLED=$(COLLECTOR_CGO) \
 		GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) \
 		$(GO_BIN) build \
@@ -154,7 +154,7 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 # Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
 $(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
+		GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),) \
 		CGO_ENABLED=0 \
 		GOOS=windows GOARCH=$(TARGETARCH) \
 		$(GO_BIN) build \

--- a/cmd/distrogen/testdata/generator/distribution/custom_templates_subdir/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/custom_templates_subdir/golden/Makefile
@@ -139,7 +139,7 @@ COLLECTOR_LD_FLAGS_STATIC_LINK ?=
 # Using OCB and the local manifest file, build a collector.
 $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
+		GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),) \
 		CGO_ENABLED=$(COLLECTOR_CGO) \
 		GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) \
 		$(GO_BIN) build \
@@ -154,7 +154,7 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 # Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
 $(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
+		GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),) \
 		CGO_ENABLED=0 \
 		GOOS=windows GOARCH=$(TARGETARCH) \
 		$(GO_BIN) build \

--- a/cmd/distrogen/testdata/generator/distribution/go_proxy/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/go_proxy/golden/Makefile
@@ -139,7 +139,7 @@ COLLECTOR_LD_FLAGS_STATIC_LINK ?=
 # Using OCB and the local manifest file, build a collector.
 $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
+		GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),) \
 		CGO_ENABLED=$(COLLECTOR_CGO) \
 		GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) \
 		$(GO_BIN) build \
@@ -154,7 +154,7 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 # Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
 $(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
+		GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),) \
 		CGO_ENABLED=0 \
 		GOOS=windows GOARCH=$(TARGETARCH) \
 		$(GO_BIN) build \

--- a/cmd/distrogen/testdata/generator/distribution/no_docker_repo/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/no_docker_repo/golden/Makefile
@@ -138,7 +138,7 @@ COLLECTOR_LD_FLAGS_STATIC_LINK ?=
 # Using OCB and the local manifest file, build a collector.
 $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
+		GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),) \
 		CGO_ENABLED=$(COLLECTOR_CGO) \
 		GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) \
 		$(GO_BIN) build \
@@ -153,7 +153,7 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 # Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
 $(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
+		GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),) \
 		CGO_ENABLED=0 \
 		GOOS=windows GOARCH=$(TARGETARCH) \
 		$(GO_BIN) build \

--- a/cmd/distrogen/testdata/generator/distribution/permanent_ocb_dir/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/permanent_ocb_dir/golden/Makefile
@@ -140,7 +140,7 @@ COLLECTOR_LD_FLAGS_STATIC_LINK ?=
 # Using OCB and the local manifest file, build a collector.
 $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
+		GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),) \
 		CGO_ENABLED=$(COLLECTOR_CGO) \
 		GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) \
 		$(GO_BIN) build \
@@ -155,7 +155,7 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 # Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
 $(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
+		GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),) \
 		CGO_ENABLED=0 \
 		GOOS=windows GOARCH=$(TARGETARCH) \
 		$(GO_BIN) build \

--- a/cmd/distrogen/testdata/generator/distribution/vendor_dependencies/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/vendor_dependencies/golden/Makefile
@@ -140,7 +140,7 @@ COLLECTOR_LD_FLAGS_STATIC_LINK ?=
 # Using OCB and the local manifest file, build a collector.
 $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
+		GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),) \
 		CGO_ENABLED=$(COLLECTOR_CGO) \
 		GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) \
 		$(GO_BIN) build \
@@ -155,7 +155,7 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 # Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
 $(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
+		GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),) \
 		CGO_ENABLED=0 \
 		GOOS=windows GOARCH=$(TARGETARCH) \
 		$(GO_BIN) build \


### PR DESCRIPTION
In PR #543 ("Permanent OCB Directory"), compilation of binary distributions
was shifted to depend on the permanent generated directory instead of running
ocb-generate. When ocb-generate is skipped, the Go module cache inside
container builds is not pre-populated.

Because the Makefile compilation recipe invoked raw `go build` without
inheriting GOPROXY, container builds attempted to download missing modules
from public proxy.golang.org directly, failing with 403 Forbidden in Kokoro.

This commit explicitly adds GOPROXY assignment to the compilation step
so container builds properly inherit proxy settings from the environment.