### PR TITLE
samples/servicemetrics: Add `aggregation_type: sum` to docker_cpu_usage processor

### DIFF
--- a/samples/servicemetrics/docker_cpu_metrics.yaml
+++ b/samples/servicemetrics/docker_cpu_metrics.yaml
@@ -21,6 +21,7 @@ processors:
       match_type: regexp
       action: combine
       new_name: "saasmanagement.googleapis.com/instance/vm/container/cpu/usage_time_unscaled"
+      aggregation_type: sum
       operations:
       - action: update_label
         label: state


### PR DESCRIPTION
See #600 for details. This PR adds the missing `aggregation_type: sum` from the configuration.