### PR TITLE
fix(distrogen): preserve existing registry during project generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,17 +80,17 @@ GEN_GOOGLE_BUILT_OTEL=$(RUN_DISTROGEN) generate --spec ./specs/google-built-open
 .PHONY: gen-google-built-otel
 gen-google-built-otel:
 	@$(GEN_GOOGLE_BUILT_OTEL)
-	@cd google-built-opentelemetry-collector && $(MAKE) clean-tools && $(MAKE) update-ocb-directory
+	@cd google-built-opentelemetry-collector && $(MAKE) clean-tools && $(MAKE) ocb-generate
 
 .PHONY: regen-google-built-otel
 regen-google-built-otel:
 	@$(GEN_GOOGLE_BUILT_OTEL) --force
-	@cd google-built-opentelemetry-collector && $(MAKE) clean-tools && $(MAKE) update-ocb-directory
+	@cd google-built-opentelemetry-collector && $(MAKE) clean-tools && $(MAKE) ocb-generate
 
 .PHONY: regen-google-built-otel-v
 regen-google-built-otel-v:
 	@$(GEN_GOOGLE_BUILT_OTEL) --force -v
-	@cd google-built-opentelemetry-collector && $(MAKE) clean-tools && $(MAKE) update-ocb-directory
+	@cd google-built-opentelemetry-collector && $(MAKE) clean-tools && $(MAKE) ocb-generate
 
 .PHONY: compare-google-built-otel
 compare-google-built-otel:

--- a/cmd/distrogen/components_registry_generator.go
+++ b/cmd/distrogen/components_registry_generator.go
@@ -40,10 +40,17 @@ func NewComponentsRegistryGenerator() *ComponentsRegistryGenerator {
 // The component registry is for custom components built within this repository.
 // Upstream components are managed in the internal registry at cmd/distrogen/registry.yaml.
 func (g *ComponentsRegistryGenerator) Generate() error {
-	registry := NewRegistry()
-
 	generateComponentsPath := filepath.Join(g.Path, "components")
-	registry.Path = filepath.Join(generateComponentsPath, "registry.yaml")
+	registryPath := filepath.Join(generateComponentsPath, "registry.yaml")
+
+	registry, err := LoadRegistry(registryPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		registry = NewRegistry()
+		registry.Path = registryPath
+	}
 
 	var dirErrors []error
 	if err := os.MkdirAll(generateComponentsPath, g.FileMode); err != nil {

--- a/cmd/distrogen/registry_test.go
+++ b/cmd/distrogen/registry_test.go
@@ -389,3 +389,36 @@ func TestRegistryComponents_RenderOCBComponents(t *testing.T) {
 		})
 	}
 }
+
+func TestComponentsRegistryGenerator_PreservesExistingRegistry(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "registry-generator-test")
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		os.RemoveAll(tempDir)
+	})
+
+	componentsDir := filepath.Join(tempDir, "components")
+	err = os.MkdirAll(componentsDir, 0755)
+	assert.NilError(t, err)
+
+	// Create an existing registry with some components
+	existingRegistry := NewRegistry()
+	existingRegistry.Path = filepath.Join(componentsDir, "registry.yaml")
+	existingRegistry.Receivers["customreceiver"] = &RegistryComponent{
+		GoMod: &GoModuleID{URL: "github.com/custom/receiver", Tag: "v1.0.0"},
+	}
+	err = existingRegistry.Save()
+	assert.NilError(t, err)
+
+	// Run generator
+	crg := NewComponentsRegistryGenerator()
+	crg.Path = tempDir
+	err = crg.Generate()
+	assert.NilError(t, err)
+
+	// Load the registry back and verify it still has the component
+	loadedRegistry, err := LoadRegistry(existingRegistry.Path)
+	assert.NilError(t, err)
+	assert.Assert(t, loadedRegistry.Receivers["customreceiver"] != nil, "Expected customreceiver to be preserved")
+	assert.Equal(t, loadedRegistry.Receivers["customreceiver"].GoMod.URL, "github.com/custom/receiver")
+}

--- a/cmd/distrogen/templates/distribution/Makefile.go.tmpl
+++ b/cmd/distrogen/templates/distribution/Makefile.go.tmpl
@@ -129,10 +129,6 @@ collector-build: clean-collector $(COLLECTOR_BINARY_NAME)
 $(COLLECTOR_BUILD_DIR):
 	$(MAKE) ocb-generate
 
-{{- if .PermanentOCBDirectory }}
-.PHONY: update-ocb-directory
-update-ocb-directory: ocb-generate
-{{- end }}
 
 .PHONY: ocb-generate
 ocb-generate: $(OCB_BIN)

--- a/cmd/distrogen/templates/project/Makefile.go.tmpl
+++ b/cmd/distrogen/templates/project/Makefile.go.tmpl
@@ -69,16 +69,16 @@ GEN_OTEL = $(DISTROGEN_BIN) generate --spec $(SPEC_FILE) \
 .PHONY: gen
 gen: distrogen
 	@$(GEN_OTEL)
-{{ if .Spec.PermanentOCBDirectory }}	cd $(DISTRO_DIR) && make update-ocb-directory{{- end }}
+{{ if .Spec.PermanentOCBDirectory }}	cd $(DISTRO_DIR) && make ocb-generate{{- end }}
 
 .PHONY: regen
 regen: distrogen
 	@$(GEN_OTEL) --force
-{{ if .Spec.PermanentOCBDirectory }}	cd $(DISTRO_DIR) && make update-ocb-directory{{- end }}
+{{ if .Spec.PermanentOCBDirectory }}	cd $(DISTRO_DIR) && make ocb-generate{{- end }}
 
 regen-v: distrogen
 	@$(GEN_OTEL) --force -v
-{{ if .Spec.PermanentOCBDirectory }}	cd $(DISTRO_DIR) && make update-ocb-directory{{- end }}
+{{ if .Spec.PermanentOCBDirectory }}	cd $(DISTRO_DIR) && make ocb-generate{{- end }}
 
 ###########
 # Workspace

--- a/cmd/distrogen/testdata/generator/distribution/basic/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/basic/golden/Makefile
@@ -127,6 +127,7 @@ collector-build: clean-collector $(COLLECTOR_BINARY_NAME)
 $(COLLECTOR_BUILD_DIR):
 	$(MAKE) ocb-generate
 
+
 .PHONY: ocb-generate
 ocb-generate: $(OCB_BIN)
 	$(GO_COMMAND_ENV) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml

--- a/cmd/distrogen/testdata/generator/distribution/boringcrypto/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/boringcrypto/golden/Makefile
@@ -127,6 +127,7 @@ collector-build: clean-collector $(COLLECTOR_BINARY_NAME)
 $(COLLECTOR_BUILD_DIR):
 	$(MAKE) ocb-generate
 
+
 .PHONY: ocb-generate
 ocb-generate: $(OCB_BIN)
 	$(GO_COMMAND_ENV) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml

--- a/cmd/distrogen/testdata/generator/distribution/build_container/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/build_container/golden/Makefile
@@ -127,6 +127,7 @@ collector-build: clean-collector $(COLLECTOR_BINARY_NAME)
 $(COLLECTOR_BUILD_DIR):
 	$(MAKE) ocb-generate
 
+
 .PHONY: ocb-generate
 ocb-generate: $(OCB_BIN)
 	$(GO_COMMAND_ENV) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml

--- a/cmd/distrogen/testdata/generator/distribution/custom_templates_subdir/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/custom_templates_subdir/golden/Makefile
@@ -127,6 +127,7 @@ collector-build: clean-collector $(COLLECTOR_BINARY_NAME)
 $(COLLECTOR_BUILD_DIR):
 	$(MAKE) ocb-generate
 
+
 .PHONY: ocb-generate
 ocb-generate: $(OCB_BIN)
 	$(GO_COMMAND_ENV) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml

--- a/cmd/distrogen/testdata/generator/distribution/go_proxy/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/go_proxy/golden/Makefile
@@ -127,6 +127,7 @@ collector-build: clean-collector $(COLLECTOR_BINARY_NAME)
 $(COLLECTOR_BUILD_DIR):
 	$(MAKE) ocb-generate
 
+
 .PHONY: ocb-generate
 ocb-generate: $(OCB_BIN)
 	$(GO_COMMAND_ENV) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml

--- a/cmd/distrogen/testdata/generator/distribution/no_docker_repo/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/no_docker_repo/golden/Makefile
@@ -126,6 +126,7 @@ collector-build: clean-collector $(COLLECTOR_BINARY_NAME)
 $(COLLECTOR_BUILD_DIR):
 	$(MAKE) ocb-generate
 
+
 .PHONY: ocb-generate
 ocb-generate: $(OCB_BIN)
 	$(GO_COMMAND_ENV) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml

--- a/cmd/distrogen/testdata/generator/distribution/permanent_ocb_dir/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/permanent_ocb_dir/golden/Makefile
@@ -125,8 +125,7 @@ collector-build: clean-collector $(COLLECTOR_BINARY_NAME)
 # since the collector build target will always clean up the _build directory.
 $(COLLECTOR_BUILD_DIR):
 	$(MAKE) ocb-generate
-.PHONY: update-ocb-directory
-update-ocb-directory: ocb-generate
+
 
 .PHONY: ocb-generate
 ocb-generate: $(OCB_BIN)

--- a/cmd/distrogen/testdata/generator/distribution/vendor_dependencies/golden/Makefile
+++ b/cmd/distrogen/testdata/generator/distribution/vendor_dependencies/golden/Makefile
@@ -125,8 +125,7 @@ collector-build: clean-collector $(COLLECTOR_BINARY_NAME)
 # since the collector build target will always clean up the _build directory.
 $(COLLECTOR_BUILD_DIR):
 	$(MAKE) ocb-generate
-.PHONY: update-ocb-directory
-update-ocb-directory: ocb-generate
+
 
 .PHONY: ocb-generate
 ocb-generate: $(OCB_BIN)

--- a/google-built-opentelemetry-collector/Makefile
+++ b/google-built-opentelemetry-collector/Makefile
@@ -125,8 +125,7 @@ collector-build: clean-collector $(COLLECTOR_BINARY_NAME)
 # since the collector build target will always clean up the _build directory.
 $(COLLECTOR_BUILD_DIR):
 	$(MAKE) ocb-generate
-.PHONY: update-ocb-directory
-update-ocb-directory: ocb-generate
+
 
 .PHONY: ocb-generate
 ocb-generate: $(OCB_BIN)

--- a/otelopscol/Makefile
+++ b/otelopscol/Makefile
@@ -126,6 +126,7 @@ collector-build: clean-collector $(COLLECTOR_BINARY_NAME)
 $(COLLECTOR_BUILD_DIR):
 	$(MAKE) ocb-generate
 
+
 .PHONY: ocb-generate
 ocb-generate: $(OCB_BIN)
 	$(GO_COMMAND_ENV) $(OCB_BIN) --skip-compilation --verbose --config manifest.yaml


### PR DESCRIPTION
This PR resolves two issues in `distrogen`:
1. Fixes a bug where generating a project or registry would overwrite and wipe the existing `components/registry.yaml` file. The generator now loads and preserves the existing registry if it exists.
2. Replaces the obsolete `update-ocb-directory` make target with `ocb-generate` in the project and distribution templates, and updates the relevant golden tests.
