### PR TITLE
Add LogFilterPolicy definition and generated Go bindings

### DIFF
--- a/gen/go/policy/v1alpha1/log_filter_policy.pb.go
+++ b/gen/go/policy/v1alpha1/log_filter_policy.pb.go
@@ -154,6 +154,112 @@ func (LogRecordField) EnumDescriptor() ([]byte, []int) {
 	return file_policy_v1alpha1_log_filter_policy_proto_rawDescGZIP(), []int{1}
 }
 
+// ScopeField identifies standard first-class fields of an InstrumentationScope.
+type ScopeField int32
+
+const (
+	// Default unspecified scope field.
+	ScopeField_SCOPE_FIELD_UNSPECIFIED ScopeField = 0
+	// The name of the instrumentation scope (e.g. library or package name).
+	ScopeField_SCOPE_FIELD_NAME ScopeField = 1
+	// The version of the instrumentation scope.
+	ScopeField_SCOPE_FIELD_VERSION ScopeField = 2
+	// The schema URL of the instrumentation scope.
+	ScopeField_SCOPE_FIELD_SCHEMA_URL ScopeField = 3
+)
+
+// Enum value maps for ScopeField.
+var (
+	ScopeField_name = map[int32]string{
+		0: "SCOPE_FIELD_UNSPECIFIED",
+		1: "SCOPE_FIELD_NAME",
+		2: "SCOPE_FIELD_VERSION",
+		3: "SCOPE_FIELD_SCHEMA_URL",
+	}
+	ScopeField_value = map[string]int32{
+		"SCOPE_FIELD_UNSPECIFIED": 0,
+		"SCOPE_FIELD_NAME":        1,
+		"SCOPE_FIELD_VERSION":     2,
+		"SCOPE_FIELD_SCHEMA_URL":  3,
+	}
+)
+
+func (x ScopeField) Enum() *ScopeField {
+	p := new(ScopeField)
+	*p = x
+	return p
+}
+
+func (x ScopeField) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ScopeField) Descriptor() protoreflect.EnumDescriptor {
+	return file_policy_v1alpha1_log_filter_policy_proto_enumTypes[2].Descriptor()
+}
+
+func (ScopeField) Type() protoreflect.EnumType {
+	return &file_policy_v1alpha1_log_filter_policy_proto_enumTypes[2]
+}
+
+func (x ScopeField) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ScopeField.Descriptor instead.
+func (ScopeField) EnumDescriptor() ([]byte, []int) {
+	return file_policy_v1alpha1_log_filter_policy_proto_rawDescGZIP(), []int{2}
+}
+
+// ResourceField identifies standard first-class fields of a Resource.
+type ResourceField int32
+
+const (
+	// Default unspecified resource field.
+	ResourceField_RESOURCE_FIELD_UNSPECIFIED ResourceField = 0
+	// The schema URL of the resource.
+	ResourceField_RESOURCE_FIELD_SCHEMA_URL ResourceField = 1
+)
+
+// Enum value maps for ResourceField.
+var (
+	ResourceField_name = map[int32]string{
+		0: "RESOURCE_FIELD_UNSPECIFIED",
+		1: "RESOURCE_FIELD_SCHEMA_URL",
+	}
+	ResourceField_value = map[string]int32{
+		"RESOURCE_FIELD_UNSPECIFIED": 0,
+		"RESOURCE_FIELD_SCHEMA_URL":  1,
+	}
+)
+
+func (x ResourceField) Enum() *ResourceField {
+	p := new(ResourceField)
+	*p = x
+	return p
+}
+
+func (x ResourceField) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ResourceField) Descriptor() protoreflect.EnumDescriptor {
+	return file_policy_v1alpha1_log_filter_policy_proto_enumTypes[3].Descriptor()
+}
+
+func (ResourceField) Type() protoreflect.EnumType {
+	return &file_policy_v1alpha1_log_filter_policy_proto_enumTypes[3]
+}
+
+func (x ResourceField) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ResourceField.Descriptor instead.
+func (ResourceField) EnumDescriptor() ([]byte, []int) {
+	return file_policy_v1alpha1_log_filter_policy_proto_rawDescGZIP(), []int{3}
+}
+
 // LogFilterPolicy defines an intent-based rule for retaining or dropping
 // log records based on structured field and attribute matches.
 //
@@ -358,10 +464,8 @@ type LogFieldSelector struct {
 	//	*LogFieldSelector_LogAttribute
 	//	*LogFieldSelector_ResourceAttribute
 	//	*LogFieldSelector_ScopeAttribute
-	//	*LogFieldSelector_ScopeName
-	//	*LogFieldSelector_ScopeVersion
-	//	*LogFieldSelector_ResourceSchemaUrl
-	//	*LogFieldSelector_ScopeSchemaUrl
+	//	*LogFieldSelector_ScopeField
+	//	*LogFieldSelector_ResourceField
 	Target        isLogFieldSelector_Target `protobuf_oneof:"target"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -440,40 +544,22 @@ func (x *LogFieldSelector) GetScopeAttribute() string {
 	return ""
 }
 
-func (x *LogFieldSelector) GetScopeName() bool {
+func (x *LogFieldSelector) GetScopeField() ScopeField {
 	if x != nil {
-		if x, ok := x.Target.(*LogFieldSelector_ScopeName); ok {
-			return x.ScopeName
+		if x, ok := x.Target.(*LogFieldSelector_ScopeField); ok {
+			return x.ScopeField
 		}
 	}
-	return false
+	return ScopeField_SCOPE_FIELD_UNSPECIFIED
 }
 
-func (x *LogFieldSelector) GetScopeVersion() bool {
+func (x *LogFieldSelector) GetResourceField() ResourceField {
 	if x != nil {
-		if x, ok := x.Target.(*LogFieldSelector_ScopeVersion); ok {
-			return x.ScopeVersion
+		if x, ok := x.Target.(*LogFieldSelector_ResourceField); ok {
+			return x.ResourceField
 		}
 	}
-	return false
-}
-
-func (x *LogFieldSelector) GetResourceSchemaUrl() bool {
-	if x != nil {
-		if x, ok := x.Target.(*LogFieldSelector_ResourceSchemaUrl); ok {
-			return x.ResourceSchemaUrl
-		}
-	}
-	return false
-}
-
-func (x *LogFieldSelector) GetScopeSchemaUrl() bool {
-	if x != nil {
-		if x, ok := x.Target.(*LogFieldSelector_ScopeSchemaUrl); ok {
-			return x.ScopeSchemaUrl
-		}
-	}
-	return false
+	return ResourceField_RESOURCE_FIELD_UNSPECIFIED
 }
 
 type isLogFieldSelector_Target interface {
@@ -500,27 +586,14 @@ type LogFieldSelector_ScopeAttribute struct {
 	ScopeAttribute string `protobuf:"bytes,4,opt,name=scope_attribute,json=scopeAttribute,proto3,oneof"`
 }
 
-type LogFieldSelector_ScopeName struct {
-	// Matches the Instrumentation Scope name.
-	// (-- api-linter: core::0122::name-suffix=disabled
-	//
-	//	aip.dev/not-precedent: Matches OpenTelemetry InstrumentationScope name. --)
-	ScopeName bool `protobuf:"varint,5,opt,name=scope_name,json=scopeName,proto3,oneof"`
+type LogFieldSelector_ScopeField struct {
+	// Standard first-class OpenTelemetry InstrumentationScope fields.
+	ScopeField ScopeField `protobuf:"varint,5,opt,name=scope_field,json=scopeField,proto3,enum=google.telemetry.policy.v1alpha1.ScopeField,oneof"`
 }
 
-type LogFieldSelector_ScopeVersion struct {
-	// Matches the Instrumentation Scope version.
-	ScopeVersion bool `protobuf:"varint,6,opt,name=scope_version,json=scopeVersion,proto3,oneof"`
-}
-
-type LogFieldSelector_ResourceSchemaUrl struct {
-	// Matches the Resource Schema URL.
-	ResourceSchemaUrl bool `protobuf:"varint,7,opt,name=resource_schema_url,json=resourceSchemaUrl,proto3,oneof"`
-}
-
-type LogFieldSelector_ScopeSchemaUrl struct {
-	// Matches the Instrumentation Scope Schema URL.
-	ScopeSchemaUrl bool `protobuf:"varint,8,opt,name=scope_schema_url,json=scopeSchemaUrl,proto3,oneof"`
+type LogFieldSelector_ResourceField struct {
+	// Standard first-class OpenTelemetry Resource fields.
+	ResourceField ResourceField `protobuf:"varint,6,opt,name=resource_field,json=resourceField,proto3,enum=google.telemetry.policy.v1alpha1.ResourceField,oneof"`
 }
 
 func (*LogFieldSelector_RecordField) isLogFieldSelector_Target() {}
@@ -531,13 +604,9 @@ func (*LogFieldSelector_ResourceAttribute) isLogFieldSelector_Target() {}
 
 func (*LogFieldSelector_ScopeAttribute) isLogFieldSelector_Target() {}
 
-func (*LogFieldSelector_ScopeName) isLogFieldSelector_Target() {}
+func (*LogFieldSelector_ScopeField) isLogFieldSelector_Target() {}
 
-func (*LogFieldSelector_ScopeVersion) isLogFieldSelector_Target() {}
-
-func (*LogFieldSelector_ResourceSchemaUrl) isLogFieldSelector_Target() {}
-
-func (*LogFieldSelector_ScopeSchemaUrl) isLogFieldSelector_Target() {}
+func (*LogFieldSelector_ResourceField) isLogFieldSelector_Target() {}
 
 var File_policy_v1alpha1_log_filter_policy_proto protoreflect.FileDescriptor
 
@@ -556,17 +625,15 @@ const file_policy_v1alpha1_log_filter_policy_proto_rawDesc = "" +
 	"\x05exact\x18\v \x01(\tH\x00R\x05exact\x12\x16\n" +
 	"\x05regex\x18\f \x01(\tH\x00R\x05regex\x12\x16\n" +
 	"\x06negate\x18\x02 \x01(\bR\x06negateB\v\n" +
-	"\tpredicate\"\x9c\x03\n" +
+	"\tpredicate\"\xa1\x03\n" +
 	"\x10LogFieldSelector\x12U\n" +
 	"\frecord_field\x18\x01 \x01(\x0e20.google.telemetry.policy.v1alpha1.LogRecordFieldH\x00R\vrecordField\x12%\n" +
 	"\rlog_attribute\x18\x02 \x01(\tH\x00R\flogAttribute\x12/\n" +
 	"\x12resource_attribute\x18\x03 \x01(\tH\x00R\x11resourceAttribute\x12)\n" +
-	"\x0fscope_attribute\x18\x04 \x01(\tH\x00R\x0escopeAttribute\x12\x1f\n" +
-	"\n" +
-	"scope_name\x18\x05 \x01(\bH\x00R\tscopeName\x12%\n" +
-	"\rscope_version\x18\x06 \x01(\bH\x00R\fscopeVersion\x120\n" +
-	"\x13resource_schema_url\x18\a \x01(\bH\x00R\x11resourceSchemaUrl\x12*\n" +
-	"\x10scope_schema_url\x18\b \x01(\bH\x00R\x0escopeSchemaUrlB\b\n" +
+	"\x0fscope_attribute\x18\x04 \x01(\tH\x00R\x0escopeAttribute\x12O\n" +
+	"\vscope_field\x18\x05 \x01(\x0e2,.google.telemetry.policy.v1alpha1.ScopeFieldH\x00R\n" +
+	"scopeField\x12X\n" +
+	"\x0eresource_field\x18\x06 \x01(\x0e2/.google.telemetry.policy.v1alpha1.ResourceFieldH\x00R\rresourceFieldB\b\n" +
 	"\x06target*B\n" +
 	"\x06Action\x12\x16\n" +
 	"\x12ACTION_UNSPECIFIED\x10\x00\x12\x0f\n" +
@@ -578,7 +645,16 @@ const file_policy_v1alpha1_log_filter_policy_proto_rawDesc = "" +
 	"\x1eLOG_RECORD_FIELD_SEVERITY_TEXT\x10\x02\x12$\n" +
 	" LOG_RECORD_FIELD_SEVERITY_NUMBER\x10\x03\x12\x1d\n" +
 	"\x19LOG_RECORD_FIELD_TRACE_ID\x10\x04\x12\x1c\n" +
-	"\x18LOG_RECORD_FIELD_SPAN_ID\x10\x05B\xc8\x02\n" +
+	"\x18LOG_RECORD_FIELD_SPAN_ID\x10\x05*t\n" +
+	"\n" +
+	"ScopeField\x12\x1b\n" +
+	"\x17SCOPE_FIELD_UNSPECIFIED\x10\x00\x12\x14\n" +
+	"\x10SCOPE_FIELD_NAME\x10\x01\x12\x17\n" +
+	"\x13SCOPE_FIELD_VERSION\x10\x02\x12\x1a\n" +
+	"\x16SCOPE_FIELD_SCHEMA_URL\x10\x03*N\n" +
+	"\rResourceField\x12\x1e\n" +
+	"\x1aRESOURCE_FIELD_UNSPECIFIED\x10\x00\x12\x1d\n" +
+	"\x19RESOURCE_FIELD_SCHEMA_URL\x10\x01B\xc8\x02\n" +
 	"$com.google.telemetry.policy.v1alpha1B\x14LogFilterPolicyProtoP\x01Zggithub.com/GoogleCloudPlatform/opentelemetry-operations-collector/gen/go/policy/v1alpha1;policyv1alpha1\xa2\x02\x03GTP\xaa\x02 Google.Telemetry.Policy.V1alpha1\xca\x02 Google\\Telemetry\\Policy\\V1alpha1\xe2\x02,Google\\Telemetry\\Policy\\V1alpha1\\GPBMetadata\xea\x02#Google::Telemetry::Policy::V1alpha1b\x06proto3"
 
 var (
@@ -593,27 +669,31 @@ func file_policy_v1alpha1_log_filter_policy_proto_rawDescGZIP() []byte {
 	return file_policy_v1alpha1_log_filter_policy_proto_rawDescData
 }
 
-var file_policy_v1alpha1_log_filter_policy_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_policy_v1alpha1_log_filter_policy_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
 var file_policy_v1alpha1_log_filter_policy_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_policy_v1alpha1_log_filter_policy_proto_goTypes = []any{
 	(Action)(0),              // 0: google.telemetry.policy.v1alpha1.Action
 	(LogRecordField)(0),      // 1: google.telemetry.policy.v1alpha1.LogRecordField
-	(*LogFilterPolicy)(nil),  // 2: google.telemetry.policy.v1alpha1.LogFilterPolicy
-	(*LogMatcher)(nil),       // 3: google.telemetry.policy.v1alpha1.LogMatcher
-	(*LogFieldSelector)(nil), // 4: google.telemetry.policy.v1alpha1.LogFieldSelector
-	(*emptypb.Empty)(nil),    // 5: google.protobuf.Empty
+	(ScopeField)(0),          // 2: google.telemetry.policy.v1alpha1.ScopeField
+	(ResourceField)(0),       // 3: google.telemetry.policy.v1alpha1.ResourceField
+	(*LogFilterPolicy)(nil),  // 4: google.telemetry.policy.v1alpha1.LogFilterPolicy
+	(*LogMatcher)(nil),       // 5: google.telemetry.policy.v1alpha1.LogMatcher
+	(*LogFieldSelector)(nil), // 6: google.telemetry.policy.v1alpha1.LogFieldSelector
+	(*emptypb.Empty)(nil),    // 7: google.protobuf.Empty
 }
 var file_policy_v1alpha1_log_filter_policy_proto_depIdxs = []int32{
 	0, // 0: google.telemetry.policy.v1alpha1.LogFilterPolicy.action:type_name -> google.telemetry.policy.v1alpha1.Action
-	3, // 1: google.telemetry.policy.v1alpha1.LogFilterPolicy.matches:type_name -> google.telemetry.policy.v1alpha1.LogMatcher
-	4, // 2: google.telemetry.policy.v1alpha1.LogMatcher.target:type_name -> google.telemetry.policy.v1alpha1.LogFieldSelector
-	5, // 3: google.telemetry.policy.v1alpha1.LogMatcher.exists:type_name -> google.protobuf.Empty
+	5, // 1: google.telemetry.policy.v1alpha1.LogFilterPolicy.matches:type_name -> google.telemetry.policy.v1alpha1.LogMatcher
+	6, // 2: google.telemetry.policy.v1alpha1.LogMatcher.target:type_name -> google.telemetry.policy.v1alpha1.LogFieldSelector
+	7, // 3: google.telemetry.policy.v1alpha1.LogMatcher.exists:type_name -> google.protobuf.Empty
 	1, // 4: google.telemetry.policy.v1alpha1.LogFieldSelector.record_field:type_name -> google.telemetry.policy.v1alpha1.LogRecordField
-	5, // [5:5] is the sub-list for method output_type
-	5, // [5:5] is the sub-list for method input_type
-	5, // [5:5] is the sub-list for extension type_name
-	5, // [5:5] is the sub-list for extension extendee
-	0, // [0:5] is the sub-list for field type_name
+	2, // 5: google.telemetry.policy.v1alpha1.LogFieldSelector.scope_field:type_name -> google.telemetry.policy.v1alpha1.ScopeField
+	3, // 6: google.telemetry.policy.v1alpha1.LogFieldSelector.resource_field:type_name -> google.telemetry.policy.v1alpha1.ResourceField
+	7, // [7:7] is the sub-list for method output_type
+	7, // [7:7] is the sub-list for method input_type
+	7, // [7:7] is the sub-list for extension type_name
+	7, // [7:7] is the sub-list for extension extendee
+	0, // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_policy_v1alpha1_log_filter_policy_proto_init() }
@@ -631,17 +711,15 @@ func file_policy_v1alpha1_log_filter_policy_proto_init() {
 		(*LogFieldSelector_LogAttribute)(nil),
 		(*LogFieldSelector_ResourceAttribute)(nil),
 		(*LogFieldSelector_ScopeAttribute)(nil),
-		(*LogFieldSelector_ScopeName)(nil),
-		(*LogFieldSelector_ScopeVersion)(nil),
-		(*LogFieldSelector_ResourceSchemaUrl)(nil),
-		(*LogFieldSelector_ScopeSchemaUrl)(nil),
+		(*LogFieldSelector_ScopeField)(nil),
+		(*LogFieldSelector_ResourceField)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_policy_v1alpha1_log_filter_policy_proto_rawDesc), len(file_policy_v1alpha1_log_filter_policy_proto_rawDesc)),
-			NumEnums:      2,
+			NumEnums:      4,
 			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/gen/go/policy/v1alpha1/log_filter_policy.pb.go
+++ b/gen/go/policy/v1alpha1/log_filter_policy.pb.go
@@ -219,55 +219,6 @@ func (ScopeField) EnumDescriptor() ([]byte, []int) {
 	return file_policy_v1alpha1_log_filter_policy_proto_rawDescGZIP(), []int{2}
 }
 
-// ResourceField identifies standard first-class fields of a Resource.
-type ResourceField int32
-
-const (
-	// Default unspecified resource field.
-	ResourceField_RESOURCE_FIELD_UNSPECIFIED ResourceField = 0
-	// The schema URL of the resource.
-	ResourceField_RESOURCE_FIELD_SCHEMA_URL ResourceField = 1
-)
-
-// Enum value maps for ResourceField.
-var (
-	ResourceField_name = map[int32]string{
-		0: "RESOURCE_FIELD_UNSPECIFIED",
-		1: "RESOURCE_FIELD_SCHEMA_URL",
-	}
-	ResourceField_value = map[string]int32{
-		"RESOURCE_FIELD_UNSPECIFIED": 0,
-		"RESOURCE_FIELD_SCHEMA_URL":  1,
-	}
-)
-
-func (x ResourceField) Enum() *ResourceField {
-	p := new(ResourceField)
-	*p = x
-	return p
-}
-
-func (x ResourceField) String() string {
-	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
-}
-
-func (ResourceField) Descriptor() protoreflect.EnumDescriptor {
-	return file_policy_v1alpha1_log_filter_policy_proto_enumTypes[3].Descriptor()
-}
-
-func (ResourceField) Type() protoreflect.EnumType {
-	return &file_policy_v1alpha1_log_filter_policy_proto_enumTypes[3]
-}
-
-func (x ResourceField) Number() protoreflect.EnumNumber {
-	return protoreflect.EnumNumber(x)
-}
-
-// Deprecated: Use ResourceField.Descriptor instead.
-func (ResourceField) EnumDescriptor() ([]byte, []int) {
-	return file_policy_v1alpha1_log_filter_policy_proto_rawDescGZIP(), []int{3}
-}
-
 // LogFilterPolicy defines an intent-based rule for retaining or dropping
 // log records based on structured field and attribute matches.
 //
@@ -473,7 +424,6 @@ type LogFieldSelector struct {
 	//	*LogFieldSelector_ResourceAttribute
 	//	*LogFieldSelector_ScopeAttribute
 	//	*LogFieldSelector_ScopeField
-	//	*LogFieldSelector_ResourceField
 	Target        isLogFieldSelector_Target `protobuf_oneof:"target"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -561,15 +511,6 @@ func (x *LogFieldSelector) GetScopeField() ScopeField {
 	return ScopeField_SCOPE_FIELD_UNSPECIFIED
 }
 
-func (x *LogFieldSelector) GetResourceField() ResourceField {
-	if x != nil {
-		if x, ok := x.Target.(*LogFieldSelector_ResourceField); ok {
-			return x.ResourceField
-		}
-	}
-	return ResourceField_RESOURCE_FIELD_UNSPECIFIED
-}
-
 type isLogFieldSelector_Target interface {
 	isLogFieldSelector_Target()
 }
@@ -599,11 +540,6 @@ type LogFieldSelector_ScopeField struct {
 	ScopeField ScopeField `protobuf:"varint,5,opt,name=scope_field,json=scopeField,proto3,enum=google.telemetry.policy.v1alpha1.ScopeField,oneof"`
 }
 
-type LogFieldSelector_ResourceField struct {
-	// Standard first-class OpenTelemetry Resource fields (OTLP path: resource.*).
-	ResourceField ResourceField `protobuf:"varint,6,opt,name=resource_field,json=resourceField,proto3,enum=google.telemetry.policy.v1alpha1.ResourceField,oneof"`
-}
-
 func (*LogFieldSelector_RecordField) isLogFieldSelector_Target() {}
 
 func (*LogFieldSelector_LogAttribute) isLogFieldSelector_Target() {}
@@ -613,8 +549,6 @@ func (*LogFieldSelector_ResourceAttribute) isLogFieldSelector_Target() {}
 func (*LogFieldSelector_ScopeAttribute) isLogFieldSelector_Target() {}
 
 func (*LogFieldSelector_ScopeField) isLogFieldSelector_Target() {}
-
-func (*LogFieldSelector_ResourceField) isLogFieldSelector_Target() {}
 
 var File_policy_v1alpha1_log_filter_policy_proto protoreflect.FileDescriptor
 
@@ -634,15 +568,14 @@ const file_policy_v1alpha1_log_filter_policy_proto_rawDesc = "" +
 	"\x05exact\x18\v \x01(\tH\x00R\x05exact\x12\x16\n" +
 	"\x05regex\x18\f \x01(\tH\x00R\x05regex\x12\x16\n" +
 	"\x06negate\x18\x02 \x01(\bR\x06negateB\v\n" +
-	"\tpredicate\"\xa1\x03\n" +
+	"\tpredicate\"\xc7\x02\n" +
 	"\x10LogFieldSelector\x12U\n" +
 	"\frecord_field\x18\x01 \x01(\x0e20.google.telemetry.policy.v1alpha1.LogRecordFieldH\x00R\vrecordField\x12%\n" +
 	"\rlog_attribute\x18\x02 \x01(\tH\x00R\flogAttribute\x12/\n" +
 	"\x12resource_attribute\x18\x03 \x01(\tH\x00R\x11resourceAttribute\x12)\n" +
 	"\x0fscope_attribute\x18\x04 \x01(\tH\x00R\x0escopeAttribute\x12O\n" +
 	"\vscope_field\x18\x05 \x01(\x0e2,.google.telemetry.policy.v1alpha1.ScopeFieldH\x00R\n" +
-	"scopeField\x12X\n" +
-	"\x0eresource_field\x18\x06 \x01(\x0e2/.google.telemetry.policy.v1alpha1.ResourceFieldH\x00R\rresourceFieldB\b\n" +
+	"scopeFieldB\b\n" +
 	"\x06target*B\n" +
 	"\x06Action\x12\x16\n" +
 	"\x12ACTION_UNSPECIFIED\x10\x00\x12\x0f\n" +
@@ -660,10 +593,7 @@ const file_policy_v1alpha1_log_filter_policy_proto_rawDesc = "" +
 	"\x17SCOPE_FIELD_UNSPECIFIED\x10\x00\x12\x14\n" +
 	"\x10SCOPE_FIELD_NAME\x10\x01\x12\x17\n" +
 	"\x13SCOPE_FIELD_VERSION\x10\x02\x12\x1a\n" +
-	"\x16SCOPE_FIELD_SCHEMA_URL\x10\x03*N\n" +
-	"\rResourceField\x12\x1e\n" +
-	"\x1aRESOURCE_FIELD_UNSPECIFIED\x10\x00\x12\x1d\n" +
-	"\x19RESOURCE_FIELD_SCHEMA_URL\x10\x01B\xc8\x02\n" +
+	"\x16SCOPE_FIELD_SCHEMA_URL\x10\x03B\xc8\x02\n" +
 	"$com.google.telemetry.policy.v1alpha1B\x14LogFilterPolicyProtoP\x01Zggithub.com/GoogleCloudPlatform/opentelemetry-operations-collector/gen/go/policy/v1alpha1;policyv1alpha1\xa2\x02\x03GTP\xaa\x02 Google.Telemetry.Policy.V1alpha1\xca\x02 Google\\Telemetry\\Policy\\V1alpha1\xe2\x02,Google\\Telemetry\\Policy\\V1alpha1\\GPBMetadata\xea\x02#Google::Telemetry::Policy::V1alpha1b\x06proto3"
 
 var (
@@ -678,31 +608,29 @@ func file_policy_v1alpha1_log_filter_policy_proto_rawDescGZIP() []byte {
 	return file_policy_v1alpha1_log_filter_policy_proto_rawDescData
 }
 
-var file_policy_v1alpha1_log_filter_policy_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_policy_v1alpha1_log_filter_policy_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
 var file_policy_v1alpha1_log_filter_policy_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_policy_v1alpha1_log_filter_policy_proto_goTypes = []any{
 	(Action)(0),              // 0: google.telemetry.policy.v1alpha1.Action
 	(LogRecordField)(0),      // 1: google.telemetry.policy.v1alpha1.LogRecordField
 	(ScopeField)(0),          // 2: google.telemetry.policy.v1alpha1.ScopeField
-	(ResourceField)(0),       // 3: google.telemetry.policy.v1alpha1.ResourceField
-	(*LogFilterPolicy)(nil),  // 4: google.telemetry.policy.v1alpha1.LogFilterPolicy
-	(*LogMatcher)(nil),       // 5: google.telemetry.policy.v1alpha1.LogMatcher
-	(*LogFieldSelector)(nil), // 6: google.telemetry.policy.v1alpha1.LogFieldSelector
-	(*emptypb.Empty)(nil),    // 7: google.protobuf.Empty
+	(*LogFilterPolicy)(nil),  // 3: google.telemetry.policy.v1alpha1.LogFilterPolicy
+	(*LogMatcher)(nil),       // 4: google.telemetry.policy.v1alpha1.LogMatcher
+	(*LogFieldSelector)(nil), // 5: google.telemetry.policy.v1alpha1.LogFieldSelector
+	(*emptypb.Empty)(nil),    // 6: google.protobuf.Empty
 }
 var file_policy_v1alpha1_log_filter_policy_proto_depIdxs = []int32{
 	0, // 0: google.telemetry.policy.v1alpha1.LogFilterPolicy.action:type_name -> google.telemetry.policy.v1alpha1.Action
-	5, // 1: google.telemetry.policy.v1alpha1.LogFilterPolicy.matches:type_name -> google.telemetry.policy.v1alpha1.LogMatcher
-	6, // 2: google.telemetry.policy.v1alpha1.LogMatcher.target:type_name -> google.telemetry.policy.v1alpha1.LogFieldSelector
-	7, // 3: google.telemetry.policy.v1alpha1.LogMatcher.exists:type_name -> google.protobuf.Empty
+	4, // 1: google.telemetry.policy.v1alpha1.LogFilterPolicy.matches:type_name -> google.telemetry.policy.v1alpha1.LogMatcher
+	5, // 2: google.telemetry.policy.v1alpha1.LogMatcher.target:type_name -> google.telemetry.policy.v1alpha1.LogFieldSelector
+	6, // 3: google.telemetry.policy.v1alpha1.LogMatcher.exists:type_name -> google.protobuf.Empty
 	1, // 4: google.telemetry.policy.v1alpha1.LogFieldSelector.record_field:type_name -> google.telemetry.policy.v1alpha1.LogRecordField
 	2, // 5: google.telemetry.policy.v1alpha1.LogFieldSelector.scope_field:type_name -> google.telemetry.policy.v1alpha1.ScopeField
-	3, // 6: google.telemetry.policy.v1alpha1.LogFieldSelector.resource_field:type_name -> google.telemetry.policy.v1alpha1.ResourceField
-	7, // [7:7] is the sub-list for method output_type
-	7, // [7:7] is the sub-list for method input_type
-	7, // [7:7] is the sub-list for extension type_name
-	7, // [7:7] is the sub-list for extension extendee
-	0, // [0:7] is the sub-list for field type_name
+	6, // [6:6] is the sub-list for method output_type
+	6, // [6:6] is the sub-list for method input_type
+	6, // [6:6] is the sub-list for extension type_name
+	6, // [6:6] is the sub-list for extension extendee
+	0, // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_policy_v1alpha1_log_filter_policy_proto_init() }
@@ -722,14 +650,13 @@ func file_policy_v1alpha1_log_filter_policy_proto_init() {
 		(*LogFieldSelector_ResourceAttribute)(nil),
 		(*LogFieldSelector_ScopeAttribute)(nil),
 		(*LogFieldSelector_ScopeField)(nil),
-		(*LogFieldSelector_ResourceField)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_policy_v1alpha1_log_filter_policy_proto_rawDesc), len(file_policy_v1alpha1_log_filter_policy_proto_rawDesc)),
-			NumEnums:      4,
+			NumEnums:      3,
 			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/gen/go/policy/v1alpha1/log_filter_policy.pb.go
+++ b/gen/go/policy/v1alpha1/log_filter_policy.pb.go
@@ -23,6 +23,7 @@ package policyv1alpha1
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	emptypb "google.golang.org/protobuf/types/known/emptypb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -289,13 +290,13 @@ func (x *LogMatcher) GetPredicate() isLogMatcher_Predicate {
 	return nil
 }
 
-func (x *LogMatcher) GetExists() bool {
+func (x *LogMatcher) GetExists() *emptypb.Empty {
 	if x != nil {
 		if x, ok := x.Predicate.(*LogMatcher_Exists); ok {
 			return x.Exists
 		}
 	}
-	return false
+	return nil
 }
 
 func (x *LogMatcher) GetExact() string {
@@ -329,7 +330,7 @@ type isLogMatcher_Predicate interface {
 
 type LogMatcher_Exists struct {
 	// Matches if the selected field or attribute exists.
-	Exists bool `protobuf:"varint,10,opt,name=exists,proto3,oneof"`
+	Exists *emptypb.Empty `protobuf:"bytes,10,opt,name=exists,proto3,oneof"`
 }
 
 type LogMatcher_Exact struct {
@@ -542,16 +543,16 @@ var File_policy_v1alpha1_log_filter_policy_proto protoreflect.FileDescriptor
 
 const file_policy_v1alpha1_log_filter_policy_proto_rawDesc = "" +
 	"\n" +
-	"'policy/v1alpha1/log_filter_policy.proto\x12 google.telemetry.policy.v1alpha1\"\xab\x01\n" +
+	"'policy/v1alpha1/log_filter_policy.proto\x12 google.telemetry.policy.v1alpha1\x1a\x1bgoogle/protobuf/empty.proto\"\xab\x01\n" +
 	"\x0fLogFilterPolicy\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12@\n" +
 	"\x06action\x18\x02 \x01(\x0e2(.google.telemetry.policy.v1alpha1.ActionR\x06action\x12F\n" +
-	"\amatches\x18\x03 \x03(\v2,.google.telemetry.policy.v1alpha1.LogMatcherR\amatches\"\xc7\x01\n" +
+	"\amatches\x18\x03 \x03(\v2,.google.telemetry.policy.v1alpha1.LogMatcherR\amatches\"\xdf\x01\n" +
 	"\n" +
 	"LogMatcher\x12J\n" +
-	"\x06target\x18\x01 \x01(\v22.google.telemetry.policy.v1alpha1.LogFieldSelectorR\x06target\x12\x18\n" +
+	"\x06target\x18\x01 \x01(\v22.google.telemetry.policy.v1alpha1.LogFieldSelectorR\x06target\x120\n" +
 	"\x06exists\x18\n" +
-	" \x01(\bH\x00R\x06exists\x12\x16\n" +
+	" \x01(\v2\x16.google.protobuf.EmptyH\x00R\x06exists\x12\x16\n" +
 	"\x05exact\x18\v \x01(\tH\x00R\x05exact\x12\x16\n" +
 	"\x05regex\x18\f \x01(\tH\x00R\x05regex\x12\x16\n" +
 	"\x06negate\x18\x14 \x01(\bR\x06negateB\v\n" +
@@ -600,17 +601,19 @@ var file_policy_v1alpha1_log_filter_policy_proto_goTypes = []any{
 	(*LogFilterPolicy)(nil),  // 2: google.telemetry.policy.v1alpha1.LogFilterPolicy
 	(*LogMatcher)(nil),       // 3: google.telemetry.policy.v1alpha1.LogMatcher
 	(*LogFieldSelector)(nil), // 4: google.telemetry.policy.v1alpha1.LogFieldSelector
+	(*emptypb.Empty)(nil),    // 5: google.protobuf.Empty
 }
 var file_policy_v1alpha1_log_filter_policy_proto_depIdxs = []int32{
 	0, // 0: google.telemetry.policy.v1alpha1.LogFilterPolicy.action:type_name -> google.telemetry.policy.v1alpha1.Action
 	3, // 1: google.telemetry.policy.v1alpha1.LogFilterPolicy.matches:type_name -> google.telemetry.policy.v1alpha1.LogMatcher
 	4, // 2: google.telemetry.policy.v1alpha1.LogMatcher.target:type_name -> google.telemetry.policy.v1alpha1.LogFieldSelector
-	1, // 3: google.telemetry.policy.v1alpha1.LogFieldSelector.record_field:type_name -> google.telemetry.policy.v1alpha1.LogRecordField
-	4, // [4:4] is the sub-list for method output_type
-	4, // [4:4] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	5, // 3: google.telemetry.policy.v1alpha1.LogMatcher.exists:type_name -> google.protobuf.Empty
+	1, // 4: google.telemetry.policy.v1alpha1.LogFieldSelector.record_field:type_name -> google.telemetry.policy.v1alpha1.LogRecordField
+	5, // [5:5] is the sub-list for method output_type
+	5, // [5:5] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_policy_v1alpha1_log_filter_policy_proto_init() }

--- a/gen/go/policy/v1alpha1/log_filter_policy.pb.go
+++ b/gen/go/policy/v1alpha1/log_filter_policy.pb.go
@@ -275,7 +275,7 @@ func (ResourceField) EnumDescriptor() ([]byte, []int) {
 type LogFilterPolicy struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Unique identifier for the policy within its configuration scope
-	// (e.g. "drop-noisy-healthchecks", "retain-error-logs").
+	// (e.g. a UUID or namespaced URI like "io.opentelemetry.operator/{namespace}/policies/retain-error-logs").
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// The filtering action to take when all `matches` conditions evaluate to true.
 	Action *Action `protobuf:"varint,2,opt,name=action,proto3,enum=google.telemetry.policy.v1alpha1.Action,oneof" json:"action,omitempty"`

--- a/gen/go/policy/v1alpha1/log_filter_policy.pb.go
+++ b/gen/go/policy/v1alpha1/log_filter_policy.pb.go
@@ -241,7 +241,7 @@ type LogMatcher struct {
 	//	*LogMatcher_Regex
 	Predicate isLogMatcher_Predicate `protobuf_oneof:"predicate"`
 	// If true, inverts the result of the predicate (logical NOT).
-	Negate        bool `protobuf:"varint,20,opt,name=negate,proto3" json:"negate,omitempty"`
+	Negate        bool `protobuf:"varint,2,opt,name=negate,proto3" json:"negate,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -555,7 +555,7 @@ const file_policy_v1alpha1_log_filter_policy_proto_rawDesc = "" +
 	" \x01(\v2\x16.google.protobuf.EmptyH\x00R\x06exists\x12\x16\n" +
 	"\x05exact\x18\v \x01(\tH\x00R\x05exact\x12\x16\n" +
 	"\x05regex\x18\f \x01(\tH\x00R\x05regex\x12\x16\n" +
-	"\x06negate\x18\x14 \x01(\bR\x06negateB\v\n" +
+	"\x06negate\x18\x02 \x01(\bR\x06negateB\v\n" +
 	"\tpredicate\"\x9c\x03\n" +
 	"\x10LogFieldSelector\x12U\n" +
 	"\frecord_field\x18\x01 \x01(\x0e20.google.telemetry.policy.v1alpha1.LogRecordFieldH\x00R\vrecordField\x12%\n" +

--- a/gen/go/policy/v1alpha1/log_filter_policy.pb.go
+++ b/gen/go/policy/v1alpha1/log_filter_policy.pb.go
@@ -575,32 +575,32 @@ type isLogFieldSelector_Target interface {
 }
 
 type LogFieldSelector_RecordField struct {
-	// Standard first-class OpenTelemetry LogRecord fields.
+	// Standard first-class OpenTelemetry LogRecord fields (OTLP path: log_record.*).
 	RecordField LogRecordField `protobuf:"varint,1,opt,name=record_field,json=recordField,proto3,enum=google.telemetry.policy.v1alpha1.LogRecordField,oneof"`
 }
 
 type LogFieldSelector_LogAttribute struct {
-	// Log record attribute by key (e.g. "http.route", "user_id").
+	// Log record attribute by key (OTLP path: log_record.attributes[*], e.g. "http.route", "user_id").
 	LogAttribute string `protobuf:"bytes,2,opt,name=log_attribute,json=logAttribute,proto3,oneof"`
 }
 
 type LogFieldSelector_ResourceAttribute struct {
-	// Resource attribute by key (e.g. "service.name", "k8s.pod.name").
+	// Resource attribute by key (OTLP path: resource.attributes[*], e.g. "service.name", "k8s.pod.name").
 	ResourceAttribute string `protobuf:"bytes,3,opt,name=resource_attribute,json=resourceAttribute,proto3,oneof"`
 }
 
 type LogFieldSelector_ScopeAttribute struct {
-	// Instrumentation scope attribute by key (e.g. "library.name").
+	// Instrumentation scope attribute by key (OTLP path: scope.attributes[*], e.g. "library.name").
 	ScopeAttribute string `protobuf:"bytes,4,opt,name=scope_attribute,json=scopeAttribute,proto3,oneof"`
 }
 
 type LogFieldSelector_ScopeField struct {
-	// Standard first-class OpenTelemetry InstrumentationScope fields.
+	// Standard first-class OpenTelemetry InstrumentationScope fields (OTLP path: scope.*).
 	ScopeField ScopeField `protobuf:"varint,5,opt,name=scope_field,json=scopeField,proto3,enum=google.telemetry.policy.v1alpha1.ScopeField,oneof"`
 }
 
 type LogFieldSelector_ResourceField struct {
-	// Standard first-class OpenTelemetry Resource fields.
+	// Standard first-class OpenTelemetry Resource fields (OTLP path: resource.*).
 	ResourceField ResourceField `protobuf:"varint,6,opt,name=resource_field,json=resourceField,proto3,enum=google.telemetry.policy.v1alpha1.ResourceField,oneof"`
 }
 

--- a/gen/go/policy/v1alpha1/log_filter_policy.pb.go
+++ b/gen/go/policy/v1alpha1/log_filter_policy.pb.go
@@ -35,15 +35,140 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// LogFilterPolicy defines an intent-based rule for filtering log records.
+// Action specifies what to do with a log record that matches all conditions.
+type Action int32
+
+const (
+	// Default unspecified action. A policy with an unspecified action is invalid.
+	Action_ACTION_UNSPECIFIED Action = 0
+	// Keep the matching log record and forward it to downstream pipelines.
+	Action_ACTION_KEEP Action = 1
+	// Drop the matching log record completely.
+	Action_ACTION_DROP Action = 2
+)
+
+// Enum value maps for Action.
+var (
+	Action_name = map[int32]string{
+		0: "ACTION_UNSPECIFIED",
+		1: "ACTION_KEEP",
+		2: "ACTION_DROP",
+	}
+	Action_value = map[string]int32{
+		"ACTION_UNSPECIFIED": 0,
+		"ACTION_KEEP":        1,
+		"ACTION_DROP":        2,
+	}
+)
+
+func (x Action) Enum() *Action {
+	p := new(Action)
+	*p = x
+	return p
+}
+
+func (x Action) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (Action) Descriptor() protoreflect.EnumDescriptor {
+	return file_policy_v1alpha1_log_filter_policy_proto_enumTypes[0].Descriptor()
+}
+
+func (Action) Type() protoreflect.EnumType {
+	return &file_policy_v1alpha1_log_filter_policy_proto_enumTypes[0]
+}
+
+func (x Action) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use Action.Descriptor instead.
+func (Action) EnumDescriptor() ([]byte, []int) {
+	return file_policy_v1alpha1_log_filter_policy_proto_rawDescGZIP(), []int{0}
+}
+
+// LogRecordField identifies standard first-class fields of an OpenTelemetry LogRecord.
+type LogRecordField int32
+
+const (
+	// Default unspecified log record field.
+	LogRecordField_LOG_RECORD_FIELD_UNSPECIFIED LogRecordField = 0
+	// The primary message body of the log record.
+	LogRecordField_LOG_RECORD_FIELD_BODY LogRecordField = 1
+	// The string severity of the log (e.g. "INFO", "ERROR", "DEBUG").
+	LogRecordField_LOG_RECORD_FIELD_SEVERITY_TEXT LogRecordField = 2
+	// The numerical severity of the log (1-24 per OpenTelemetry specification).
+	LogRecordField_LOG_RECORD_FIELD_SEVERITY_NUMBER LogRecordField = 3
+	// The 16-byte trace identifier associated with the log record.
+	LogRecordField_LOG_RECORD_FIELD_TRACE_ID LogRecordField = 4
+	// The 8-byte span identifier associated with the log record.
+	LogRecordField_LOG_RECORD_FIELD_SPAN_ID LogRecordField = 5
+)
+
+// Enum value maps for LogRecordField.
+var (
+	LogRecordField_name = map[int32]string{
+		0: "LOG_RECORD_FIELD_UNSPECIFIED",
+		1: "LOG_RECORD_FIELD_BODY",
+		2: "LOG_RECORD_FIELD_SEVERITY_TEXT",
+		3: "LOG_RECORD_FIELD_SEVERITY_NUMBER",
+		4: "LOG_RECORD_FIELD_TRACE_ID",
+		5: "LOG_RECORD_FIELD_SPAN_ID",
+	}
+	LogRecordField_value = map[string]int32{
+		"LOG_RECORD_FIELD_UNSPECIFIED":     0,
+		"LOG_RECORD_FIELD_BODY":            1,
+		"LOG_RECORD_FIELD_SEVERITY_TEXT":   2,
+		"LOG_RECORD_FIELD_SEVERITY_NUMBER": 3,
+		"LOG_RECORD_FIELD_TRACE_ID":        4,
+		"LOG_RECORD_FIELD_SPAN_ID":         5,
+	}
+)
+
+func (x LogRecordField) Enum() *LogRecordField {
+	p := new(LogRecordField)
+	*p = x
+	return p
+}
+
+func (x LogRecordField) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (LogRecordField) Descriptor() protoreflect.EnumDescriptor {
+	return file_policy_v1alpha1_log_filter_policy_proto_enumTypes[1].Descriptor()
+}
+
+func (LogRecordField) Type() protoreflect.EnumType {
+	return &file_policy_v1alpha1_log_filter_policy_proto_enumTypes[1]
+}
+
+func (x LogRecordField) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use LogRecordField.Descriptor instead.
+func (LogRecordField) EnumDescriptor() ([]byte, []int) {
+	return file_policy_v1alpha1_log_filter_policy_proto_rawDescGZIP(), []int{1}
+}
+
+// LogFilterPolicy defines an intent-based rule for retaining or dropping
+// log records based on structured field and attribute matches.
 //
-// Policies are declarative and transport-agnostic.
-//
-// Note: Detailed filter conditions, matchers, and action semantics are deferred
-// to a subsequent design. This message is currently stubbed to establish the
-// package hierarchy, repository organization, and xDS transport plumbing.
+// Policies are declarative, atomic, and transport-agnostic.
 type LogFilterPolicy struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Unique identifier for the policy within its configuration scope
+	// (e.g. "drop-noisy-healthchecks", "retain-error-logs").
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// The filtering action to take when all `matches` conditions evaluate to true.
+	Action Action `protobuf:"varint,2,opt,name=action,proto3,enum=google.telemetry.policy.v1alpha1.Action" json:"action,omitempty"`
+	// Conditions evaluated against incoming log records.
+	// All matchers in this list are ANDed together: all conditions must evaluate
+	// to true for the policy action to take effect. If empty, the policy matches
+	// all log records.
+	Matches       []*LogMatcher `protobuf:"bytes,3,rep,name=matches,proto3" json:"matches,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -78,12 +203,381 @@ func (*LogFilterPolicy) Descriptor() ([]byte, []int) {
 	return file_policy_v1alpha1_log_filter_policy_proto_rawDescGZIP(), []int{0}
 }
 
+func (x *LogFilterPolicy) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *LogFilterPolicy) GetAction() Action {
+	if x != nil {
+		return x.Action
+	}
+	return Action_ACTION_UNSPECIFIED
+}
+
+func (x *LogFilterPolicy) GetMatches() []*LogMatcher {
+	if x != nil {
+		return x.Matches
+	}
+	return nil
+}
+
+// LogMatcher defines a single predicate evaluated against a specific log field
+// or attribute.
+type LogMatcher struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The field, attribute, or metadata to inspect. Exactly one must be set.
+	Target *LogFieldSelector `protobuf:"bytes,1,opt,name=target,proto3" json:"target,omitempty"`
+	// The comparison predicate to evaluate against the target value.
+	// Exactly one predicate must be set.
+	//
+	// Types that are valid to be assigned to Predicate:
+	//
+	//	*LogMatcher_Exists
+	//	*LogMatcher_Exact
+	//	*LogMatcher_Regex
+	Predicate isLogMatcher_Predicate `protobuf_oneof:"predicate"`
+	// If true, inverts the result of the predicate (logical NOT).
+	Negate        bool `protobuf:"varint,20,opt,name=negate,proto3" json:"negate,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LogMatcher) Reset() {
+	*x = LogMatcher{}
+	mi := &file_policy_v1alpha1_log_filter_policy_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LogMatcher) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LogMatcher) ProtoMessage() {}
+
+func (x *LogMatcher) ProtoReflect() protoreflect.Message {
+	mi := &file_policy_v1alpha1_log_filter_policy_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LogMatcher.ProtoReflect.Descriptor instead.
+func (*LogMatcher) Descriptor() ([]byte, []int) {
+	return file_policy_v1alpha1_log_filter_policy_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *LogMatcher) GetTarget() *LogFieldSelector {
+	if x != nil {
+		return x.Target
+	}
+	return nil
+}
+
+func (x *LogMatcher) GetPredicate() isLogMatcher_Predicate {
+	if x != nil {
+		return x.Predicate
+	}
+	return nil
+}
+
+func (x *LogMatcher) GetExists() bool {
+	if x != nil {
+		if x, ok := x.Predicate.(*LogMatcher_Exists); ok {
+			return x.Exists
+		}
+	}
+	return false
+}
+
+func (x *LogMatcher) GetExact() string {
+	if x != nil {
+		if x, ok := x.Predicate.(*LogMatcher_Exact); ok {
+			return x.Exact
+		}
+	}
+	return ""
+}
+
+func (x *LogMatcher) GetRegex() string {
+	if x != nil {
+		if x, ok := x.Predicate.(*LogMatcher_Regex); ok {
+			return x.Regex
+		}
+	}
+	return ""
+}
+
+func (x *LogMatcher) GetNegate() bool {
+	if x != nil {
+		return x.Negate
+	}
+	return false
+}
+
+type isLogMatcher_Predicate interface {
+	isLogMatcher_Predicate()
+}
+
+type LogMatcher_Exists struct {
+	// Matches if the selected field or attribute exists.
+	Exists bool `protobuf:"varint,10,opt,name=exists,proto3,oneof"`
+}
+
+type LogMatcher_Exact struct {
+	// Exact string equality match.
+	Exact string `protobuf:"bytes,11,opt,name=exact,proto3,oneof"`
+}
+
+type LogMatcher_Regex struct {
+	// Regular expression match using RE2 syntax.
+	Regex string `protobuf:"bytes,12,opt,name=regex,proto3,oneof"`
+}
+
+func (*LogMatcher_Exists) isLogMatcher_Predicate() {}
+
+func (*LogMatcher_Exact) isLogMatcher_Predicate() {}
+
+func (*LogMatcher_Regex) isLogMatcher_Predicate() {}
+
+// LogFieldSelector designates a first-class OTel log field, attribute, or metadata.
+type LogFieldSelector struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Target:
+	//
+	//	*LogFieldSelector_RecordField
+	//	*LogFieldSelector_LogAttribute
+	//	*LogFieldSelector_ResourceAttribute
+	//	*LogFieldSelector_ScopeAttribute
+	//	*LogFieldSelector_ScopeName
+	//	*LogFieldSelector_ScopeVersion
+	//	*LogFieldSelector_ResourceSchemaUrl
+	//	*LogFieldSelector_ScopeSchemaUrl
+	Target        isLogFieldSelector_Target `protobuf_oneof:"target"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LogFieldSelector) Reset() {
+	*x = LogFieldSelector{}
+	mi := &file_policy_v1alpha1_log_filter_policy_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LogFieldSelector) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LogFieldSelector) ProtoMessage() {}
+
+func (x *LogFieldSelector) ProtoReflect() protoreflect.Message {
+	mi := &file_policy_v1alpha1_log_filter_policy_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LogFieldSelector.ProtoReflect.Descriptor instead.
+func (*LogFieldSelector) Descriptor() ([]byte, []int) {
+	return file_policy_v1alpha1_log_filter_policy_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *LogFieldSelector) GetTarget() isLogFieldSelector_Target {
+	if x != nil {
+		return x.Target
+	}
+	return nil
+}
+
+func (x *LogFieldSelector) GetRecordField() LogRecordField {
+	if x != nil {
+		if x, ok := x.Target.(*LogFieldSelector_RecordField); ok {
+			return x.RecordField
+		}
+	}
+	return LogRecordField_LOG_RECORD_FIELD_UNSPECIFIED
+}
+
+func (x *LogFieldSelector) GetLogAttribute() string {
+	if x != nil {
+		if x, ok := x.Target.(*LogFieldSelector_LogAttribute); ok {
+			return x.LogAttribute
+		}
+	}
+	return ""
+}
+
+func (x *LogFieldSelector) GetResourceAttribute() string {
+	if x != nil {
+		if x, ok := x.Target.(*LogFieldSelector_ResourceAttribute); ok {
+			return x.ResourceAttribute
+		}
+	}
+	return ""
+}
+
+func (x *LogFieldSelector) GetScopeAttribute() string {
+	if x != nil {
+		if x, ok := x.Target.(*LogFieldSelector_ScopeAttribute); ok {
+			return x.ScopeAttribute
+		}
+	}
+	return ""
+}
+
+func (x *LogFieldSelector) GetScopeName() bool {
+	if x != nil {
+		if x, ok := x.Target.(*LogFieldSelector_ScopeName); ok {
+			return x.ScopeName
+		}
+	}
+	return false
+}
+
+func (x *LogFieldSelector) GetScopeVersion() bool {
+	if x != nil {
+		if x, ok := x.Target.(*LogFieldSelector_ScopeVersion); ok {
+			return x.ScopeVersion
+		}
+	}
+	return false
+}
+
+func (x *LogFieldSelector) GetResourceSchemaUrl() bool {
+	if x != nil {
+		if x, ok := x.Target.(*LogFieldSelector_ResourceSchemaUrl); ok {
+			return x.ResourceSchemaUrl
+		}
+	}
+	return false
+}
+
+func (x *LogFieldSelector) GetScopeSchemaUrl() bool {
+	if x != nil {
+		if x, ok := x.Target.(*LogFieldSelector_ScopeSchemaUrl); ok {
+			return x.ScopeSchemaUrl
+		}
+	}
+	return false
+}
+
+type isLogFieldSelector_Target interface {
+	isLogFieldSelector_Target()
+}
+
+type LogFieldSelector_RecordField struct {
+	// Standard first-class OpenTelemetry LogRecord fields.
+	RecordField LogRecordField `protobuf:"varint,1,opt,name=record_field,json=recordField,proto3,enum=google.telemetry.policy.v1alpha1.LogRecordField,oneof"`
+}
+
+type LogFieldSelector_LogAttribute struct {
+	// Log record attribute by key (e.g. "http.route", "user_id").
+	LogAttribute string `protobuf:"bytes,2,opt,name=log_attribute,json=logAttribute,proto3,oneof"`
+}
+
+type LogFieldSelector_ResourceAttribute struct {
+	// Resource attribute by key (e.g. "service.name", "k8s.pod.name").
+	ResourceAttribute string `protobuf:"bytes,3,opt,name=resource_attribute,json=resourceAttribute,proto3,oneof"`
+}
+
+type LogFieldSelector_ScopeAttribute struct {
+	// Instrumentation scope attribute by key (e.g. "library.name").
+	ScopeAttribute string `protobuf:"bytes,4,opt,name=scope_attribute,json=scopeAttribute,proto3,oneof"`
+}
+
+type LogFieldSelector_ScopeName struct {
+	// Matches the Instrumentation Scope name.
+	// (-- api-linter: core::0122::name-suffix=disabled
+	//
+	//	aip.dev/not-precedent: Matches OpenTelemetry InstrumentationScope name. --)
+	ScopeName bool `protobuf:"varint,5,opt,name=scope_name,json=scopeName,proto3,oneof"`
+}
+
+type LogFieldSelector_ScopeVersion struct {
+	// Matches the Instrumentation Scope version.
+	ScopeVersion bool `protobuf:"varint,6,opt,name=scope_version,json=scopeVersion,proto3,oneof"`
+}
+
+type LogFieldSelector_ResourceSchemaUrl struct {
+	// Matches the Resource Schema URL.
+	ResourceSchemaUrl bool `protobuf:"varint,7,opt,name=resource_schema_url,json=resourceSchemaUrl,proto3,oneof"`
+}
+
+type LogFieldSelector_ScopeSchemaUrl struct {
+	// Matches the Instrumentation Scope Schema URL.
+	ScopeSchemaUrl bool `protobuf:"varint,8,opt,name=scope_schema_url,json=scopeSchemaUrl,proto3,oneof"`
+}
+
+func (*LogFieldSelector_RecordField) isLogFieldSelector_Target() {}
+
+func (*LogFieldSelector_LogAttribute) isLogFieldSelector_Target() {}
+
+func (*LogFieldSelector_ResourceAttribute) isLogFieldSelector_Target() {}
+
+func (*LogFieldSelector_ScopeAttribute) isLogFieldSelector_Target() {}
+
+func (*LogFieldSelector_ScopeName) isLogFieldSelector_Target() {}
+
+func (*LogFieldSelector_ScopeVersion) isLogFieldSelector_Target() {}
+
+func (*LogFieldSelector_ResourceSchemaUrl) isLogFieldSelector_Target() {}
+
+func (*LogFieldSelector_ScopeSchemaUrl) isLogFieldSelector_Target() {}
+
 var File_policy_v1alpha1_log_filter_policy_proto protoreflect.FileDescriptor
 
 const file_policy_v1alpha1_log_filter_policy_proto_rawDesc = "" +
 	"\n" +
-	"'policy/v1alpha1/log_filter_policy.proto\x12 google.telemetry.policy.v1alpha1\"\x11\n" +
-	"\x0fLogFilterPolicyB\xc8\x02\n" +
+	"'policy/v1alpha1/log_filter_policy.proto\x12 google.telemetry.policy.v1alpha1\"\xab\x01\n" +
+	"\x0fLogFilterPolicy\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12@\n" +
+	"\x06action\x18\x02 \x01(\x0e2(.google.telemetry.policy.v1alpha1.ActionR\x06action\x12F\n" +
+	"\amatches\x18\x03 \x03(\v2,.google.telemetry.policy.v1alpha1.LogMatcherR\amatches\"\xc7\x01\n" +
+	"\n" +
+	"LogMatcher\x12J\n" +
+	"\x06target\x18\x01 \x01(\v22.google.telemetry.policy.v1alpha1.LogFieldSelectorR\x06target\x12\x18\n" +
+	"\x06exists\x18\n" +
+	" \x01(\bH\x00R\x06exists\x12\x16\n" +
+	"\x05exact\x18\v \x01(\tH\x00R\x05exact\x12\x16\n" +
+	"\x05regex\x18\f \x01(\tH\x00R\x05regex\x12\x16\n" +
+	"\x06negate\x18\x14 \x01(\bR\x06negateB\v\n" +
+	"\tpredicate\"\x9c\x03\n" +
+	"\x10LogFieldSelector\x12U\n" +
+	"\frecord_field\x18\x01 \x01(\x0e20.google.telemetry.policy.v1alpha1.LogRecordFieldH\x00R\vrecordField\x12%\n" +
+	"\rlog_attribute\x18\x02 \x01(\tH\x00R\flogAttribute\x12/\n" +
+	"\x12resource_attribute\x18\x03 \x01(\tH\x00R\x11resourceAttribute\x12)\n" +
+	"\x0fscope_attribute\x18\x04 \x01(\tH\x00R\x0escopeAttribute\x12\x1f\n" +
+	"\n" +
+	"scope_name\x18\x05 \x01(\bH\x00R\tscopeName\x12%\n" +
+	"\rscope_version\x18\x06 \x01(\bH\x00R\fscopeVersion\x120\n" +
+	"\x13resource_schema_url\x18\a \x01(\bH\x00R\x11resourceSchemaUrl\x12*\n" +
+	"\x10scope_schema_url\x18\b \x01(\bH\x00R\x0escopeSchemaUrlB\b\n" +
+	"\x06target*B\n" +
+	"\x06Action\x12\x16\n" +
+	"\x12ACTION_UNSPECIFIED\x10\x00\x12\x0f\n" +
+	"\vACTION_KEEP\x10\x01\x12\x0f\n" +
+	"\vACTION_DROP\x10\x02*\xd4\x01\n" +
+	"\x0eLogRecordField\x12 \n" +
+	"\x1cLOG_RECORD_FIELD_UNSPECIFIED\x10\x00\x12\x19\n" +
+	"\x15LOG_RECORD_FIELD_BODY\x10\x01\x12\"\n" +
+	"\x1eLOG_RECORD_FIELD_SEVERITY_TEXT\x10\x02\x12$\n" +
+	" LOG_RECORD_FIELD_SEVERITY_NUMBER\x10\x03\x12\x1d\n" +
+	"\x19LOG_RECORD_FIELD_TRACE_ID\x10\x04\x12\x1c\n" +
+	"\x18LOG_RECORD_FIELD_SPAN_ID\x10\x05B\xc8\x02\n" +
 	"$com.google.telemetry.policy.v1alpha1B\x14LogFilterPolicyProtoP\x01Zggithub.com/GoogleCloudPlatform/opentelemetry-operations-collector/gen/go/policy/v1alpha1;policyv1alpha1\xa2\x02\x03GTP\xaa\x02 Google.Telemetry.Policy.V1alpha1\xca\x02 Google\\Telemetry\\Policy\\V1alpha1\xe2\x02,Google\\Telemetry\\Policy\\V1alpha1\\GPBMetadata\xea\x02#Google::Telemetry::Policy::V1alpha1b\x06proto3"
 
 var (
@@ -98,16 +592,25 @@ func file_policy_v1alpha1_log_filter_policy_proto_rawDescGZIP() []byte {
 	return file_policy_v1alpha1_log_filter_policy_proto_rawDescData
 }
 
-var file_policy_v1alpha1_log_filter_policy_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_policy_v1alpha1_log_filter_policy_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_policy_v1alpha1_log_filter_policy_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_policy_v1alpha1_log_filter_policy_proto_goTypes = []any{
-	(*LogFilterPolicy)(nil), // 0: google.telemetry.policy.v1alpha1.LogFilterPolicy
+	(Action)(0),              // 0: google.telemetry.policy.v1alpha1.Action
+	(LogRecordField)(0),      // 1: google.telemetry.policy.v1alpha1.LogRecordField
+	(*LogFilterPolicy)(nil),  // 2: google.telemetry.policy.v1alpha1.LogFilterPolicy
+	(*LogMatcher)(nil),       // 3: google.telemetry.policy.v1alpha1.LogMatcher
+	(*LogFieldSelector)(nil), // 4: google.telemetry.policy.v1alpha1.LogFieldSelector
 }
 var file_policy_v1alpha1_log_filter_policy_proto_depIdxs = []int32{
-	0, // [0:0] is the sub-list for method output_type
-	0, // [0:0] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	0, // 0: google.telemetry.policy.v1alpha1.LogFilterPolicy.action:type_name -> google.telemetry.policy.v1alpha1.Action
+	3, // 1: google.telemetry.policy.v1alpha1.LogFilterPolicy.matches:type_name -> google.telemetry.policy.v1alpha1.LogMatcher
+	4, // 2: google.telemetry.policy.v1alpha1.LogMatcher.target:type_name -> google.telemetry.policy.v1alpha1.LogFieldSelector
+	1, // 3: google.telemetry.policy.v1alpha1.LogFieldSelector.record_field:type_name -> google.telemetry.policy.v1alpha1.LogRecordField
+	4, // [4:4] is the sub-list for method output_type
+	4, // [4:4] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_policy_v1alpha1_log_filter_policy_proto_init() }
@@ -115,18 +618,34 @@ func file_policy_v1alpha1_log_filter_policy_proto_init() {
 	if File_policy_v1alpha1_log_filter_policy_proto != nil {
 		return
 	}
+	file_policy_v1alpha1_log_filter_policy_proto_msgTypes[1].OneofWrappers = []any{
+		(*LogMatcher_Exists)(nil),
+		(*LogMatcher_Exact)(nil),
+		(*LogMatcher_Regex)(nil),
+	}
+	file_policy_v1alpha1_log_filter_policy_proto_msgTypes[2].OneofWrappers = []any{
+		(*LogFieldSelector_RecordField)(nil),
+		(*LogFieldSelector_LogAttribute)(nil),
+		(*LogFieldSelector_ResourceAttribute)(nil),
+		(*LogFieldSelector_ScopeAttribute)(nil),
+		(*LogFieldSelector_ScopeName)(nil),
+		(*LogFieldSelector_ScopeVersion)(nil),
+		(*LogFieldSelector_ResourceSchemaUrl)(nil),
+		(*LogFieldSelector_ScopeSchemaUrl)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_policy_v1alpha1_log_filter_policy_proto_rawDesc), len(file_policy_v1alpha1_log_filter_policy_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   1,
+			NumEnums:      2,
+			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
 		GoTypes:           file_policy_v1alpha1_log_filter_policy_proto_goTypes,
 		DependencyIndexes: file_policy_v1alpha1_log_filter_policy_proto_depIdxs,
+		EnumInfos:         file_policy_v1alpha1_log_filter_policy_proto_enumTypes,
 		MessageInfos:      file_policy_v1alpha1_log_filter_policy_proto_msgTypes,
 	}.Build()
 	File_policy_v1alpha1_log_filter_policy_proto = out.File

--- a/gen/go/policy/v1alpha1/log_filter_policy.pb.go
+++ b/gen/go/policy/v1alpha1/log_filter_policy.pb.go
@@ -281,8 +281,8 @@ type LogFilterPolicy struct {
 	Action *Action `protobuf:"varint,2,opt,name=action,proto3,enum=google.telemetry.policy.v1alpha1.Action,oneof" json:"action,omitempty"`
 	// Conditions evaluated against incoming log records.
 	// All matchers in this list are ANDed together: all conditions must evaluate
-	// to true for the policy action to take effect. If empty, the policy matches
-	// all log records.
+	// to true for the policy action to take effect.
+	// At least one matcher is required; a policy with no matchers is invalid.
 	Matches       []*LogMatcher `protobuf:"bytes,3,rep,name=matches,proto3" json:"matches,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/gen/go/policy/v1alpha1/log_filter_policy.pb.go
+++ b/gen/go/policy/v1alpha1/log_filter_policy.pb.go
@@ -100,10 +100,18 @@ const (
 	// The string severity of the log (e.g. "INFO", "ERROR", "DEBUG").
 	LogRecordField_LOG_RECORD_FIELD_SEVERITY_TEXT LogRecordField = 2
 	// The numerical severity of the log (1-24 per OpenTelemetry specification).
+	// When evaluated against string predicates (`exact`, `regex`), this matches
+	// against the canonical base-10 integer string representation (e.g. "17").
 	LogRecordField_LOG_RECORD_FIELD_SEVERITY_NUMBER LogRecordField = 3
 	// The 16-byte trace identifier associated with the log record.
+	// When evaluated against string predicates (`exact`, `regex`), this matches
+	// against the 32-character lowercase hexadecimal string representation
+	// per the OpenTelemetry / W3C Trace Context specification.
 	LogRecordField_LOG_RECORD_FIELD_TRACE_ID LogRecordField = 4
 	// The 8-byte span identifier associated with the log record.
+	// When evaluated against string predicates (`exact`, `regex`), this matches
+	// against the 16-character lowercase hexadecimal string representation
+	// per the OpenTelemetry / W3C Trace Context specification.
 	LogRecordField_LOG_RECORD_FIELD_SPAN_ID LogRecordField = 5
 )
 

--- a/gen/go/policy/v1alpha1/log_filter_policy.pb.go
+++ b/gen/go/policy/v1alpha1/log_filter_policy.pb.go
@@ -278,7 +278,7 @@ type LogFilterPolicy struct {
 	// (e.g. "drop-noisy-healthchecks", "retain-error-logs").
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// The filtering action to take when all `matches` conditions evaluate to true.
-	Action Action `protobuf:"varint,2,opt,name=action,proto3,enum=google.telemetry.policy.v1alpha1.Action" json:"action,omitempty"`
+	Action *Action `protobuf:"varint,2,opt,name=action,proto3,enum=google.telemetry.policy.v1alpha1.Action,oneof" json:"action,omitempty"`
 	// Conditions evaluated against incoming log records.
 	// All matchers in this list are ANDed together: all conditions must evaluate
 	// to true for the policy action to take effect. If empty, the policy matches
@@ -326,8 +326,8 @@ func (x *LogFilterPolicy) GetId() string {
 }
 
 func (x *LogFilterPolicy) GetAction() Action {
-	if x != nil {
-		return x.Action
+	if x != nil && x.Action != nil {
+		return *x.Action
 	}
 	return Action_ACTION_UNSPECIFIED
 }
@@ -620,11 +620,12 @@ var File_policy_v1alpha1_log_filter_policy_proto protoreflect.FileDescriptor
 
 const file_policy_v1alpha1_log_filter_policy_proto_rawDesc = "" +
 	"\n" +
-	"'policy/v1alpha1/log_filter_policy.proto\x12 google.telemetry.policy.v1alpha1\x1a\x1bgoogle/protobuf/empty.proto\"\xab\x01\n" +
+	"'policy/v1alpha1/log_filter_policy.proto\x12 google.telemetry.policy.v1alpha1\x1a\x1bgoogle/protobuf/empty.proto\"\xbb\x01\n" +
 	"\x0fLogFilterPolicy\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\x12@\n" +
-	"\x06action\x18\x02 \x01(\x0e2(.google.telemetry.policy.v1alpha1.ActionR\x06action\x12F\n" +
-	"\amatches\x18\x03 \x03(\v2,.google.telemetry.policy.v1alpha1.LogMatcherR\amatches\"\xdf\x01\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12E\n" +
+	"\x06action\x18\x02 \x01(\x0e2(.google.telemetry.policy.v1alpha1.ActionH\x00R\x06action\x88\x01\x01\x12F\n" +
+	"\amatches\x18\x03 \x03(\v2,.google.telemetry.policy.v1alpha1.LogMatcherR\amatchesB\t\n" +
+	"\a_action\"\xdf\x01\n" +
 	"\n" +
 	"LogMatcher\x12J\n" +
 	"\x06target\x18\x01 \x01(\v22.google.telemetry.policy.v1alpha1.LogFieldSelectorR\x06target\x120\n" +
@@ -709,6 +710,7 @@ func file_policy_v1alpha1_log_filter_policy_proto_init() {
 	if File_policy_v1alpha1_log_filter_policy_proto != nil {
 		return
 	}
+	file_policy_v1alpha1_log_filter_policy_proto_msgTypes[0].OneofWrappers = []any{}
 	file_policy_v1alpha1_log_filter_policy_proto_msgTypes[1].OneofWrappers = []any{
 		(*LogMatcher_Exists)(nil),
 		(*LogMatcher_Exact)(nil),

--- a/gen/go/policy/v1alpha1/log_filter_policy_test.go
+++ b/gen/go/policy/v1alpha1/log_filter_policy_test.go
@@ -76,8 +76,8 @@ func TestLogFilterPolicy_Serialization(t *testing.T) {
 			},
 			{
 				Target: &policyv1alpha1.LogFieldSelector{
-					Target: &policyv1alpha1.LogFieldSelector_ScopeName{
-						ScopeName: true,
+					Target: &policyv1alpha1.LogFieldSelector_ScopeField{
+						ScopeField: policyv1alpha1.ScopeField_SCOPE_FIELD_NAME,
 					},
 				},
 				Predicate: &policyv1alpha1.LogMatcher_Exact{
@@ -86,8 +86,8 @@ func TestLogFilterPolicy_Serialization(t *testing.T) {
 			},
 			{
 				Target: &policyv1alpha1.LogFieldSelector{
-					Target: &policyv1alpha1.LogFieldSelector_ScopeVersion{
-						ScopeVersion: true,
+					Target: &policyv1alpha1.LogFieldSelector_ScopeField{
+						ScopeField: policyv1alpha1.ScopeField_SCOPE_FIELD_VERSION,
 					},
 				},
 				Predicate: &policyv1alpha1.LogMatcher_Exact{
@@ -96,8 +96,8 @@ func TestLogFilterPolicy_Serialization(t *testing.T) {
 			},
 			{
 				Target: &policyv1alpha1.LogFieldSelector{
-					Target: &policyv1alpha1.LogFieldSelector_ResourceSchemaUrl{
-						ResourceSchemaUrl: true,
+					Target: &policyv1alpha1.LogFieldSelector_ResourceField{
+						ResourceField: policyv1alpha1.ResourceField_RESOURCE_FIELD_SCHEMA_URL,
 					},
 				},
 				Predicate: &policyv1alpha1.LogMatcher_Exact{
@@ -106,8 +106,8 @@ func TestLogFilterPolicy_Serialization(t *testing.T) {
 			},
 			{
 				Target: &policyv1alpha1.LogFieldSelector{
-					Target: &policyv1alpha1.LogFieldSelector_ScopeSchemaUrl{
-						ScopeSchemaUrl: true,
+					Target: &policyv1alpha1.LogFieldSelector_ScopeField{
+						ScopeField: policyv1alpha1.ScopeField_SCOPE_FIELD_SCHEMA_URL,
 					},
 				},
 				Predicate: &policyv1alpha1.LogMatcher_Exact{
@@ -116,6 +116,7 @@ func TestLogFilterPolicy_Serialization(t *testing.T) {
 			},
 		},
 	}
+
 
 	// Verify Any packaging.
 	anyPolicy, err := anypb.New(policy)

--- a/gen/go/policy/v1alpha1/log_filter_policy_test.go
+++ b/gen/go/policy/v1alpha1/log_filter_policy_test.go
@@ -97,16 +97,6 @@ func TestLogFilterPolicy_Serialization(t *testing.T) {
 			},
 			{
 				Target: &policyv1alpha1.LogFieldSelector{
-					Target: &policyv1alpha1.LogFieldSelector_ResourceField{
-						ResourceField: policyv1alpha1.ResourceField_RESOURCE_FIELD_SCHEMA_URL,
-					},
-				},
-				Predicate: &policyv1alpha1.LogMatcher_Exact{
-					Exact: "https://opentelemetry.io/schemas/1.24.0",
-				},
-			},
-			{
-				Target: &policyv1alpha1.LogFieldSelector{
 					Target: &policyv1alpha1.LogFieldSelector_ScopeField{
 						ScopeField: policyv1alpha1.ScopeField_SCOPE_FIELD_SCHEMA_URL,
 					},
@@ -134,7 +124,7 @@ func TestLogFilterPolicy_Serialization(t *testing.T) {
 	assert.Equal(t, "drop-noisy-healthchecks", unmarshaled.GetId())
 	assert.NotNil(t, unmarshaled.Action)
 	assert.Equal(t, policyv1alpha1.Action_ACTION_DROP, unmarshaled.GetAction())
-	require.Len(t, unmarshaled.GetMatches(), 8)
+	require.Len(t, unmarshaled.GetMatches(), 7)
 }
 
 func TestLogFilterPolicy_JSONSerialization(t *testing.T) {
@@ -155,8 +145,8 @@ func TestLogFilterPolicy_JSONSerialization(t *testing.T) {
 			},
 			{
 				Target: &policyv1alpha1.LogFieldSelector{
-					Target: &policyv1alpha1.LogFieldSelector_ResourceField{
-						ResourceField: policyv1alpha1.ResourceField_RESOURCE_FIELD_SCHEMA_URL,
+					Target: &policyv1alpha1.LogFieldSelector_ScopeField{
+						ScopeField: policyv1alpha1.ScopeField_SCOPE_FIELD_SCHEMA_URL,
 					},
 				},
 				Predicate: &policyv1alpha1.LogMatcher_Exists{
@@ -166,6 +156,7 @@ func TestLogFilterPolicy_JSONSerialization(t *testing.T) {
 			},
 		},
 	}
+
 
 	// ProtoJSON marshal and unmarshal round-trip.
 	jsonData, err := protojson.Marshal(policy)

--- a/gen/go/policy/v1alpha1/log_filter_policy_test.go
+++ b/gen/go/policy/v1alpha1/log_filter_policy_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policyv1alpha1_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	policyv1alpha1 "github.com/GoogleCloudPlatform/opentelemetry-operations-collector/gen/go/policy/v1alpha1"
+)
+
+func TestLogFilterPolicy_Serialization(t *testing.T) {
+	policy := &policyv1alpha1.LogFilterPolicy{
+		Id:     "drop-noisy-healthchecks",
+		Action: policyv1alpha1.Action_ACTION_DROP,
+		Matches: []*policyv1alpha1.LogMatcher{
+			{
+				Target: &policyv1alpha1.LogFieldSelector{
+					Target: &policyv1alpha1.LogFieldSelector_RecordField{
+						RecordField: policyv1alpha1.LogRecordField_LOG_RECORD_FIELD_BODY,
+					},
+				},
+				Predicate: &policyv1alpha1.LogMatcher_Regex{
+					Regex: "^healthcheck.*",
+				},
+				Negate: false,
+			},
+			{
+				Target: &policyv1alpha1.LogFieldSelector{
+					Target: &policyv1alpha1.LogFieldSelector_LogAttribute{
+						LogAttribute: "http.route",
+					},
+				},
+				Predicate: &policyv1alpha1.LogMatcher_Exact{
+					Exact: "/healthz",
+				},
+			},
+			{
+				Target: &policyv1alpha1.LogFieldSelector{
+					Target: &policyv1alpha1.LogFieldSelector_ResourceAttribute{
+						ResourceAttribute: "service.name",
+					},
+				},
+				Predicate: &policyv1alpha1.LogMatcher_Exists{
+					Exists: true,
+				},
+				Negate: true,
+			},
+			{
+				Target: &policyv1alpha1.LogFieldSelector{
+					Target: &policyv1alpha1.LogFieldSelector_ScopeAttribute{
+						ScopeAttribute: "library.name",
+					},
+				},
+				Predicate: &policyv1alpha1.LogMatcher_Exact{
+					Exact: "my-library",
+				},
+			},
+			{
+				Target: &policyv1alpha1.LogFieldSelector{
+					Target: &policyv1alpha1.LogFieldSelector_ScopeName{
+						ScopeName: true,
+					},
+				},
+				Predicate: &policyv1alpha1.LogMatcher_Exact{
+					Exact: "my-scope",
+				},
+			},
+			{
+				Target: &policyv1alpha1.LogFieldSelector{
+					Target: &policyv1alpha1.LogFieldSelector_ScopeVersion{
+						ScopeVersion: true,
+					},
+				},
+				Predicate: &policyv1alpha1.LogMatcher_Exact{
+					Exact: "v1.2.3",
+				},
+			},
+			{
+				Target: &policyv1alpha1.LogFieldSelector{
+					Target: &policyv1alpha1.LogFieldSelector_ResourceSchemaUrl{
+						ResourceSchemaUrl: true,
+					},
+				},
+				Predicate: &policyv1alpha1.LogMatcher_Exact{
+					Exact: "https://opentelemetry.io/schemas/1.24.0",
+				},
+			},
+			{
+				Target: &policyv1alpha1.LogFieldSelector{
+					Target: &policyv1alpha1.LogFieldSelector_ScopeSchemaUrl{
+						ScopeSchemaUrl: true,
+					},
+				},
+				Predicate: &policyv1alpha1.LogMatcher_Exact{
+					Exact: "https://opentelemetry.io/schemas/1.24.0",
+				},
+			},
+		},
+	}
+
+	// Verify Any packaging.
+	anyPolicy, err := anypb.New(policy)
+	require.NoError(t, err)
+	assert.Equal(t, "type.googleapis.com/google.telemetry.policy.v1alpha1.LogFilterPolicy", anyPolicy.GetTypeUrl())
+
+	// Round-trip serialization.
+	data, err := proto.Marshal(policy)
+	require.NoError(t, err)
+
+	unmarshaled := &policyv1alpha1.LogFilterPolicy{}
+	require.NoError(t, proto.Unmarshal(data, unmarshaled))
+
+	assert.True(t, proto.Equal(policy, unmarshaled))
+	assert.Equal(t, "drop-noisy-healthchecks", unmarshaled.GetId())
+	assert.Equal(t, policyv1alpha1.Action_ACTION_DROP, unmarshaled.GetAction())
+	require.Len(t, unmarshaled.GetMatches(), 8)
+}

--- a/gen/go/policy/v1alpha1/log_filter_policy_test.go
+++ b/gen/go/policy/v1alpha1/log_filter_policy_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -63,7 +64,6 @@ func TestLogFilterPolicy_Serialization(t *testing.T) {
 				},
 				Negate: true,
 			},
-
 			{
 				Target: &policyv1alpha1.LogFieldSelector{
 					Target: &policyv1alpha1.LogFieldSelector_ScopeAttribute{
@@ -117,7 +117,6 @@ func TestLogFilterPolicy_Serialization(t *testing.T) {
 		},
 	}
 
-
 	// Verify Any packaging.
 	anyPolicy, err := anypb.New(policy)
 	require.NoError(t, err)
@@ -135,3 +134,62 @@ func TestLogFilterPolicy_Serialization(t *testing.T) {
 	assert.Equal(t, policyv1alpha1.Action_ACTION_DROP, unmarshaled.GetAction())
 	require.Len(t, unmarshaled.GetMatches(), 8)
 }
+
+func TestLogFilterPolicy_JSONSerialization(t *testing.T) {
+	policy := &policyv1alpha1.LogFilterPolicy{
+		Id:     "drop-noisy-healthchecks",
+		Action: policyv1alpha1.Action_ACTION_DROP,
+		Matches: []*policyv1alpha1.LogMatcher{
+			{
+				Target: &policyv1alpha1.LogFieldSelector{
+					Target: &policyv1alpha1.LogFieldSelector_LogAttribute{
+						LogAttribute: "http.route",
+					},
+				},
+				Predicate: &policyv1alpha1.LogMatcher_Exact{
+					Exact: "/healthz",
+				},
+				Negate: false,
+			},
+			{
+				Target: &policyv1alpha1.LogFieldSelector{
+					Target: &policyv1alpha1.LogFieldSelector_ResourceField{
+						ResourceField: policyv1alpha1.ResourceField_RESOURCE_FIELD_SCHEMA_URL,
+					},
+				},
+				Predicate: &policyv1alpha1.LogMatcher_Exists{
+					Exists: &emptypb.Empty{},
+				},
+				Negate: true,
+			},
+		},
+	}
+
+	// ProtoJSON marshal and unmarshal round-trip.
+	jsonData, err := protojson.Marshal(policy)
+	require.NoError(t, err)
+
+	unmarshaled := &policyv1alpha1.LogFilterPolicy{}
+	require.NoError(t, protojson.Unmarshal(jsonData, unmarshaled))
+	assert.True(t, proto.Equal(policy, unmarshaled))
+
+	// Zero-value handling: ACTION_UNSPECIFIED explicit.
+	jsonWithUnspecified := []byte(`{"id": "unspecified-policy", "action": "ACTION_UNSPECIFIED"}`)
+	zeroPolicy := &policyv1alpha1.LogFilterPolicy{}
+	require.NoError(t, protojson.Unmarshal(jsonWithUnspecified, zeroPolicy))
+	assert.Equal(t, "unspecified-policy", zeroPolicy.GetId())
+	assert.Equal(t, policyv1alpha1.Action_ACTION_UNSPECIFIED, zeroPolicy.GetAction())
+
+	// Action omitted in JSON defaults to ACTION_UNSPECIFIED.
+	jsonOmittedAction := []byte(`{"id": "omitted-action-policy"}`)
+	omittedPolicy := &policyv1alpha1.LogFilterPolicy{}
+	require.NoError(t, protojson.Unmarshal(jsonOmittedAction, omittedPolicy))
+	assert.Equal(t, "omitted-action-policy", omittedPolicy.GetId())
+	assert.Equal(t, policyv1alpha1.Action_ACTION_UNSPECIFIED, omittedPolicy.GetAction())
+
+	// EmitUnpopulated includes ACTION_UNSPECIFIED in output.
+	marshaledUnpopulated, err := protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(zeroPolicy)
+	require.NoError(t, err)
+	assert.Contains(t, string(marshaledUnpopulated), `"action":"ACTION_UNSPECIFIED"`)
+}
+

--- a/gen/go/policy/v1alpha1/log_filter_policy_test.go
+++ b/gen/go/policy/v1alpha1/log_filter_policy_test.go
@@ -30,8 +30,9 @@ import (
 func TestLogFilterPolicy_Serialization(t *testing.T) {
 	policy := &policyv1alpha1.LogFilterPolicy{
 		Id:     "drop-noisy-healthchecks",
-		Action: policyv1alpha1.Action_ACTION_DROP,
+		Action: policyv1alpha1.Action_ACTION_DROP.Enum(),
 		Matches: []*policyv1alpha1.LogMatcher{
+
 			{
 				Target: &policyv1alpha1.LogFieldSelector{
 					Target: &policyv1alpha1.LogFieldSelector_RecordField{
@@ -131,6 +132,7 @@ func TestLogFilterPolicy_Serialization(t *testing.T) {
 
 	assert.True(t, proto.Equal(policy, unmarshaled))
 	assert.Equal(t, "drop-noisy-healthchecks", unmarshaled.GetId())
+	assert.NotNil(t, unmarshaled.Action)
 	assert.Equal(t, policyv1alpha1.Action_ACTION_DROP, unmarshaled.GetAction())
 	require.Len(t, unmarshaled.GetMatches(), 8)
 }
@@ -138,7 +140,7 @@ func TestLogFilterPolicy_Serialization(t *testing.T) {
 func TestLogFilterPolicy_JSONSerialization(t *testing.T) {
 	policy := &policyv1alpha1.LogFilterPolicy{
 		Id:     "drop-noisy-healthchecks",
-		Action: policyv1alpha1.Action_ACTION_DROP,
+		Action: policyv1alpha1.Action_ACTION_DROP.Enum(),
 		Matches: []*policyv1alpha1.LogMatcher{
 			{
 				Target: &policyv1alpha1.LogFieldSelector{
@@ -172,19 +174,22 @@ func TestLogFilterPolicy_JSONSerialization(t *testing.T) {
 	unmarshaled := &policyv1alpha1.LogFilterPolicy{}
 	require.NoError(t, protojson.Unmarshal(jsonData, unmarshaled))
 	assert.True(t, proto.Equal(policy, unmarshaled))
+	assert.NotNil(t, unmarshaled.Action)
 
 	// Zero-value handling: ACTION_UNSPECIFIED explicit.
 	jsonWithUnspecified := []byte(`{"id": "unspecified-policy", "action": "ACTION_UNSPECIFIED"}`)
 	zeroPolicy := &policyv1alpha1.LogFilterPolicy{}
 	require.NoError(t, protojson.Unmarshal(jsonWithUnspecified, zeroPolicy))
 	assert.Equal(t, "unspecified-policy", zeroPolicy.GetId())
+	assert.NotNil(t, zeroPolicy.Action)
 	assert.Equal(t, policyv1alpha1.Action_ACTION_UNSPECIFIED, zeroPolicy.GetAction())
 
-	// Action omitted in JSON defaults to ACTION_UNSPECIFIED.
+	// Action omitted in JSON defaults to ACTION_UNSPECIFIED but Action pointer is nil.
 	jsonOmittedAction := []byte(`{"id": "omitted-action-policy"}`)
 	omittedPolicy := &policyv1alpha1.LogFilterPolicy{}
 	require.NoError(t, protojson.Unmarshal(jsonOmittedAction, omittedPolicy))
 	assert.Equal(t, "omitted-action-policy", omittedPolicy.GetId())
+	assert.Nil(t, omittedPolicy.Action)
 	assert.Equal(t, policyv1alpha1.Action_ACTION_UNSPECIFIED, omittedPolicy.GetAction())
 
 	// EmitUnpopulated includes ACTION_UNSPECIFIED in output.
@@ -192,4 +197,6 @@ func TestLogFilterPolicy_JSONSerialization(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(marshaledUnpopulated), `"action":"ACTION_UNSPECIFIED"`)
 }
+
+
 

--- a/gen/go/policy/v1alpha1/log_filter_policy_test.go
+++ b/gen/go/policy/v1alpha1/log_filter_policy_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	policyv1alpha1 "github.com/GoogleCloudPlatform/opentelemetry-operations-collector/gen/go/policy/v1alpha1"
 )
@@ -58,10 +59,11 @@ func TestLogFilterPolicy_Serialization(t *testing.T) {
 					},
 				},
 				Predicate: &policyv1alpha1.LogMatcher_Exists{
-					Exists: true,
+					Exists: &emptypb.Empty{},
 				},
 				Negate: true,
 			},
+
 			{
 				Target: &policyv1alpha1.LogFieldSelector{
 					Target: &policyv1alpha1.LogFieldSelector_ScopeAttribute{

--- a/proto/policy/v1alpha1/log_filter_policy.proto
+++ b/proto/policy/v1alpha1/log_filter_policy.proto
@@ -26,7 +26,7 @@ option go_package = "github.com/GoogleCloudPlatform/opentelemetry-operations-col
 // Policies are declarative, atomic, and transport-agnostic.
 message LogFilterPolicy {
   // Unique identifier for the policy within its configuration scope
-  // (e.g. "drop-noisy-healthchecks", "retain-error-logs").
+  // (e.g. a UUID or namespaced URI like "io.opentelemetry.operator/{namespace}/policies/retain-error-logs").
   string id = 1;
 
   // The filtering action to take when all `matches` conditions evaluate to true.

--- a/proto/policy/v1alpha1/log_filter_policy.proto
+++ b/proto/policy/v1alpha1/log_filter_policy.proto
@@ -59,7 +59,7 @@ message LogMatcher {
   }
 
   // If true, inverts the result of the predicate (logical NOT).
-  bool negate = 20;
+  bool negate = 2;
 }
 
 // LogFieldSelector designates a first-class OTel log field, attribute, or metadata.

--- a/proto/policy/v1alpha1/log_filter_policy.proto
+++ b/proto/policy/v1alpha1/log_filter_policy.proto
@@ -18,11 +18,108 @@ package google.telemetry.policy.v1alpha1;
 
 option go_package = "github.com/GoogleCloudPlatform/opentelemetry-operations-collector/gen/go/policy/v1alpha1;policyv1alpha1";
 
-// LogFilterPolicy defines an intent-based rule for filtering log records.
+// LogFilterPolicy defines an intent-based rule for retaining or dropping
+// log records based on structured field and attribute matches.
 //
-// Policies are declarative and transport-agnostic.
-//
-// Note: Detailed filter conditions, matchers, and action semantics are deferred
-// to a subsequent design. This message is currently stubbed to establish the
-// package hierarchy, repository organization, and xDS transport plumbing.
-message LogFilterPolicy {}
+// Policies are declarative, atomic, and transport-agnostic.
+message LogFilterPolicy {
+  // Unique identifier for the policy within its configuration scope
+  // (e.g. "drop-noisy-healthchecks", "retain-error-logs").
+  string id = 1;
+
+  // The filtering action to take when all `matches` conditions evaluate to true.
+  Action action = 2;
+
+  // Conditions evaluated against incoming log records.
+  // All matchers in this list are ANDed together: all conditions must evaluate
+  // to true for the policy action to take effect. If empty, the policy matches
+  // all log records.
+  repeated LogMatcher matches = 3;
+}
+
+// LogMatcher defines a single predicate evaluated against a specific log field
+// or attribute.
+message LogMatcher {
+  // The field, attribute, or metadata to inspect. Exactly one must be set.
+  LogFieldSelector target = 1;
+
+  // The comparison predicate to evaluate against the target value.
+  // Exactly one predicate must be set.
+  oneof predicate {
+    // Matches if the selected field or attribute exists.
+    bool exists = 10;
+
+    // Exact string equality match.
+    string exact = 11;
+
+    // Regular expression match using RE2 syntax.
+    string regex = 12;
+  }
+
+  // If true, inverts the result of the predicate (logical NOT).
+  bool negate = 20;
+}
+
+// LogFieldSelector designates a first-class OTel log field, attribute, or metadata.
+message LogFieldSelector {
+  oneof target {
+    // Standard first-class OpenTelemetry LogRecord fields.
+    LogRecordField record_field = 1;
+
+    // Log record attribute by key (e.g. "http.route", "user_id").
+    string log_attribute = 2;
+
+    // Resource attribute by key (e.g. "service.name", "k8s.pod.name").
+    string resource_attribute = 3;
+
+    // Instrumentation scope attribute by key (e.g. "library.name").
+    string scope_attribute = 4;
+
+    // Matches the Instrumentation Scope name.
+    // (-- api-linter: core::0122::name-suffix=disabled
+    //     aip.dev/not-precedent: Matches OpenTelemetry InstrumentationScope name. --)
+    bool scope_name = 5;
+
+    // Matches the Instrumentation Scope version.
+    bool scope_version = 6;
+
+    // Matches the Resource Schema URL.
+    bool resource_schema_url = 7;
+
+    // Matches the Instrumentation Scope Schema URL.
+    bool scope_schema_url = 8;
+  }
+}
+
+// Action specifies what to do with a log record that matches all conditions.
+enum Action {
+  // Default unspecified action. A policy with an unspecified action is invalid.
+  ACTION_UNSPECIFIED = 0;
+
+  // Keep the matching log record and forward it to downstream pipelines.
+  ACTION_KEEP = 1;
+
+  // Drop the matching log record completely.
+  ACTION_DROP = 2;
+}
+
+// LogRecordField identifies standard first-class fields of an OpenTelemetry LogRecord.
+enum LogRecordField {
+  // Default unspecified log record field.
+  LOG_RECORD_FIELD_UNSPECIFIED = 0;
+
+  // The primary message body of the log record.
+  LOG_RECORD_FIELD_BODY = 1;
+
+  // The string severity of the log (e.g. "INFO", "ERROR", "DEBUG").
+  LOG_RECORD_FIELD_SEVERITY_TEXT = 2;
+
+  // The numerical severity of the log (1-24 per OpenTelemetry specification).
+  LOG_RECORD_FIELD_SEVERITY_NUMBER = 3;
+
+  // The 16-byte trace identifier associated with the log record.
+  LOG_RECORD_FIELD_TRACE_ID = 4;
+
+  // The 8-byte span identifier associated with the log record.
+  LOG_RECORD_FIELD_SPAN_ID = 5;
+}

--- a/proto/policy/v1alpha1/log_filter_policy.proto
+++ b/proto/policy/v1alpha1/log_filter_policy.proto
@@ -109,12 +109,20 @@ enum LogRecordField {
   LOG_RECORD_FIELD_SEVERITY_TEXT = 2;
 
   // The numerical severity of the log (1-24 per OpenTelemetry specification).
+  // When evaluated against string predicates (`exact`, `regex`), this matches
+  // against the canonical base-10 integer string representation (e.g. "17").
   LOG_RECORD_FIELD_SEVERITY_NUMBER = 3;
 
   // The 16-byte trace identifier associated with the log record.
+  // When evaluated against string predicates (`exact`, `regex`), this matches
+  // against the 32-character lowercase hexadecimal string representation
+  // per the OpenTelemetry / W3C Trace Context specification.
   LOG_RECORD_FIELD_TRACE_ID = 4;
 
   // The 8-byte span identifier associated with the log record.
+  // When evaluated against string predicates (`exact`, `regex`), this matches
+  // against the 16-character lowercase hexadecimal string representation
+  // per the OpenTelemetry / W3C Trace Context specification.
   LOG_RECORD_FIELD_SPAN_ID = 5;
 }
 

--- a/proto/policy/v1alpha1/log_filter_policy.proto
+++ b/proto/policy/v1alpha1/log_filter_policy.proto
@@ -34,8 +34,8 @@ message LogFilterPolicy {
 
   // Conditions evaluated against incoming log records.
   // All matchers in this list are ANDed together: all conditions must evaluate
-  // to true for the policy action to take effect. If empty, the policy matches
-  // all log records.
+  // to true for the policy action to take effect.
+  // At least one matcher is required; a policy with no matchers is invalid.
   repeated LogMatcher matches = 3;
 }
 

--- a/proto/policy/v1alpha1/log_filter_policy.proto
+++ b/proto/policy/v1alpha1/log_filter_policy.proto
@@ -77,19 +77,11 @@ message LogFieldSelector {
     // Instrumentation scope attribute by key (e.g. "library.name").
     string scope_attribute = 4;
 
-    // Matches the Instrumentation Scope name.
-    // (-- api-linter: core::0122::name-suffix=disabled
-    //     aip.dev/not-precedent: Matches OpenTelemetry InstrumentationScope name. --)
-    bool scope_name = 5;
+    // Standard first-class OpenTelemetry InstrumentationScope fields.
+    ScopeField scope_field = 5;
 
-    // Matches the Instrumentation Scope version.
-    bool scope_version = 6;
-
-    // Matches the Resource Schema URL.
-    bool resource_schema_url = 7;
-
-    // Matches the Instrumentation Scope Schema URL.
-    bool scope_schema_url = 8;
+    // Standard first-class OpenTelemetry Resource fields.
+    ResourceField resource_field = 6;
   }
 }
 
@@ -124,4 +116,28 @@ enum LogRecordField {
 
   // The 8-byte span identifier associated with the log record.
   LOG_RECORD_FIELD_SPAN_ID = 5;
+}
+
+// ScopeField identifies standard first-class fields of an InstrumentationScope.
+enum ScopeField {
+  // Default unspecified scope field.
+  SCOPE_FIELD_UNSPECIFIED = 0;
+
+  // The name of the instrumentation scope (e.g. library or package name).
+  SCOPE_FIELD_NAME = 1;
+
+  // The version of the instrumentation scope.
+  SCOPE_FIELD_VERSION = 2;
+
+  // The schema URL of the instrumentation scope.
+  SCOPE_FIELD_SCHEMA_URL = 3;
+}
+
+// ResourceField identifies standard first-class fields of a Resource.
+enum ResourceField {
+  // Default unspecified resource field.
+  RESOURCE_FIELD_UNSPECIFIED = 0;
+
+  // The schema URL of the resource.
+  RESOURCE_FIELD_SCHEMA_URL = 1;
 }

--- a/proto/policy/v1alpha1/log_filter_policy.proto
+++ b/proto/policy/v1alpha1/log_filter_policy.proto
@@ -16,6 +16,8 @@ syntax = "proto3";
 
 package google.telemetry.policy.v1alpha1;
 
+import "google/protobuf/empty.proto";
+
 option go_package = "github.com/GoogleCloudPlatform/opentelemetry-operations-collector/gen/go/policy/v1alpha1;policyv1alpha1";
 
 // LogFilterPolicy defines an intent-based rule for retaining or dropping
@@ -47,7 +49,7 @@ message LogMatcher {
   // Exactly one predicate must be set.
   oneof predicate {
     // Matches if the selected field or attribute exists.
-    bool exists = 10;
+    google.protobuf.Empty exists = 10;
 
     // Exact string equality match.
     string exact = 11;

--- a/proto/policy/v1alpha1/log_filter_policy.proto
+++ b/proto/policy/v1alpha1/log_filter_policy.proto
@@ -30,7 +30,7 @@ message LogFilterPolicy {
   string id = 1;
 
   // The filtering action to take when all `matches` conditions evaluate to true.
-  Action action = 2;
+  optional Action action = 2;
 
   // Conditions evaluated against incoming log records.
   // All matchers in this list are ANDed together: all conditions must evaluate

--- a/proto/policy/v1alpha1/log_filter_policy.proto
+++ b/proto/policy/v1alpha1/log_filter_policy.proto
@@ -65,22 +65,22 @@ message LogMatcher {
 // LogFieldSelector designates a first-class OTel log field, attribute, or metadata.
 message LogFieldSelector {
   oneof target {
-    // Standard first-class OpenTelemetry LogRecord fields.
+    // Standard first-class OpenTelemetry LogRecord fields (OTLP path: log_record.*).
     LogRecordField record_field = 1;
 
-    // Log record attribute by key (e.g. "http.route", "user_id").
+    // Log record attribute by key (OTLP path: log_record.attributes[*], e.g. "http.route", "user_id").
     string log_attribute = 2;
 
-    // Resource attribute by key (e.g. "service.name", "k8s.pod.name").
+    // Resource attribute by key (OTLP path: resource.attributes[*], e.g. "service.name", "k8s.pod.name").
     string resource_attribute = 3;
 
-    // Instrumentation scope attribute by key (e.g. "library.name").
+    // Instrumentation scope attribute by key (OTLP path: scope.attributes[*], e.g. "library.name").
     string scope_attribute = 4;
 
-    // Standard first-class OpenTelemetry InstrumentationScope fields.
+    // Standard first-class OpenTelemetry InstrumentationScope fields (OTLP path: scope.*).
     ScopeField scope_field = 5;
 
-    // Standard first-class OpenTelemetry Resource fields.
+    // Standard first-class OpenTelemetry Resource fields (OTLP path: resource.*).
     ResourceField resource_field = 6;
   }
 }

--- a/proto/policy/v1alpha1/log_filter_policy.proto
+++ b/proto/policy/v1alpha1/log_filter_policy.proto
@@ -79,9 +79,6 @@ message LogFieldSelector {
 
     // Standard first-class OpenTelemetry InstrumentationScope fields (OTLP path: scope.*).
     ScopeField scope_field = 5;
-
-    // Standard first-class OpenTelemetry Resource fields (OTLP path: resource.*).
-    ResourceField resource_field = 6;
   }
 }
 
@@ -139,13 +136,4 @@ enum ScopeField {
 
   // The schema URL of the instrumentation scope.
   SCOPE_FIELD_SCHEMA_URL = 3;
-}
-
-// ResourceField identifies standard first-class fields of a Resource.
-enum ResourceField {
-  // Default unspecified resource field.
-  RESOURCE_FIELD_UNSPECIFIED = 0;
-
-  // The schema URL of the resource.
-  RESOURCE_FIELD_SCHEMA_URL = 1;
 }


### PR DESCRIPTION
## Description

This PR defines the canonical schema and generated Go bindings for **`LogFilterPolicy`** under `google.telemetry.policy.v1alpha1`, following the merged xDS transport foundation (#631).

`LogFilterPolicy` provides a declarative, transport-agnostic specification for retaining or dropping OpenTelemetry log records.

### Schema Summary
* **`LogFilterPolicy`**: Top-level atomic policy containing an identifier (`id`), an explicit optional action (`action`), and a list of ANDed condition matchers (`matches`). At least one matcher is required to prevent accidental drop-all policies.
* **`Action`**: Strongly typed enum (`ACTION_UNSPECIFIED = 0`, `ACTION_KEEP = 1`, `ACTION_DROP = 2`), marked `optional` per AIP-203 to distinguish omitted action from `ACTION_UNSPECIFIED`. An unspecified action is invalid; fail-open evaluation skips invalid policies at runtime with errors reported.
* **`LogMatcher`**: Evaluates a `LogFieldSelector` against a `oneof predicate` (`exists`, `exact`, or `regex` using RE2 syntax), with a boolean `negate` flag on tag 2.
* **`LogFieldSelector`**: Strongly typed target selecting standard `record_field`s (`BODY`, `SEVERITY_TEXT`, `SEVERITY_NUMBER`, `TRACE_ID`, `SPAN_ID`), flat attribute keys (`log_attribute`, `resource_attribute`, `scope_attribute`), scope metadata via `ScopeField` enum (`scope_field`), or resource metadata via `ResourceField` enum (`resource_field`).

---

## Comparison with OTEP 4738

This schema aligns with the core principles of [OTEP 4738](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/4738-telemetry-policy.md) (declarative, transport-agnostic, fail-open), but introduces intentional structural refinements:

* **Atomic Filtering vs. Multi-Action Envelope**: OTEP 4738 combines filtering, rate-limiting, percentage sampling, and mutations (`redact`/`transform`) into a single object (`"keep": "none"`, `"keep": "50%"`). This PR establishes `LogFilterPolicy` as an atomic boolean filtering policy (`KEEP` vs. `DROP`). Mutations and sampling will be modeled as separate policy types.
* **Typed `Action` Enum vs. Polymorphic String**: OTEP 4738 represents policy behavior via a polymorphic string field (`"keep": "none"` / `"all"` / `"N%"` / `"N/s"`). This PR uses an `optional Action` enum, eliminating string parsing, casing bugs, and ambiguous states in favor of compile-time type safety.
* **`google.protobuf.Empty` for `exists` vs. `bool exists`**: OTEP 4738 examples specify `"exists": true`. In Protobuf, putting `bool exists` inside a `oneof predicate` allows an ambiguous `exists: false` state alongside `negate: true`. Using `google.protobuf.Empty` eliminates this ambiguity: setting `exists` tests for presence, while setting `exists` with `negate: true` tests for absence.
* **Structured Scope and Resource Enums vs. Open Fields**: OTEP 4738 groups schema URLs into `LogField` without dedicated scope selectors. This PR introduces `ScopeField` (`NAME`, `VERSION`, `SCHEMA_URL`) and `ResourceField` (`SCHEMA_URL`) enums, providing strongly typed, extensible selectors while avoiding boolean presence flags in `oneof target`.
* **Flat Attribute Keys vs. Key Arrays**: OTEP 4738 examples use arrays for attribute paths (e.g. `["ccn"]`). This PR uses flat strings (`string log_attribute = 2;`, etc.) to optimize for the vast majority of OTel attributes without heap allocations. Nested path traversal is deferred and can be added later as a separate variant in `oneof target`.
* **String Coercion Specifications**: To prevent evaluator discrepancies across collector implementations, this PR explicitly documents string coercion for non-string fields (`SEVERITY_NUMBER` as base-10 decimal `"17"`, and `TRACE_ID`/`SPAN_ID` as lowercase hex strings).
* **Omission of `name` / `description`**: OTEP 4738 includes human-readable `"name"` and `"description"` fields on policies. In our architecture, policies are wrapped inside `envoy.config.core.v3.TypedExtensionConfig`, where `name` is already the extension identifier. Human-readable descriptions are maintained in management plane APIs (`PolicySet`), keeping wire policy protos minimal.
* **At Least One Matcher Required**: OTEP 4738 specifies that implementations must reject policies with empty matchers. This PR documents this constraint explicitly in the proto to prevent accidental drop-all policies when `ACTION_DROP` is selected.

---

## Alternatives Considered

1. **Open String / Boolean Action (Rejected)**
   * *Considered*: `string action = 2;` or `bool drop = 2;`.
   * *Why Rejected*: Strings invite typo and casing bugs and lack compile-time validation (AIP-126). Booleans lack an explicit `UNSPECIFIED` state and prevent future extension. An enum provides type safety, compile-time constants, and clear invalid/unspecified handling.
2. **`bool exists` vs. `google.protobuf.Empty exists` in `oneof predicate` (Rejected)**
   * *Considered*: `bool exists = 10;`.
   * *Why Rejected*: Allows setting `exists: false`, which creates an ambiguous wire state alongside `bool negate`. Using `google.protobuf.Empty` ensures existence is expressed solely by presence in `oneof`, and absence is expressed by pairing with `negate: true`.
3. **Boolean Flags vs. Enums for Scope/Resource Targets (Rejected)**
   * *Considered*: `bool scope_name = 5;`, `bool scope_version = 6;`, etc.
   * *Why Rejected*: Boolean flags in a `oneof` allow an ambiguous `false` state and triggered AIP-122 linter warnings. Grouping them into `ScopeField` and `ResourceField` enums is cleaner, strongly typed, and extensible.
4. **Unstructured Expression Strings / OTTL / CEL (Rejected)**
   * *Considered*: Defining filter criteria as expression strings (e.g. `attributes["http.route"] == "/healthz"`).
   * *Why Rejected*: Defeats Protobuf’s strongly typed structure, introduces escaping and quoting edge cases, couples the schema to specific expression grammar runtimes, and forces all components to embed expression parsers.
5. **Operator Enum + Value Pair (Rejected)**
   * *Considered*: An enum `Operator { EQUALS = 0; REGEX = 1; EXISTS = 2; }` paired with a `string value = 3;`.
   * *Why Rejected*: Leaves `value` ambiguous and unused for `EXISTS`, and allows invalid state combinations. A `oneof predicate` makes invalid states unrepresentable on the wire while `bool negate` provides clean logical inversion.
6. **Recursive Boolean Expression Trees (Rejected)**
   * *Considered*: Full boolean trees (`all_of`, `any_of`, `none_of`).
   * *Why Rejected*: Turns declarative configuration into a programming language, increasing evaluation latency and complexity. A flat list of ANDed matchers satisfies standard filtering needs; OR semantics are achieved by defining multiple policies in a policy set.

---

## Deferred Features

1. **Nested Attribute Paths**: 99% of OTel attributes use flat string keys (`"http.route"`). A `repeated string path` / `AttributePath` variant can be added to `LogFieldSelector` later without breaking wire compatibility.
2. **Sampling Actions (`ACTION_SAMPLE`)**: Boolean filtering is kept distinct from probabilistic sampling and rate limiting. Sampling can be added as a dedicated action or independent policy type (`LogSamplingPolicy`).
3. **Numeric Range Predicates (`gt`, `gte`, `lt`, `lte`)**: Log filtering is overwhelmingly string- and attribute-based. Numeric comparisons can be introduced as dedicated scalar predicate variants if needed for latency or numerical status thresholds.
4. **Syntactic Sugar Matchers (`starts_with`, `ends_with`, `contains`)**: Prefix, suffix, substring, and case-insensitive matching are already supported via RE2 regexes and exact matching. Dedicated predicate variants can be added later if profiling demonstrates measurable performance gains.
5. **Cross-Policy Priority / Conflict Resolution**: Multi-policy resolution is managed at the policy set / fleet envelope level rather than inside atomic policy definitions.