### PR TITLE
[googleservicecontrolexporter] Fix health status reporting for permanent errors and retry loops

### DIFF
--- a/components/google-built-opentelemetry-collector/exporter/googleservicecontrolexporter/exporter.go
+++ b/components/google-built-opentelemetry-collector/exporter/googleservicecontrolexporter/exporter.go
@@ -211,11 +211,11 @@ func (e *Exporter) pushReportRequest(ctx context.Context, req *scpb.ReportReques
 	resp, err := e.client.Report(ctx, req)
 
 	if err != nil {
-		// ReportStatus tells health check that we had an error.
-		componentstatus.ReportStatus(e.host, componentstatus.NewRecoverableErrorEvent(err))
 		e.logFailedReportReq(req, err)
 
 		if shouldRetry(err) {
+			// ReportStatus tells health check that we had a retriable error.
+			componentstatus.ReportStatus(e.host, componentstatus.NewRecoverableErrorEvent(err))
 			if e.enableDebugHeaders {
 				// Get retriable error and enable debug header: Add encrypted debug header for 3 min
 				e.debugHeaderMutex.Lock()
@@ -226,6 +226,8 @@ func (e *Exporter) pushReportRequest(ctx context.Context, req *scpb.ReportReques
 			}
 			return err
 		}
+		// ReportStatus tells health check that we had a permanent error (e.g. PermissionDenied).
+		componentstatus.ReportStatus(e.host, componentstatus.NewPermanentErrorEvent(err))
 		// "Permanent" tells OTel retry machinery that request should not be retried.
 		return consumererror.NewPermanent(err)
 	}

--- a/components/google-built-opentelemetry-collector/exporter/googleservicecontrolexporter/exporter.go
+++ b/components/google-built-opentelemetry-collector/exporter/googleservicecontrolexporter/exporter.go
@@ -88,6 +88,9 @@ type Exporter struct {
 	debugHeaderMutex          sync.Mutex
 	debugHeaderExpirationTime time.Time
 	nowFunc                   func() time.Time
+
+	statusMu   sync.Mutex
+	lastStatus componentstatus.Status
 }
 
 // TODO(lujieduan): move MetricsExporter specific code to a separate file.
@@ -196,6 +199,15 @@ func (e *MetricsExporter) ConsumeMetrics(ctx context.Context, m pmetric.Metrics)
 	return e.pushReportRequest(ctx, req)
 }
 
+func (e *Exporter) reportStatus(ev *componentstatus.Event) {
+	e.statusMu.Lock()
+	defer e.statusMu.Unlock()
+	if e.lastStatus != ev.Status() {
+		e.lastStatus = ev.Status()
+		componentstatus.ReportStatus(e.host, ev)
+	}
+}
+
 func (e *Exporter) pushReportRequest(ctx context.Context, req *scpb.ReportRequest) error {
 	// Check if we need to add the debug encrypted header
 	if e.enableDebugHeaders {
@@ -215,7 +227,7 @@ func (e *Exporter) pushReportRequest(ctx context.Context, req *scpb.ReportReques
 
 		if shouldRetry(err) {
 			// ReportStatus tells health check that we had a retriable error.
-			componentstatus.ReportStatus(e.host, componentstatus.NewRecoverableErrorEvent(err))
+			e.reportStatus(componentstatus.NewRecoverableErrorEvent(err))
 			if e.enableDebugHeaders {
 				// Get retriable error and enable debug header: Add encrypted debug header for 3 min
 				e.debugHeaderMutex.Lock()
@@ -227,7 +239,7 @@ func (e *Exporter) pushReportRequest(ctx context.Context, req *scpb.ReportReques
 			return err
 		}
 		// ReportStatus tells health check that we had a permanent error (e.g. PermissionDenied).
-		componentstatus.ReportStatus(e.host, componentstatus.NewPermanentErrorEvent(err))
+		e.reportStatus(componentstatus.NewPermanentErrorEvent(err))
 		// "Permanent" tells OTel retry machinery that request should not be retried.
 		return consumererror.NewPermanent(err)
 	}
@@ -237,7 +249,7 @@ func (e *Exporter) pushReportRequest(ctx context.Context, req *scpb.ReportReques
 	}
 
 	// ReportStatus tells health check that everything is OK.
-	componentstatus.ReportStatus(e.host, componentstatus.NewEvent(componentstatus.StatusOK))
+	e.reportStatus(componentstatus.NewEvent(componentstatus.StatusOK))
 
 	return nil
 }

--- a/components/google-built-opentelemetry-collector/exporter/googleservicecontrolexporter/exporter_test.go
+++ b/components/google-built-opentelemetry-collector/exporter/googleservicecontrolexporter/exporter_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componentstatus"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/config/configretry"
@@ -1645,3 +1647,67 @@ var cleanOperation = cmp.Transformer("cleanOperation", func(op *scpb.Operation) 
 	tmp.EndTime = nil
 	return tmp
 })
+
+type fakeStatusReporterHost struct {
+	component.Host
+	events []*componentstatus.Event
+	mu     sync.Mutex
+}
+
+func (f *fakeStatusReporterHost) Report(e *componentstatus.Event) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.events = append(f.events, e)
+}
+
+func TestReportStatus_PermanentAndRecoverableErrors(t *testing.T) {
+	tests := []struct {
+		name           string
+		errFunc        func(context.Context) error
+		expectedStatus componentstatus.Status
+	}{
+		{
+			name: "recoverable error (unavailable)",
+			errFunc: func(context.Context) error {
+				return status.Error(codes.Unavailable, "service unavailable")
+			},
+			expectedStatus: componentstatus.StatusRecoverableError,
+		},
+		{
+			name: "permanent error (permission denied)",
+			errFunc: func(context.Context) error {
+				return status.Error(codes.PermissionDenied, "permission denied")
+			},
+			expectedStatus: componentstatus.StatusPermanentError,
+		},
+		{
+			name: "success",
+			errFunc: func(context.Context) error {
+				return nil
+			},
+			expectedStatus: componentstatus.StatusOK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			metrics := sampleMetricData(t)
+			c := newFakeClient(tc.errFunc)
+			cfg := Config{
+				ServiceName:     testServiceID,
+				ConsumerProject: testConsumerID,
+				ServiceConfigID: testServiceConfigID,
+			}
+			e := NewMetricsExporter(cfg, zap.NewNop(), c, componenttest.NewNopTelemetrySettings())
+			fakeHost := &fakeStatusReporterHost{Host: componenttest.NewNopHost()}
+			require.NoError(t, e.Start(context.Background(), fakeHost))
+
+			_ = e.ConsumeMetrics(context.Background(), metricDataToPmetric(metrics))
+
+			fakeHost.mu.Lock()
+			defer fakeHost.mu.Unlock()
+			require.Len(t, fakeHost.events, 1)
+			require.Equal(t, tc.expectedStatus, fakeHost.events[0].Status())
+		})
+	}
+}


### PR DESCRIPTION
### Summary
This PR fixes two issues in `googleservicecontrolexporter` status reporting (`componentstatus.ReportStatus`) that prevented `healthcheckv2` (`healthcheckv2extension`) from correctly identifying unhealthy collector states:
1. **Immediate reporting of non-retriable (`PermanentError`) failures:**
   When `e.client.Report()` encountered a non-retriable error (`!shouldRetry(err)`, such as `PermissionDenied` or `InvalidArgument`), the exporter previously emitted `componentstatus.NewRecoverableErrorEvent(err)` right before returning `consumererror.NewPermanent(err)`. Because `healthcheckv2` received a `StatusRecoverableError`, configuring `include_permanent_errors: true` did not immediately flag non-retriable authentication and IAM permission failures as unhealthy (`HTTP 500`).

2. **State-tracking (`e.lastStatus`) to prevent `recovery_duration` clock resets during retry loops:**
   When `exporterhelper` retries a batch (`ConsumeMetrics`), `pushReportRequest` runs on every retry execution (every ~1-2s). Previously, it emitted a brand-new `componentstatus.NewRecoverableErrorEvent(err)` (`time.Now()`) on every attempt. Because `healthcheckv2` checks `now.Before(ev.Timestamp().Add(recovery_duration))`, repeatedly emitting new events refreshed the timestamp on every tick, pushing `ev.Timestamp().Add(recovery_duration)` infinitely into the future and preventing retriable errors (`codes.Unavailable`) from ever transitioning to `HTTP 500`.

### Changes
- Track `lastStatus` (`componentstatus.Status`) and `statusMu` (`sync.Mutex`) on `Exporter`.
- Add `reportStatus(ev)` helper method to only call `componentstatus.ReportStatus(e.host, ev)` when `ev.Status() != e.lastStatus`.
- Emit `componentstatus.NewPermanentErrorEvent(err)` when `!shouldRetry(err)`.
- Emit `componentstatus.NewRecoverableErrorEvent(err)` when `shouldRetry(err)` (only on the initial state transition).
- Add unit test `TestReportStatus_PermanentAndRecoverableErrors` verifying exact event emission for `codes.PermissionDenied`, `codes.Unavailable`, and success.
### Testing
- **Unit Tests:** `go test -v ./...` in `googleservicecontrolexporter` passes cleanly (`TestReportStatus_PermanentAndRecoverableErrors`).
- **VM Verification:** Compiled `otelcol-google` and verified against `healthcheckv2` on a live GCE VM (`healthcheck-poc-vm`):
  - With `service_control_endpoint: 127.0.0.1:1` (`codes.Unavailable`) and `recovery_duration: 5s`, `/metrics?verbose` correctly returned `HTTP 200` at `t=2s` and cleanly transitioned to `HTTP 500 Internal Server Error` at `t=8s`.
  - With an invalid project / auth error (`codes.InvalidArgument`), `/metrics?verbose` immediately returned `HTTP 500 Internal Server Error` (`StatusPermanentError`).