### PR TITLE
distrogen: fix goreleaser for permanent_ocb_directory

### DIFF
--- a/cmd/distrogen/templates/distribution/.goreleaser.yaml.go.tmpl
+++ b/cmd/distrogen/templates/distribution/.goreleaser.yaml.go.tmpl
@@ -18,7 +18,7 @@ builds:
       - amd64
       - arm64
     binary: {{ .BinaryName }}
-    dir: _build
+    dir: {{ .OCBOutputDir }}
     ldflags:
       - "-s -w"
     flags:
@@ -31,7 +31,7 @@ builds:
     goarch:
       - amd64
     binary: {{ .BinaryName }}
-    dir: _build
+    dir: {{ .OCBOutputDir }}
     ldflags:
       - "-s -w"
     flags:

--- a/cmd/distrogen/testdata/generator/distribution/permanent_ocb_dir/golden/.goreleaser.yaml
+++ b/cmd/distrogen/testdata/generator/distribution/permanent_ocb_dir/golden/.goreleaser.yaml
@@ -18,7 +18,7 @@ builds:
       - amd64
       - arm64
     binary: otelcol-basic
-    dir: _build
+    dir: generated_collector
     ldflags:
       - "-s -w"
     flags:
@@ -31,7 +31,7 @@ builds:
     goarch:
       - amd64
     binary: otelcol-basic
-    dir: _build
+    dir: generated_collector
     ldflags:
       - "-s -w"
     flags:

--- a/cmd/distrogen/testdata/generator/distribution/vendor_dependencies/golden/.goreleaser.yaml
+++ b/cmd/distrogen/testdata/generator/distribution/vendor_dependencies/golden/.goreleaser.yaml
@@ -18,7 +18,7 @@ builds:
       - amd64
       - arm64
     binary: otelcol-basic
-    dir: _build
+    dir: generated_collector
     ldflags:
       - "-s -w"
     flags:
@@ -31,7 +31,7 @@ builds:
     goarch:
       - amd64
     binary: otelcol-basic
-    dir: _build
+    dir: generated_collector
     ldflags:
       - "-s -w"
     flags:

--- a/google-built-opentelemetry-collector/.goreleaser.yaml
+++ b/google-built-opentelemetry-collector/.goreleaser.yaml
@@ -18,7 +18,7 @@ builds:
       - amd64
       - arm64
     binary: otelcol-google
-    dir: _build
+    dir: generated_collector
     ldflags:
       - "-s -w"
     flags:
@@ -31,7 +31,7 @@ builds:
     goarch:
       - amd64
     binary: otelcol-google
-    dir: _build
+    dir: generated_collector
     ldflags:
       - "-s -w"
     flags:


### PR DESCRIPTION
I forgot that I also need to update the goreleaser template to use the `OCBOutputDir` template variable instead of the previously hardcoded `_build`.