### PR TITLE
fix: remove deprecated RHEL SAP HA images

### DIFF
--- a/distros.yaml
+++ b/distros.yaml
@@ -45,7 +45,6 @@ targets:
           - rocky-linux-cloud:rocky-linux-8
           exhaustive:
           - rhel-cloud:rhel-8
-          - rhel-sap-cloud:rhel-8-6-sap-ha
           - rhel-sap-cloud:rhel-8-8-sap-ha
           - rhel-sap-cloud:rhel-8-10-sap-ha
           - rocky-linux-cloud:rocky-linux-8-optimized-gcp


### PR DESCRIPTION
The RHEL SAP HA images rhel-8-6-sap-ha have been deprecated and removed from the rhel-sap-cloud project. 