### PR TITLE
distrogen: Add GO_COMMAND_ENV to all appropriate locations

### DIFF
--- a/cmd/distrogen/templates/distribution/Makefile.go.tmpl
+++ b/cmd/distrogen/templates/distribution/Makefile.go.tmpl
@@ -30,7 +30,7 @@ GO_VERSION = {{ .GoVersion }}
 GO_BIN_DIR ?= $(TOOLS_DIR)/go/bin
 GO_BIN ?= $(GO_BIN_DIR)/go
 SET_GO_BIN_PATH ?= PATH="$(GO_BIN_DIR):$$PATH"
-RUN_GO_COMMAND = $(SET_GO_BIN_PATH) GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),)
+GO_COMMAND_ENV = $(SET_GO_BIN_PATH) GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),)
 
 USE_GO_PROXY ?= {{ .GoProxy }}
 
@@ -136,8 +136,8 @@ update-ocb-directory: ocb-generate
 
 .PHONY: ocb-generate
 ocb-generate: $(OCB_BIN)
-	$(RUN_GO_COMMAND) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
-{{ if .VendorDependencies }}	cd $(COLLECTOR_BUILD_DIR) && $(RUN_GO_COMMAND) $(GO_BIN) mod tidy && $(RUN_GO_COMMAND) $(GO_BIN) mod vendor{{ end }}
+	$(GO_COMMAND_ENV) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
+{{ if .VendorDependencies }}	cd $(COLLECTOR_BUILD_DIR) && $(GO_COMMAND_ENV) $(GO_BIN) mod tidy && $(GO_COMMAND_ENV) $(GO_BIN) mod vendor{{ end }}
 
 COLLECTOR_LD_FLAGS ?=
 COLLECTOR_LD_FLAGS_STRIP ?= -s -w
@@ -146,13 +146,12 @@ COLLECTOR_LD_FLAGS_STATIC_LINK ?= {{ if .BoringCrypto }}-linkmode=external -extl
 # Using OCB and the local manifest file, build a collector.
 $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
 		{{ if .BoringCrypto -}}
 		GOEXPERIMENT=boringcrypto \
 		{{ end -}}
 		CGO_ENABLED=$(COLLECTOR_CGO) \
 		GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) \
-		$(GO_BIN) build \
+		$(GO_COMMAND_ENV) $(GO_BIN) build \
 			-buildvcs=$(COLLECTOR_BUILDVCS) \
 			-tags=$(COLLECTOR_BUILD_TAGS) \
 			-ldflags="$(COLLECTOR_LD_FLAGS_STRIP) $(COLLECTOR_LD_FLAGS_STATIC_LINK) $(COLLECTOR_LD_FLAGS)" \
@@ -164,10 +163,9 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 # Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
 $(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
 		CGO_ENABLED=0 \
 		GOOS=windows GOARCH=$(TARGETARCH) \
-		$(GO_BIN) build \
+		$(GO_COMMAND_ENV) $(GO_BIN) build \
 			-buildvcs=$(COLLECTOR_BUILDVCS) \
 			-tags=$(COLLECTOR_BUILD_TAGS) \
 			-o ../{{ .BinaryName }}.exe \

--- a/cmd/distrogen/testdata/generator/distribution/basic/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/basic/golden/Makefile
@@ -28,7 +28,7 @@ GO_VERSION = 1.24.0
 GO_BIN_DIR ?= $(TOOLS_DIR)/go/bin
 GO_BIN ?= $(GO_BIN_DIR)/go
 SET_GO_BIN_PATH ?= PATH="$(GO_BIN_DIR):$$PATH"
-RUN_GO_COMMAND = $(SET_GO_BIN_PATH) GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),)
+GO_COMMAND_ENV = $(SET_GO_BIN_PATH) GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),)
 
 USE_GO_PROXY ?= 
 
@@ -129,7 +129,7 @@ $(COLLECTOR_BUILD_DIR):
 
 .PHONY: ocb-generate
 ocb-generate: $(OCB_BIN)
-	$(RUN_GO_COMMAND) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
+	$(GO_COMMAND_ENV) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
 
 
 COLLECTOR_LD_FLAGS ?=
@@ -139,10 +139,9 @@ COLLECTOR_LD_FLAGS_STATIC_LINK ?=
 # Using OCB and the local manifest file, build a collector.
 $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
 		CGO_ENABLED=$(COLLECTOR_CGO) \
 		GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) \
-		$(GO_BIN) build \
+		$(GO_COMMAND_ENV) $(GO_BIN) build \
 			-buildvcs=$(COLLECTOR_BUILDVCS) \
 			-tags=$(COLLECTOR_BUILD_TAGS) \
 			-ldflags="$(COLLECTOR_LD_FLAGS_STRIP) $(COLLECTOR_LD_FLAGS_STATIC_LINK) $(COLLECTOR_LD_FLAGS)" \
@@ -154,10 +153,9 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 # Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
 $(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
 		CGO_ENABLED=0 \
 		GOOS=windows GOARCH=$(TARGETARCH) \
-		$(GO_BIN) build \
+		$(GO_COMMAND_ENV) $(GO_BIN) build \
 			-buildvcs=$(COLLECTOR_BUILDVCS) \
 			-tags=$(COLLECTOR_BUILD_TAGS) \
 			-o ../otelcol-basic.exe \

--- a/cmd/distrogen/testdata/generator/distribution/boringcrypto/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/boringcrypto/golden/Makefile
@@ -28,7 +28,7 @@ GO_VERSION = 1.24.0
 GO_BIN_DIR ?= $(TOOLS_DIR)/go/bin
 GO_BIN ?= $(GO_BIN_DIR)/go
 SET_GO_BIN_PATH ?= PATH="$(GO_BIN_DIR):$$PATH"
-RUN_GO_COMMAND = $(SET_GO_BIN_PATH) GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),)
+GO_COMMAND_ENV = $(SET_GO_BIN_PATH) GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),)
 
 USE_GO_PROXY ?= 
 
@@ -129,7 +129,7 @@ $(COLLECTOR_BUILD_DIR):
 
 .PHONY: ocb-generate
 ocb-generate: $(OCB_BIN)
-	$(RUN_GO_COMMAND) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
+	$(GO_COMMAND_ENV) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
 
 
 COLLECTOR_LD_FLAGS ?=
@@ -139,11 +139,10 @@ COLLECTOR_LD_FLAGS_STATIC_LINK ?= -linkmode=external -extldflags=-static
 # Using OCB and the local manifest file, build a collector.
 $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
 		GOEXPERIMENT=boringcrypto \
 		CGO_ENABLED=$(COLLECTOR_CGO) \
 		GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) \
-		$(GO_BIN) build \
+		$(GO_COMMAND_ENV) $(GO_BIN) build \
 			-buildvcs=$(COLLECTOR_BUILDVCS) \
 			-tags=$(COLLECTOR_BUILD_TAGS) \
 			-ldflags="$(COLLECTOR_LD_FLAGS_STRIP) $(COLLECTOR_LD_FLAGS_STATIC_LINK) $(COLLECTOR_LD_FLAGS)" \
@@ -155,10 +154,9 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 # Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
 $(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
 		CGO_ENABLED=0 \
 		GOOS=windows GOARCH=$(TARGETARCH) \
-		$(GO_BIN) build \
+		$(GO_COMMAND_ENV) $(GO_BIN) build \
 			-buildvcs=$(COLLECTOR_BUILDVCS) \
 			-tags=$(COLLECTOR_BUILD_TAGS) \
 			-o ../otelcol-basic.exe \

--- a/cmd/distrogen/testdata/generator/distribution/build_container/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/build_container/golden/Makefile
@@ -28,7 +28,7 @@ GO_VERSION = 1.24.0
 GO_BIN_DIR ?= $(TOOLS_DIR)/go/bin
 GO_BIN ?= $(GO_BIN_DIR)/go
 SET_GO_BIN_PATH ?= PATH="$(GO_BIN_DIR):$$PATH"
-RUN_GO_COMMAND = $(SET_GO_BIN_PATH) GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),)
+GO_COMMAND_ENV = $(SET_GO_BIN_PATH) GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),)
 
 USE_GO_PROXY ?= 
 
@@ -129,7 +129,7 @@ $(COLLECTOR_BUILD_DIR):
 
 .PHONY: ocb-generate
 ocb-generate: $(OCB_BIN)
-	$(RUN_GO_COMMAND) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
+	$(GO_COMMAND_ENV) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
 
 
 COLLECTOR_LD_FLAGS ?=
@@ -139,10 +139,9 @@ COLLECTOR_LD_FLAGS_STATIC_LINK ?=
 # Using OCB and the local manifest file, build a collector.
 $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
 		CGO_ENABLED=$(COLLECTOR_CGO) \
 		GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) \
-		$(GO_BIN) build \
+		$(GO_COMMAND_ENV) $(GO_BIN) build \
 			-buildvcs=$(COLLECTOR_BUILDVCS) \
 			-tags=$(COLLECTOR_BUILD_TAGS) \
 			-ldflags="$(COLLECTOR_LD_FLAGS_STRIP) $(COLLECTOR_LD_FLAGS_STATIC_LINK) $(COLLECTOR_LD_FLAGS)" \
@@ -154,10 +153,9 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 # Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
 $(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
 		CGO_ENABLED=0 \
 		GOOS=windows GOARCH=$(TARGETARCH) \
-		$(GO_BIN) build \
+		$(GO_COMMAND_ENV) $(GO_BIN) build \
 			-buildvcs=$(COLLECTOR_BUILDVCS) \
 			-tags=$(COLLECTOR_BUILD_TAGS) \
 			-o ../otelcol-basic.exe \

--- a/cmd/distrogen/testdata/generator/distribution/custom_templates_subdir/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/custom_templates_subdir/golden/Makefile
@@ -28,7 +28,7 @@ GO_VERSION = 1.24.0
 GO_BIN_DIR ?= $(TOOLS_DIR)/go/bin
 GO_BIN ?= $(GO_BIN_DIR)/go
 SET_GO_BIN_PATH ?= PATH="$(GO_BIN_DIR):$$PATH"
-RUN_GO_COMMAND = $(SET_GO_BIN_PATH) GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),)
+GO_COMMAND_ENV = $(SET_GO_BIN_PATH) GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),)
 
 USE_GO_PROXY ?= 
 
@@ -129,7 +129,7 @@ $(COLLECTOR_BUILD_DIR):
 
 .PHONY: ocb-generate
 ocb-generate: $(OCB_BIN)
-	$(RUN_GO_COMMAND) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
+	$(GO_COMMAND_ENV) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
 
 
 COLLECTOR_LD_FLAGS ?=
@@ -139,10 +139,9 @@ COLLECTOR_LD_FLAGS_STATIC_LINK ?=
 # Using OCB and the local manifest file, build a collector.
 $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
 		CGO_ENABLED=$(COLLECTOR_CGO) \
 		GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) \
-		$(GO_BIN) build \
+		$(GO_COMMAND_ENV) $(GO_BIN) build \
 			-buildvcs=$(COLLECTOR_BUILDVCS) \
 			-tags=$(COLLECTOR_BUILD_TAGS) \
 			-ldflags="$(COLLECTOR_LD_FLAGS_STRIP) $(COLLECTOR_LD_FLAGS_STATIC_LINK) $(COLLECTOR_LD_FLAGS)" \
@@ -154,10 +153,9 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 # Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
 $(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
 		CGO_ENABLED=0 \
 		GOOS=windows GOARCH=$(TARGETARCH) \
-		$(GO_BIN) build \
+		$(GO_COMMAND_ENV) $(GO_BIN) build \
 			-buildvcs=$(COLLECTOR_BUILDVCS) \
 			-tags=$(COLLECTOR_BUILD_TAGS) \
 			-o ../otelcol-basic.exe \

--- a/cmd/distrogen/testdata/generator/distribution/go_proxy/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/go_proxy/golden/Makefile
@@ -28,7 +28,7 @@ GO_VERSION = 1.24.0
 GO_BIN_DIR ?= $(TOOLS_DIR)/go/bin
 GO_BIN ?= $(GO_BIN_DIR)/go
 SET_GO_BIN_PATH ?= PATH="$(GO_BIN_DIR):$$PATH"
-RUN_GO_COMMAND = $(SET_GO_BIN_PATH) GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),)
+GO_COMMAND_ENV = $(SET_GO_BIN_PATH) GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),)
 
 USE_GO_PROXY ?= https://not-real.org,direct
 
@@ -129,7 +129,7 @@ $(COLLECTOR_BUILD_DIR):
 
 .PHONY: ocb-generate
 ocb-generate: $(OCB_BIN)
-	$(RUN_GO_COMMAND) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
+	$(GO_COMMAND_ENV) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
 
 
 COLLECTOR_LD_FLAGS ?=
@@ -139,10 +139,9 @@ COLLECTOR_LD_FLAGS_STATIC_LINK ?=
 # Using OCB and the local manifest file, build a collector.
 $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
 		CGO_ENABLED=$(COLLECTOR_CGO) \
 		GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) \
-		$(GO_BIN) build \
+		$(GO_COMMAND_ENV) $(GO_BIN) build \
 			-buildvcs=$(COLLECTOR_BUILDVCS) \
 			-tags=$(COLLECTOR_BUILD_TAGS) \
 			-ldflags="$(COLLECTOR_LD_FLAGS_STRIP) $(COLLECTOR_LD_FLAGS_STATIC_LINK) $(COLLECTOR_LD_FLAGS)" \
@@ -154,10 +153,9 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 # Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
 $(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
 		CGO_ENABLED=0 \
 		GOOS=windows GOARCH=$(TARGETARCH) \
-		$(GO_BIN) build \
+		$(GO_COMMAND_ENV) $(GO_BIN) build \
 			-buildvcs=$(COLLECTOR_BUILDVCS) \
 			-tags=$(COLLECTOR_BUILD_TAGS) \
 			-o ../otelcol-basic.exe \

--- a/cmd/distrogen/testdata/generator/distribution/no_docker_repo/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/no_docker_repo/golden/Makefile
@@ -27,7 +27,7 @@ GO_VERSION = 1.24.0
 GO_BIN_DIR ?= $(TOOLS_DIR)/go/bin
 GO_BIN ?= $(GO_BIN_DIR)/go
 SET_GO_BIN_PATH ?= PATH="$(GO_BIN_DIR):$$PATH"
-RUN_GO_COMMAND = $(SET_GO_BIN_PATH) GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),)
+GO_COMMAND_ENV = $(SET_GO_BIN_PATH) GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),)
 
 USE_GO_PROXY ?= 
 
@@ -128,7 +128,7 @@ $(COLLECTOR_BUILD_DIR):
 
 .PHONY: ocb-generate
 ocb-generate: $(OCB_BIN)
-	$(RUN_GO_COMMAND) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
+	$(GO_COMMAND_ENV) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
 
 
 COLLECTOR_LD_FLAGS ?=
@@ -138,10 +138,9 @@ COLLECTOR_LD_FLAGS_STATIC_LINK ?=
 # Using OCB and the local manifest file, build a collector.
 $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
 		CGO_ENABLED=$(COLLECTOR_CGO) \
 		GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) \
-		$(GO_BIN) build \
+		$(GO_COMMAND_ENV) $(GO_BIN) build \
 			-buildvcs=$(COLLECTOR_BUILDVCS) \
 			-tags=$(COLLECTOR_BUILD_TAGS) \
 			-ldflags="$(COLLECTOR_LD_FLAGS_STRIP) $(COLLECTOR_LD_FLAGS_STATIC_LINK) $(COLLECTOR_LD_FLAGS)" \
@@ -153,10 +152,9 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 # Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
 $(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
 		CGO_ENABLED=0 \
 		GOOS=windows GOARCH=$(TARGETARCH) \
-		$(GO_BIN) build \
+		$(GO_COMMAND_ENV) $(GO_BIN) build \
 			-buildvcs=$(COLLECTOR_BUILDVCS) \
 			-tags=$(COLLECTOR_BUILD_TAGS) \
 			-o ../otelcol-basic.exe \

--- a/cmd/distrogen/testdata/generator/distribution/permanent_ocb_dir/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/permanent_ocb_dir/golden/Makefile
@@ -27,7 +27,7 @@ GO_VERSION = 1.24.0
 GO_BIN_DIR ?= $(TOOLS_DIR)/go/bin
 GO_BIN ?= $(GO_BIN_DIR)/go
 SET_GO_BIN_PATH ?= PATH="$(GO_BIN_DIR):$$PATH"
-RUN_GO_COMMAND = $(SET_GO_BIN_PATH) GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),)
+GO_COMMAND_ENV = $(SET_GO_BIN_PATH) GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),)
 
 USE_GO_PROXY ?= 
 
@@ -130,7 +130,7 @@ update-ocb-directory: ocb-generate
 
 .PHONY: ocb-generate
 ocb-generate: $(OCB_BIN)
-	$(RUN_GO_COMMAND) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
+	$(GO_COMMAND_ENV) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
 
 
 COLLECTOR_LD_FLAGS ?=
@@ -140,10 +140,9 @@ COLLECTOR_LD_FLAGS_STATIC_LINK ?=
 # Using OCB and the local manifest file, build a collector.
 $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
 		CGO_ENABLED=$(COLLECTOR_CGO) \
 		GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) \
-		$(GO_BIN) build \
+		$(GO_COMMAND_ENV) $(GO_BIN) build \
 			-buildvcs=$(COLLECTOR_BUILDVCS) \
 			-tags=$(COLLECTOR_BUILD_TAGS) \
 			-ldflags="$(COLLECTOR_LD_FLAGS_STRIP) $(COLLECTOR_LD_FLAGS_STATIC_LINK) $(COLLECTOR_LD_FLAGS)" \
@@ -155,10 +154,9 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 # Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
 $(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
 		CGO_ENABLED=0 \
 		GOOS=windows GOARCH=$(TARGETARCH) \
-		$(GO_BIN) build \
+		$(GO_COMMAND_ENV) $(GO_BIN) build \
 			-buildvcs=$(COLLECTOR_BUILDVCS) \
 			-tags=$(COLLECTOR_BUILD_TAGS) \
 			-o ../otelcol-basic.exe \

--- a/cmd/distrogen/testdata/generator/distribution/vendor_dependencies/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/vendor_dependencies/golden/Makefile
@@ -27,7 +27,7 @@ GO_VERSION = 1.24.0
 GO_BIN_DIR ?= $(TOOLS_DIR)/go/bin
 GO_BIN ?= $(GO_BIN_DIR)/go
 SET_GO_BIN_PATH ?= PATH="$(GO_BIN_DIR):$$PATH"
-RUN_GO_COMMAND = $(SET_GO_BIN_PATH) GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),)
+GO_COMMAND_ENV = $(SET_GO_BIN_PATH) GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),)
 
 USE_GO_PROXY ?= 
 
@@ -130,8 +130,8 @@ update-ocb-directory: ocb-generate
 
 .PHONY: ocb-generate
 ocb-generate: $(OCB_BIN)
-	$(RUN_GO_COMMAND) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
-	cd $(COLLECTOR_BUILD_DIR) && $(RUN_GO_COMMAND) $(GO_BIN) mod tidy && $(RUN_GO_COMMAND) $(GO_BIN) mod vendor
+	$(GO_COMMAND_ENV) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
+	cd $(COLLECTOR_BUILD_DIR) && $(GO_COMMAND_ENV) $(GO_BIN) mod tidy && $(GO_COMMAND_ENV) $(GO_BIN) mod vendor
 
 COLLECTOR_LD_FLAGS ?=
 COLLECTOR_LD_FLAGS_STRIP ?= -s -w
@@ -140,10 +140,9 @@ COLLECTOR_LD_FLAGS_STATIC_LINK ?=
 # Using OCB and the local manifest file, build a collector.
 $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
 		CGO_ENABLED=$(COLLECTOR_CGO) \
 		GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) \
-		$(GO_BIN) build \
+		$(GO_COMMAND_ENV) $(GO_BIN) build \
 			-buildvcs=$(COLLECTOR_BUILDVCS) \
 			-tags=$(COLLECTOR_BUILD_TAGS) \
 			-ldflags="$(COLLECTOR_LD_FLAGS_STRIP) $(COLLECTOR_LD_FLAGS_STATIC_LINK) $(COLLECTOR_LD_FLAGS)" \
@@ -155,10 +154,9 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 # Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
 $(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
 		CGO_ENABLED=0 \
 		GOOS=windows GOARCH=$(TARGETARCH) \
-		$(GO_BIN) build \
+		$(GO_COMMAND_ENV) $(GO_BIN) build \
 			-buildvcs=$(COLLECTOR_BUILDVCS) \
 			-tags=$(COLLECTOR_BUILD_TAGS) \
 			-o ../otelcol-basic.exe \

--- a/google-built-opentelemetry-collector/Makefile
+++ b/google-built-opentelemetry-collector/Makefile
@@ -27,7 +27,7 @@ GO_VERSION = 1.26.2
 GO_BIN_DIR ?= $(TOOLS_DIR)/go/bin
 GO_BIN ?= $(GO_BIN_DIR)/go
 SET_GO_BIN_PATH ?= PATH="$(GO_BIN_DIR):$$PATH"
-RUN_GO_COMMAND = $(SET_GO_BIN_PATH) GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),)
+GO_COMMAND_ENV = $(SET_GO_BIN_PATH) GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),)
 
 USE_GO_PROXY ?= 
 
@@ -130,7 +130,7 @@ update-ocb-directory: ocb-generate
 
 .PHONY: ocb-generate
 ocb-generate: $(OCB_BIN)
-	$(RUN_GO_COMMAND) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
+	$(GO_COMMAND_ENV) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
 
 
 COLLECTOR_LD_FLAGS ?=
@@ -140,11 +140,10 @@ COLLECTOR_LD_FLAGS_STATIC_LINK ?= -linkmode=external -extldflags=-static
 # Using OCB and the local manifest file, build a collector.
 $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
 		GOEXPERIMENT=boringcrypto \
 		CGO_ENABLED=$(COLLECTOR_CGO) \
 		GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) \
-		$(GO_BIN) build \
+		$(GO_COMMAND_ENV) $(GO_BIN) build \
 			-buildvcs=$(COLLECTOR_BUILDVCS) \
 			-tags=$(COLLECTOR_BUILD_TAGS) \
 			-ldflags="$(COLLECTOR_LD_FLAGS_STRIP) $(COLLECTOR_LD_FLAGS_STATIC_LINK) $(COLLECTOR_LD_FLAGS)" \
@@ -156,10 +155,9 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 # Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
 $(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
 		CGO_ENABLED=0 \
 		GOOS=windows GOARCH=$(TARGETARCH) \
-		$(GO_BIN) build \
+		$(GO_COMMAND_ENV) $(GO_BIN) build \
 			-buildvcs=$(COLLECTOR_BUILDVCS) \
 			-tags=$(COLLECTOR_BUILD_TAGS) \
 			-o ../otelcol-google.exe \

--- a/otelopscol/Makefile
+++ b/otelopscol/Makefile
@@ -27,7 +27,7 @@ GO_VERSION = 1.26.1
 GO_BIN_DIR ?= $(TOOLS_DIR)/go/bin
 GO_BIN ?= $(GO_BIN_DIR)/go
 SET_GO_BIN_PATH ?= PATH="$(GO_BIN_DIR):$$PATH"
-RUN_GO_COMMAND = $(SET_GO_BIN_PATH) GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),)
+GO_COMMAND_ENV = $(SET_GO_BIN_PATH) GOWORK=off $(if $(USE_GO_PROXY),GOPROXY=$(USE_GO_PROXY),)
 
 USE_GO_PROXY ?= 
 
@@ -128,7 +128,7 @@ $(COLLECTOR_BUILD_DIR):
 
 .PHONY: ocb-generate
 ocb-generate: $(OCB_BIN)
-	$(RUN_GO_COMMAND) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
+	$(GO_COMMAND_ENV) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml
 
 
 COLLECTOR_LD_FLAGS ?=
@@ -138,10 +138,9 @@ COLLECTOR_LD_FLAGS_STATIC_LINK ?=
 # Using OCB and the local manifest file, build a collector.
 $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
 		CGO_ENABLED=$(COLLECTOR_CGO) \
 		GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) \
-		$(GO_BIN) build \
+		$(GO_COMMAND_ENV) $(GO_BIN) build \
 			-buildvcs=$(COLLECTOR_BUILDVCS) \
 			-tags=$(COLLECTOR_BUILD_TAGS) \
 			-ldflags="$(COLLECTOR_LD_FLAGS_STRIP) $(COLLECTOR_LD_FLAGS_STATIC_LINK) $(COLLECTOR_LD_FLAGS)" \
@@ -153,10 +152,9 @@ $(COLLECTOR_BINARY_NAME): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 # Note: distrogen currently does not support BoringCrypto and CGO for Windows builds.
 $(COLLECTOR_BINARY_NAME_EXE): $(COLLECTOR_BUILD_DIR) $(GO_BIN)
 	cd $(COLLECTOR_BUILD_DIR) && \
-		GOWORK=off \
 		CGO_ENABLED=0 \
 		GOOS=windows GOARCH=$(TARGETARCH) \
-		$(GO_BIN) build \
+		$(GO_COMMAND_ENV) $(GO_BIN) build \
 			-buildvcs=$(COLLECTOR_BUILDVCS) \
 			-tags=$(COLLECTOR_BUILD_TAGS) \
 			-o ../otelopscol.exe \


### PR DESCRIPTION
The Go proxy is no longer applied in the build after the refactor I did in the last PR to the Makefile template. This PR reapplies the necessary GO_PROXY variable within the build target.