### PR TITLE
Recognize AlmaLinux as RHEL

### DIFF
--- a/integration_test/gce-testing-internal/gce/gce_testing.go
+++ b/integration_test/gce-testing-internal/gce/gce_testing.go
@@ -1593,7 +1593,7 @@ func IsCentOS(imageSpec string) bool {
 }
 
 func IsRHEL(imageSpec string) bool {
-	return strings.HasPrefix(imageSpec, "rhel-")
+	return strings.HasPrefix(imageSpec, "rhel-") || strings.Contains(imageSpec, "almalinux-")
 }
 
 func isRHEL9(imageSpec string) bool {

--- a/integration_test/gce-testing-internal/gce/gce_testing.go
+++ b/integration_test/gce-testing-internal/gce/gce_testing.go
@@ -1593,11 +1593,11 @@ func IsCentOS(imageSpec string) bool {
 }
 
 func IsRHEL(imageSpec string) bool {
-	return strings.HasPrefix(imageSpec, "rhel-") || strings.Contains(imageSpec, "almalinux-")
+	return strings.HasPrefix(imageSpec, "rhel-")
 }
 
 func isRHEL9(imageSpec string) bool {
-	return strings.Contains(imageSpec, "rhel-9") || strings.Contains(imageSpec, "rocky-linux-9")
+	return strings.Contains(imageSpec, "rhel-9") || strings.Contains(imageSpec, "rocky-linux-9") || strings.Contains(imageSpec, "almalinux-9")
 }
 
 func isRHEL7SAPHA(imageSpec string) bool {
@@ -1609,7 +1609,7 @@ func IsDLVMImage(imageSpec string) bool {
 }
 
 func IsRocky(imageSpec string) bool {
-	return strings.Contains(imageSpec, "rocky-linux-")
+	return strings.Contains(imageSpec, "rocky-linux-") || strings.Contains(imageSpec, "almalinux-")
 }
 
 func IsRpm(imageSpec string) bool {

--- a/integration_test/smoke_test/smoke_test.go
+++ b/integration_test/smoke_test/smoke_test.go
@@ -166,6 +166,7 @@ func restartCommandForPlatform(platform string) string {
 func isRPMBased(imageSpec string) bool {
 	return strings.HasPrefix(imageSpec, "centos-cloud") ||
 		strings.HasPrefix(imageSpec, "rhel-") ||
+		strings.Contains(imageSpec, "almalinux-") ||
 		strings.HasPrefix(imageSpec, "rocky-linux-cloud") ||
 		strings.HasPrefix(imageSpec, "suse-cloud") ||
 		strings.HasPrefix(imageSpec, "suse-sap-cloud") ||


### PR DESCRIPTION
Updates isRPM and isRPMBased to correctly recognize AlmaLinux as an RPM-based OS instead of falling back to Debian/apt-get in tests.