### PR TITLE
Retry VM starts on GCE zone capacity stockouts and availability errors

### DIFF
--- a/integration_test/gce-testing-internal/gce/gce_testing.go
+++ b/integration_test/gce-testing-internal/gce/gce_testing.go
@@ -1916,6 +1916,21 @@ func StopInstance(ctx context.Context, logger *log.Logger, vm *VM) error {
 	return err
 }
 
+func shouldRetryStartVM(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Starting instances can hit CPU quota or IP address allocation errors.
+	return strings.Contains(err.Error(), "Quota") ||
+		// Instance starting can fail due to temporary zone hardware stockout (ZONE_RESOURCE_POOL_EXHAUSTED).
+		strings.Contains(err.Error(), "currently unavailable") ||
+		strings.Contains(err.Error(), "ZONE_RESOURCE_POOL_EXHAUSTED") ||
+		// Rarely, instance starting fails due to internal compute API errors.
+		strings.Contains(err.Error(), "Internal error") ||
+		// gcloud sqlite database lock contention under concurrency.
+		strings.Contains(err.Error(), "database is locked")
+}
+
 // StartInstance boots a previously-stopped VM instance.
 // Also waits for the instance to be started up.
 func StartInstance(ctx context.Context, logger *log.Logger, vm *VM) error {
@@ -1933,9 +1948,9 @@ func StartInstance(ctx context.Context, logger *log.Logger, vm *VM) error {
 				vm.Name,
 				"--format=json",
 			})
-		// Sometimes we see errors about running out of CPU quota or IP addresses,
+		// Sometimes we see errors about running out of CPU quota, zone stockouts, or IP addresses.
 		// Back off and retry in these cases, just like CreateInstance().
-		if err != nil && !strings.Contains(err.Error(), "Quota") {
+		if err != nil && !shouldRetryStartVM(err) {
 			err = backoff.Permanent(err)
 		}
 		// Returning a non-permanent error triggers retries.

--- a/integration_test/gce-testing-internal/gce/retry_start_test.go
+++ b/integration_test/gce-testing-internal/gce/retry_start_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gce
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestShouldRetryStartVM(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "quota error",
+			err:      errors.New("Quotas exceeded for cpu"),
+			expected: true,
+		},
+		{
+			name:     "currently unavailable stockout",
+			err:      errors.New("A t2a-standard-2 VM instance is currently unavailable in the us-central1-a zone"),
+			expected: true,
+		},
+		{
+			name:     "zone resource pool exhausted",
+			err:      errors.New("ERROR: (gcloud.compute.instances.start) --- code: ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS"),
+			expected: true,
+		},
+		{
+			name:     "internal error",
+			err:      errors.New("Internal error encountered while processing request"),
+			expected: true,
+		},
+		{
+			name:     "database is locked concurrency error",
+			err:      errors.New("sqlite3 error: database is locked"),
+			expected: true,
+		},
+		{
+			name:     "non-retryable error",
+			err:      errors.New("instance test-vm not found in zone us-central1-a"),
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := shouldRetryStartVM(tc.err)
+			if actual != tc.expected {
+				t.Errorf("shouldRetryStartVM(%v) = %v; want %v", tc.err, actual, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Matching the behavior on CreateInstance.
This will prevent some Arm tests from failing because of ZONE_RESOURCE_POOL_EXHAUSTED when restarting the VM