### PR TITLE
Initialize default metrics config in varnishreceiver factory

### DIFF
--- a/components/otelopscol/receiver/varnishreceiver/factory.go
+++ b/components/otelopscol/receiver/varnishreceiver/factory.go
@@ -40,6 +40,7 @@ func createDefaultConfig() component.Config {
 		ControllerConfig: scraperhelper.ControllerConfig{
 			CollectionInterval: 1 * time.Minute,
 		},
+		Metrics: metadata.DefaultMetricsConfig(),
 	}
 }
 


### PR DESCRIPTION
This PR fixes a configuration validation error that occurs when starting the `varnish` receiver with a default configuration (e.g. when the `metrics` section is omitted from the receiver config).

### Problem
In the updated OTel version, `mdatagen` strictly validates that the `aggregation_strategy` for metrics is set. The Varnish receiver factory was not initializing the `Metrics` field in `createDefaultConfig()`, leaving the aggregation strategies as empty strings (`""`) and causing validation to fail with:
`invalid configuration: receivers::varnish/varnish::metrics::varnish.backend.connection.count: invalid aggregation strategy ""`

### Solution
Updated `createDefaultConfig()` in `components/otelopscol/receiver/varnishreceiver/factory.go` to use `metadata.DefaultMetricsConfig()`, which correctly sets the default aggregation strategies (matching the pattern used by other custom receivers like `mongodb` and `dcgm`).