### PR TITLE
feat(distrogen): add Windows build templates to project generation

### DIFF
--- a/cmd/distrogen/templates/project/Dockerfile.windows.build.go.tmpl
+++ b/cmd/distrogen/templates/project/Dockerfile.windows.build.go.tmpl
@@ -1,0 +1,9 @@
+ARG WINDOWS_VERSION=2019
+ARG WINBASE=mcr.microsoft.com/windows/servercore:ltsc${WINDOWS_VERSION}
+FROM ${WINBASE} AS windows
+
+COPY {{ .Spec.BinaryName }}.exe /{{ .Spec.BinaryName }}.exe
+COPY config.yaml /etc/{{ .Spec.BinaryName }}/config.yaml
+
+ENTRYPOINT ["/{{ .Spec.BinaryName }}.exe"{{ $length := len .Spec.FeatureGates }}{{ if gt $length 0 }}, "--feature-gates={{ .Spec.FeatureGates.Render }}"{{ end }}]
+CMD ["--config=/etc/{{ .Spec.BinaryName }}/config.yaml"]

--- a/cmd/distrogen/templates/project/build.bat.go.tmpl
+++ b/cmd/distrogen/templates/project/build.bat.go.tmpl
@@ -1,0 +1,4 @@
+set PROJECT_DIR=%~dp0
+REM powershell's exit codes are apparently completely broken with -File
+powershell.exe -Command " & '%PROJECT_DIR%build.ps1'"
+exit %ERRORLEVEL%

--- a/cmd/distrogen/templates/project/build.ps1.go.tmpl
+++ b/cmd/distrogen/templates/project/build.ps1.go.tmpl
@@ -1,0 +1,69 @@
+$ErrorActionPreference = "Stop"
+
+if (-not $env:_WINDOWS_VERSION) {
+    Write-Error "_WINDOWS_VERSION environment variable is required but not set."
+    exit 1
+}
+
+# Determine the artifacts output directory relative to $env:KOKORO_ARTIFACTS_DIR
+$ArtifactsDir = if ($env:KOKORO_ARTIFACTS_DIR) { $env:KOKORO_ARTIFACTS_DIR } else { (Get-Item .).FullName }
+$TarDir = Join-Path $ArtifactsDir "container"
+$TarPath = Join-Path $TarDir "container.tar"
+
+Write-Host "Artifacts directory: $ArtifactsDir"
+Write-Host "Target tarball path: $TarPath"
+
+# Make sure the target directory exists
+if (-not (Test-Path $TarDir)) {
+    New-Item -ItemType Directory -Force -Path $TarDir
+}
+
+# Ensure the correct version of Go is installed
+$GoVersion = "{{ .Spec.GoVersion }}"
+$ToolsDir = Join-Path $PSScriptRoot ".tools"
+$GoDir = Join-Path $ToolsDir "go"
+$GoBinDir = Join-Path $GoDir "bin"
+$GoExePath = Join-Path $GoBinDir "go.exe"
+
+$GoUrl = "https://go.dev/dl/go$GoVersion.windows-amd64.zip"
+
+Write-Host "Downloading Go $GoVersion from $GoUrl..."
+curl.exe -L $GoUrl -o go.zip
+
+Write-Host "Extracting Go to $ToolsDir..."
+unzip.exe -q go.zip -d $ToolsDir
+Remove-Item -Force go.zip
+
+# Compile the Go binary on the host (inside the build environment)
+Write-Host "Compiling Go binary..."
+Set-Location $PSScriptRoot
+$env:PATH = "$GoBinDir;$env:PATH"
+$env:GOROOT = $GoDir
+
+# Format paths with forward slashes for maximum compatibility with make
+$NormalizedPwd = $PSScriptRoot.Replace("\", "/")
+
+& make PWD=$NormalizedPwd --trace TARGETOS=windows TARGETARCH=amd64 build-win
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Compilation failed with exit code $LASTEXITCODE"
+    exit $LASTEXITCODE
+}
+
+
+# Execute docker build inside the distribution directory
+Write-Host "Building Docker image..."
+docker build --build-arg WINDOWS_VERSION=$env:_WINDOWS_VERSION -f Dockerfile.windows.build -t {{ .Spec.BinaryName }}-windows:latest .
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Docker build failed with exit code $LASTEXITCODE"
+    exit $LASTEXITCODE
+}
+
+# Save the docker image as a tar archive
+Write-Host "Saving Docker image to $TarPath..."
+docker save {{ .Spec.BinaryName }}-windows:latest -o $TarPath
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Docker save failed with exit code $LASTEXITCODE"
+    exit $LASTEXITCODE
+}
+
+Write-Host "Windows container build complete."

--- a/cmd/distrogen/testdata/generator/project/basic/golden/Dockerfile.windows.build
+++ b/cmd/distrogen/testdata/generator/project/basic/golden/Dockerfile.windows.build
@@ -1,0 +1,9 @@
+ARG WINDOWS_VERSION=2019
+ARG WINBASE=mcr.microsoft.com/windows/servercore:ltsc${WINDOWS_VERSION}
+FROM ${WINBASE} AS windows
+
+COPY otelcol-basic.exe /otelcol-basic.exe
+COPY config.yaml /etc/otelcol-basic/config.yaml
+
+ENTRYPOINT ["/otelcol-basic.exe", "--feature-gates=exporter.googlemanagedprometheus.intToDouble"]
+CMD ["--config=/etc/otelcol-basic/config.yaml"]

--- a/cmd/distrogen/testdata/generator/project/basic/golden/build.bat
+++ b/cmd/distrogen/testdata/generator/project/basic/golden/build.bat
@@ -1,0 +1,4 @@
+set PROJECT_DIR=%~dp0
+REM powershell's exit codes are apparently completely broken with -File
+powershell.exe -Command " & '%PROJECT_DIR%build.ps1'"
+exit %ERRORLEVEL%

--- a/cmd/distrogen/testdata/generator/project/basic/golden/build.ps1
+++ b/cmd/distrogen/testdata/generator/project/basic/golden/build.ps1
@@ -1,0 +1,69 @@
+$ErrorActionPreference = "Stop"
+
+if (-not $env:_WINDOWS_VERSION) {
+    Write-Error "_WINDOWS_VERSION environment variable is required but not set."
+    exit 1
+}
+
+# Determine the artifacts output directory relative to $env:KOKORO_ARTIFACTS_DIR
+$ArtifactsDir = if ($env:KOKORO_ARTIFACTS_DIR) { $env:KOKORO_ARTIFACTS_DIR } else { (Get-Item .).FullName }
+$TarDir = Join-Path $ArtifactsDir "container"
+$TarPath = Join-Path $TarDir "container.tar"
+
+Write-Host "Artifacts directory: $ArtifactsDir"
+Write-Host "Target tarball path: $TarPath"
+
+# Make sure the target directory exists
+if (-not (Test-Path $TarDir)) {
+    New-Item -ItemType Directory -Force -Path $TarDir
+}
+
+# Ensure the correct version of Go is installed
+$GoVersion = "1.24.0"
+$ToolsDir = Join-Path $PSScriptRoot ".tools"
+$GoDir = Join-Path $ToolsDir "go"
+$GoBinDir = Join-Path $GoDir "bin"
+$GoExePath = Join-Path $GoBinDir "go.exe"
+
+$GoUrl = "https://go.dev/dl/go$GoVersion.windows-amd64.zip"
+
+Write-Host "Downloading Go $GoVersion from $GoUrl..."
+curl.exe -L $GoUrl -o go.zip
+
+Write-Host "Extracting Go to $ToolsDir..."
+unzip.exe -q go.zip -d $ToolsDir
+Remove-Item -Force go.zip
+
+# Compile the Go binary on the host (inside the build environment)
+Write-Host "Compiling Go binary..."
+Set-Location $PSScriptRoot
+$env:PATH = "$GoBinDir;$env:PATH"
+$env:GOROOT = $GoDir
+
+# Format paths with forward slashes for maximum compatibility with make
+$NormalizedPwd = $PSScriptRoot.Replace("\", "/")
+
+& make PWD=$NormalizedPwd --trace TARGETOS=windows TARGETARCH=amd64 build-win
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Compilation failed with exit code $LASTEXITCODE"
+    exit $LASTEXITCODE
+}
+
+
+# Execute docker build inside the distribution directory
+Write-Host "Building Docker image..."
+docker build --build-arg WINDOWS_VERSION=$env:_WINDOWS_VERSION -f Dockerfile.windows.build -t otelcol-basic-windows:latest .
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Docker build failed with exit code $LASTEXITCODE"
+    exit $LASTEXITCODE
+}
+
+# Save the docker image as a tar archive
+Write-Host "Saving Docker image to $TarPath..."
+docker save otelcol-basic-windows:latest -o $TarPath
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Docker save failed with exit code $LASTEXITCODE"
+    exit $LASTEXITCODE
+}
+
+Write-Host "Windows container build complete."

--- a/cmd/distrogen/testdata/generator/project/vendoring/golden/Dockerfile.windows.build
+++ b/cmd/distrogen/testdata/generator/project/vendoring/golden/Dockerfile.windows.build
@@ -1,0 +1,9 @@
+ARG WINDOWS_VERSION=2019
+ARG WINBASE=mcr.microsoft.com/windows/servercore:ltsc${WINDOWS_VERSION}
+FROM ${WINBASE} AS windows
+
+COPY otelcol-basic.exe /otelcol-basic.exe
+COPY config.yaml /etc/otelcol-basic/config.yaml
+
+ENTRYPOINT ["/otelcol-basic.exe", "--feature-gates=exporter.googlemanagedprometheus.intToDouble"]
+CMD ["--config=/etc/otelcol-basic/config.yaml"]

--- a/cmd/distrogen/testdata/generator/project/vendoring/golden/build.bat
+++ b/cmd/distrogen/testdata/generator/project/vendoring/golden/build.bat
@@ -1,0 +1,4 @@
+set PROJECT_DIR=%~dp0
+REM powershell's exit codes are apparently completely broken with -File
+powershell.exe -Command " & '%PROJECT_DIR%build.ps1'"
+exit %ERRORLEVEL%

--- a/cmd/distrogen/testdata/generator/project/vendoring/golden/build.ps1
+++ b/cmd/distrogen/testdata/generator/project/vendoring/golden/build.ps1
@@ -1,0 +1,69 @@
+$ErrorActionPreference = "Stop"
+
+if (-not $env:_WINDOWS_VERSION) {
+    Write-Error "_WINDOWS_VERSION environment variable is required but not set."
+    exit 1
+}
+
+# Determine the artifacts output directory relative to $env:KOKORO_ARTIFACTS_DIR
+$ArtifactsDir = if ($env:KOKORO_ARTIFACTS_DIR) { $env:KOKORO_ARTIFACTS_DIR } else { (Get-Item .).FullName }
+$TarDir = Join-Path $ArtifactsDir "container"
+$TarPath = Join-Path $TarDir "container.tar"
+
+Write-Host "Artifacts directory: $ArtifactsDir"
+Write-Host "Target tarball path: $TarPath"
+
+# Make sure the target directory exists
+if (-not (Test-Path $TarDir)) {
+    New-Item -ItemType Directory -Force -Path $TarDir
+}
+
+# Ensure the correct version of Go is installed
+$GoVersion = "1.24.0"
+$ToolsDir = Join-Path $PSScriptRoot ".tools"
+$GoDir = Join-Path $ToolsDir "go"
+$GoBinDir = Join-Path $GoDir "bin"
+$GoExePath = Join-Path $GoBinDir "go.exe"
+
+$GoUrl = "https://go.dev/dl/go$GoVersion.windows-amd64.zip"
+
+Write-Host "Downloading Go $GoVersion from $GoUrl..."
+curl.exe -L $GoUrl -o go.zip
+
+Write-Host "Extracting Go to $ToolsDir..."
+unzip.exe -q go.zip -d $ToolsDir
+Remove-Item -Force go.zip
+
+# Compile the Go binary on the host (inside the build environment)
+Write-Host "Compiling Go binary..."
+Set-Location $PSScriptRoot
+$env:PATH = "$GoBinDir;$env:PATH"
+$env:GOROOT = $GoDir
+
+# Format paths with forward slashes for maximum compatibility with make
+$NormalizedPwd = $PSScriptRoot.Replace("\", "/")
+
+& make PWD=$NormalizedPwd --trace TARGETOS=windows TARGETARCH=amd64 build-win
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Compilation failed with exit code $LASTEXITCODE"
+    exit $LASTEXITCODE
+}
+
+
+# Execute docker build inside the distribution directory
+Write-Host "Building Docker image..."
+docker build --build-arg WINDOWS_VERSION=$env:_WINDOWS_VERSION -f Dockerfile.windows.build -t otelcol-basic-windows:latest .
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Docker build failed with exit code $LASTEXITCODE"
+    exit $LASTEXITCODE
+}
+
+# Save the docker image as a tar archive
+Write-Host "Saving Docker image to $TarPath..."
+docker save otelcol-basic-windows:latest -o $TarPath
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Docker save failed with exit code $LASTEXITCODE"
+    exit $LASTEXITCODE
+}
+
+Write-Host "Windows container build complete."


### PR DESCRIPTION
This PR adds Windows build templates (Dockerfile, build.ps1, build.bat) to distrogen's project generation templates.