### PR TITLE
Fix gcloud execution env loss and add quiet flag to delete

### DIFF
--- a/integration_test/gce-testing-internal/gce/gce_testing.go
+++ b/integration_test/gce-testing-internal/gce/gce_testing.go
@@ -752,11 +752,10 @@ func runCommand(ctx context.Context, logger *log.Logger, stdin io.Reader, args [
 	cmd.Stdout = io.MultiWriter(&stdoutBuilder, interleavedWriter)
 	cmd.Stderr = io.MultiWriter(&stderrBuilder, interleavedWriter)
 	if len(env) > 0 {
-		environment := []string{}
+		cmd.Env = os.Environ()
 		for k, v := range env {
-			environment = append(environment, fmt.Sprintf("%s=%s", k, v))
+			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
 		}
-		cmd.Env = environment
 	}
 
 	err := cmd.Run()
@@ -1838,6 +1837,7 @@ func DeleteInstance(ctx context.Context, logger *log.Logger, vm *VM) error {
 				"--project=" + vm.Project,
 				"--zone=" + vm.Zone,
 				vm.Name,
+				"--quiet",
 			})
 		return handleDeleteError(err, attempt)
 	}
@@ -1873,6 +1873,7 @@ func DeleteManagedInstanceGroupVM(ctx context.Context, logger *log.Logger, migVM
 				"compute", "instance-groups", "managed", "delete", migVM.ManagedInstanceGroupName(),
 				"--project=" + migVM.Project,
 				"--zone=" + migVM.Zone,
+				"--quiet",
 			})
 		if err == nil {
 			return nil
@@ -1891,6 +1892,7 @@ func DeleteManagedInstanceGroupVM(ctx context.Context, logger *log.Logger, migVM
 			[]string{
 				"compute", "instance-templates", "delete", migVM.InstanceTemplateName(),
 				"--project=" + migVM.Project,
+				"--quiet",
 			})
 		return handleDeleteError(err, attempt)
 	}

--- a/integration_test/gce-testing-internal/gce/gce_testing_test.go
+++ b/integration_test/gce-testing-internal/gce/gce_testing_test.go
@@ -484,6 +484,46 @@ func TestUploadContent(t *testing.T) {
 	})
 }
 
+func TestRunCommandEnvMerging(t *testing.T) {
+	// Set a unique environment variable
+	testKey := "TEST_ENV_VAR_FOR_GCE_TESTING"
+	testVal := "unique_value_12345"
+	t.Setenv(testKey, testVal)
+
+	// Set gcloudPath to "env" to print environment
+	gce.SetGcloudPath("env")
+	defer func() {
+		// Restore gcloudPath
+		if path := os.Getenv("GCLOUD_BIN"); path != "" {
+			gce.SetGcloudPath(path)
+		} else {
+			gce.SetGcloudPath("gcloud")
+		}
+	}()
+
+	// Create a context with a config dir to trigger env merging
+	ctx := context.Background()
+	ctx = gce.WithGcloudConfigDir(ctx, "/tmp/mock-config-dir")
+
+	// Run "gcloud" (which is now "env")
+	output, err := gce.RunGcloud(ctx, log.New(io.Discard, "", 0), "", nil)
+	if err != nil {
+		t.Fatalf("RunGcloud failed: %v", err)
+	}
+
+	// Check if our test variable is in the output
+	expectedLine := fmt.Sprintf("%s=%s", testKey, testVal)
+	if !strings.Contains(output.Stdout, expectedLine) {
+		t.Errorf("Expected environment to contain %q, but it was not found. Output:\n%s", expectedLine, output.Stdout)
+	}
+
+	// Also check if CLOUDSDK_CONFIG is present and has the correct value
+	expectedConfigLine := "CLOUDSDK_CONFIG=/tmp/mock-config-dir"
+	if !strings.Contains(output.Stdout, expectedConfigLine) {
+		t.Errorf("Expected environment to contain %q, but it was not found. Output:\n%s", expectedConfigLine, output.Stdout)
+	}
+}
+
 func TestMain(m *testing.M) {
 	code := m.Run()
 	gce.CleanupKeysOrDie()


### PR DESCRIPTION
This PR fixes a side-effect introduced in the previous gcloud deletion fix, where VM cleanup commands would hang on confirmation prompts in non-interactive environments (CI).

Problem
In the previous fix, we passed custom environment variables (like CLOUDSDK_CONFIG) to gcloud commands. However, the runCommand helper was completely overriding the command's environment (cmd.Env) with only the custom variables, discarding the parent process's environment.

This caused the loss of CLOUDSDK_CORE_DISABLE_PROMPTS=1 (and other variables like PATH) in the CI environment, leading to gcloud compute instances delete prompting for confirmation and hanging until timeout.

Solution
Environment Merging: Updated runCommand in gce_testing.go to merge custom environment variables with os.Environ() instead of completely replacing it.
Explicit Quiet Flag: Added --quiet explicitly to the delete commands in DeleteInstance and DeleteManagedInstanceGroupVM as a robust backup to ensure non-interactive execution regardless of environment variables.
Unit Test: Added TestRunCommandEnvMerging in gce_testing_test.go to verify that environment variables are correctly merged and parent environment variables are not lost.