### PR TITLE
[chore] Update components golang version to 1.26.0

### DIFF
--- a/components/google-built-opentelemetry-collector/exporter/googleservicecontrolexporter/go.mod
+++ b/components/google-built-opentelemetry-collector/exporter/googleservicecontrolexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/google-built-opentelemetry-collector/exporter/googleservicecontrolexporter
 
-go 1.25.0
+go 1.26.0
 
 require (
 	cloud.google.com/go/logging v1.13.1

--- a/components/google-built-opentelemetry-collector/extension/healthagent/go.mod
+++ b/components/google-built-opentelemetry-collector/extension/healthagent/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/google-built-opentelemetry-collector/extension/healthagent
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/components/google-built-opentelemetry-collector/extension/oauth2clientauthextension/go.mod
+++ b/components/google-built-opentelemetry-collector/extension/oauth2clientauthextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/components/google-built-opentelemetry-collector/internal/tools/go.mod
+++ b/components/google-built-opentelemetry-collector/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/google-build-opentelemetry-collector/internal/tools
 
-go 1.25.0
+go 1.26.0
 
 require go.opentelemetry.io/collector/cmd/mdatagen v0.159.0
 

--- a/components/otelopscol/internal/tools/go.mod
+++ b/components/otelopscol/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/internal/tools
 
-go 1.25.0
+go 1.26.0
 
 require go.opentelemetry.io/collector/cmd/mdatagen v0.156.0
 

--- a/components/otelopscol/processor/agentmetricsprocessor/go.mod
+++ b/components/otelopscol/processor/agentmetricsprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/processor/agentmetricsprocessor
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/components/otelopscol/processor/casttosumprocessor/go.mod
+++ b/components/otelopscol/processor/casttosumprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/processor/casttosumprocessor
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/components/otelopscol/processor/filterprocessor/go.mod
+++ b/components/otelopscol/processor/filterprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/processor/filterprocessor
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-collector v0.156.0

--- a/components/otelopscol/processor/normalizesumsprocessor/go.mod
+++ b/components/otelopscol/processor/normalizesumsprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/processor/normalizesumsprocessor
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.156.0

--- a/components/otelopscol/processor/transformprocessor/go.mod
+++ b/components/otelopscol/processor/transformprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/processor/transformprocessor
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-collector v0.156.0

--- a/components/otelopscol/receiver/dcgmreceiver/go.mod
+++ b/components/otelopscol/receiver/dcgmreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/receiver/dcgmreceiver
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/NVIDIA/go-dcgm v0.0.0-20240910155525-85ceb314ca65

--- a/components/otelopscol/receiver/jmxreceiver/go.mod
+++ b/components/otelopscol/receiver/jmxreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/moby/moby/api v1.55.0

--- a/components/otelopscol/receiver/mongodbreceiver/go.mod
+++ b/components/otelopscol/receiver/mongodbreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/receiver/mongodbreceiver
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/components/otelopscol/receiver/nvmlreceiver/go.mod
+++ b/components/otelopscol/receiver/nvmlreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/receiver/nvmlreceiver
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/NVIDIA/go-nvml v0.12.4-0

--- a/components/otelopscol/receiver/varnishreceiver/go.mod
+++ b/components/otelopscol/receiver/varnishreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-collector/components/otelopscol/receiver/varnishreceiver
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-collector
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/integration_test/gce-testing-internal/go.mod
+++ b/integration_test/gce-testing-internal/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal
 
-go 1.25.0
+go 1.26.0
 
 require (
 	cloud.google.com/go/logging v1.13.0

--- a/integration_test/smoke_test/go.mod
+++ b/integration_test/smoke_test/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/smoke_test
 
-go 1.25.0
+go 1.26.0
 
 require github.com/GoogleCloudPlatform/opentelemetry-operations-collector/integration_test/gce-testing-internal v0.0.0-20260119145159-eff68fc7b8ef
 

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/opentelemetry-operations-collector/internal/tools
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/client9/misspell v0.3.4


### PR DESCRIPTION
This PR bumps the Go directive across all `go.mod` files to `1.26.0` to resolve `undefined reference to ... go.shape` linker errors during make test (specifically affecting `filterprocessor`).

**Reasoning:** The go1.25.0 toolchain suffers from a CGO/generics linker bug ([golang/go#75461](https://github.com/golang/go/issues/75461)). Bumping to 1.26.0 brings in the upstream fix.

**Sample:** 
```
/usr/bin/x86_64-linux-gnu-ld.bfd: go.go:(.text+***): undefined reference to `github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl.WithConditionConverter[*github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlscope.TransformContext,go.shape.***]'
```