### PR TITLE
googleservicecontrolexporter: fix flaky CI test

### DIFF
--- a/components/google-built-opentelemetry-collector/exporter/googleservicecontrolexporter/factory.go
+++ b/components/google-built-opentelemetry-collector/exporter/googleservicecontrolexporter/factory.go
@@ -28,6 +28,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"google.golang.org/api/impersonate"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/google"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/credentials/oauth"
@@ -45,6 +46,23 @@ var (
 	defaultTimeout  = 16 * time.Second
 	defaultEndpoint = "servicecontrol.googleapis.com:443"
 	clientProvider  = NewServiceControllerClient
+	getCredentials  = func(ctx context.Context, impersonateAccount string) (credentials.Bundle, error) {
+		if impersonateAccount != "" {
+			src, err := impersonate.CredentialsTokenSource(ctx,
+				impersonate.CredentialsConfig{
+					TargetPrincipal: impersonateAccount,
+					Scopes:          []string{"https://www.googleapis.com/auth/cloud-platform"},
+				})
+			if err != nil {
+				return nil, fmt.Errorf("failed to impersonate serviceAccount: %w", err)
+			}
+			return google.NewDefaultCredentialsWithOptions(
+				google.DefaultCredentialsOptions{
+					PerRPCCreds:     oauth.TokenSource{TokenSource: src},
+					ALTSPerRPCCreds: nil}), nil
+		}
+		return google.NewDefaultCredentials(), nil
+	}
 )
 
 func NewFactory() exporter.Factory {
@@ -142,22 +160,11 @@ func createClient(ctx context.Context, oCfg *Config, settings exporter.Settings)
 	if oCfg.UseInsecure {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	} else if useRawServiceControlClient {
-		var credentials = google.NewDefaultCredentials()
-		if oCfg.ImpersonateServiceAccount != "" {
-			src, err := impersonate.CredentialsTokenSource(ctx,
-				impersonate.CredentialsConfig{
-					TargetPrincipal: oCfg.ImpersonateServiceAccount,
-					Scopes:          []string{"https://www.googleapis.com/auth/cloud-platform"},
-				})
-			if err != nil {
-				return nil, fmt.Errorf("failed to impersonate serviceAccount: %w", err)
-			}
-			credentials = google.NewDefaultCredentialsWithOptions(
-				google.DefaultCredentialsOptions{
-					PerRPCCreds:     oauth.TokenSource{TokenSource: src},
-					ALTSPerRPCCreds: nil})
+		creds, err := getCredentials(ctx, oCfg.ImpersonateServiceAccount)
+		if err != nil {
+			return nil, err
 		}
-		opts = append(opts, grpc.WithCredentialsBundle(credentials))
+		opts = append(opts, grpc.WithCredentialsBundle(creds))
 	}
 
 	c, err := clientProvider(oCfg.ServiceControlEndpoint, useRawServiceControlClient, oCfg.UseInsecure, oCfg.EnableDebugHeaders, settings.Logger, opts...)

--- a/components/google-built-opentelemetry-collector/exporter/googleservicecontrolexporter/factory_test.go
+++ b/components/google-built-opentelemetry-collector/exporter/googleservicecontrolexporter/factory_test.go
@@ -33,6 +33,8 @@ import (
 	"go.opentelemetry.io/collector/otelcol/otelcoltest"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	grpcmd "google.golang.org/grpc/metadata"
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/google-built-opentelemetry-collector/exporter/googleservicecontrolexporter/internal/metadata"
@@ -429,5 +431,25 @@ func TestCreateClientUserAgent(t *testing.T) {
 				assert.Equal(t, expected, got[0], "user-agent header mismatch")
 			}
 		})
+	}
+}
+
+type mockBundle struct{}
+
+func (mockBundle) TransportCredentials() credentials.TransportCredentials {
+	return insecure.NewCredentials()
+}
+
+func (mockBundle) PerRPCCredentials() credentials.PerRPCCredentials {
+	return nil
+}
+
+func (b mockBundle) NewWithMode(mode string) (credentials.Bundle, error) {
+	return b, nil
+}
+
+func init() {
+	getCredentials = func(ctx context.Context, impersonateAccount string) (credentials.Bundle, error) {
+		return mockBundle{}, nil
 	}
 }


### PR DESCRIPTION
[This recently flaky test](https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/actions/runs/28467756544/job/84371892093?pr=587) is caused by `google.NewDefaultCredentials()` which is called during exporter creation. In CI environments without local GCP credentials, this function attempts to check for the GCE metadata server. This check establishes a persistent HTTP connection cached in `http.DefaultTransport`'s connection pool. These idle connection goroutines remained alive at the end of the test run, causing goleak to fail.

This PR mocks the credential generation in unit tests:

* Wrapped GCP credentials initialization behind a package-level variable getCredentials in `factory.go`
* Overrode getCredentials in `factory_test.go`'s init() function with a mock bundle that uses insecure.NewCredentials() and does not hit the network.