### PR TITLE
Clarify filter policy semantics and run proto Go tests in CI

### DIFF
--- a/.github/workflows/proto.yaml
+++ b/.github/workflows/proto.yaml
@@ -50,3 +50,15 @@ jobs:
         run: make install-tools
       - name: Verify generated code is up-to-date
         run: make compare-protos
+
+  proto-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version: '1.26'
+          cache: true
+      - name: Test generated proto code
+        run: make test-protos
+

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ setup-hooks:
 	git config core.hooksPath $(PWD)/hooks
 
 .PHONY: precommit
-precommit: checklicense misspell lint compare-all test-distrogen validate-samples
+precommit: checklicense misspell lint compare-all test-distrogen test-protos validate-samples
 
 .PHONY: presubmit
-presubmit: checklicense misspell lint compare-all
+presubmit: checklicense misspell lint compare-all test-protos
 
 
 #######################
@@ -93,6 +93,10 @@ lint-protos: $(BUF) $(API_LINTER)
 .PHONY: compare-protos
 compare-protos: gen-protos
 	@git diff --exit-code gen/go && test -z "$$(git status --porcelain gen/go)" || (echo "Generated proto files in gen/go are out-of-date. Run 'make gen-protos' to regenerate." && exit 1)
+
+.PHONY: test-protos
+test-protos:
+	go test -v ./gen/go/...
 
 .PHONY: gen-all
 gen-all: distrogen-golden-update gen-google-built-otel gen-otelopscol gen-protos

--- a/gen/go/policy/v1alpha1/common_policy_types.pb.go
+++ b/gen/go/policy/v1alpha1/common_policy_types.pb.go
@@ -36,6 +36,15 @@ const (
 )
 
 // Action specifies what to do with a telemetry record that matches all conditions.
+//
+// Evaluation Semantics & Action Precedence:
+//   - Default Allow: Telemetry records or streams pass through by default if no
+//     policy matches.
+//   - Keep Overrides Drop: When multiple policies match a record, ACTION_KEEP
+//     always overrides ACTION_DROP (keep always overrides drop). ACTION_KEEP acts as
+//     an explicit exemption retaining matching records; it does not prune
+//     non-matching records. To implement an allowlist that prunes non-matching
+//     records, authors specify ACTION_DROP with negate: true on the matchers.
 type Action int32
 
 const (
@@ -89,6 +98,8 @@ func (Action) EnumDescriptor() ([]byte, []int) {
 }
 
 // ScopeField identifies standard first-class fields of an InstrumentationScope.
+// For presence checking with `exists`, these fields lack explicit presence
+// tracking in OpenTelemetry and evaluate to true when set to a non-empty string.
 type ScopeField int32
 
 const (

--- a/gen/go/policy/v1alpha1/log_filter_policy.pb.go
+++ b/gen/go/policy/v1alpha1/log_filter_policy.pb.go
@@ -37,6 +37,8 @@ const (
 )
 
 // LogRecordField identifies standard first-class fields of an OpenTelemetry LogRecord.
+// When evaluated with `exists`, first-class fields evaluate to true when set
+// to a non-default (non-empty / non-zero) value.
 type LogRecordField int32
 
 const (
@@ -113,6 +115,15 @@ func (LogRecordField) EnumDescriptor() ([]byte, []int) {
 // log records based on structured field and attribute matches.
 //
 // Policies are declarative, atomic, and transport-agnostic.
+//
+// Evaluation Granularity & Action Precedence:
+//   - Record-Level Granularity: Log records are evaluated individually.
+//   - Action Precedence & Exemptions: Telemetry passes through by default (default
+//     allow). When multiple policies match a log record, ACTION_KEEP always
+//     overrides ACTION_DROP (keep always overrides drop). ACTION_KEEP acts as an
+//     explicit exemption retaining matching log records; it does not prune
+//     non-matching log records. To implement an allowlist that prunes non-matching
+//     log records, authors specify ACTION_DROP with negate: true on the matchers.
 type LogFilterPolicy struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Unique identifier for the policy within its configuration scope
@@ -285,6 +296,11 @@ type isLogMatcher_Predicate interface {
 
 type LogMatcher_Exists struct {
 	// Matches if the selected field or attribute exists.
+	// For attributes, this evaluates to true if the attribute key exists.
+	// For first-class fields (record_field, scope_field) that lack explicit
+	// presence tracking in the OpenTelemetry data model, this evaluates to true
+	// when the field is set to a non-default (non-zero/non-empty) value, and
+	// false when absent or default (e.g. empty string or 0).
 	Exists *emptypb.Empty `protobuf:"bytes,10,opt,name=exists,proto3,oneof"`
 }
 
@@ -295,6 +311,9 @@ type LogMatcher_Exact struct {
 
 type LogMatcher_Regex struct {
 	// Regular expression match using RE2 syntax.
+	// Evaluates as an unanchored partial match (like Go regexp.MatchString and
+	// OpenTelemetry OTTL IsMatch). Callers requiring full string equality must
+	// provide explicit anchors ('^' and '$').
 	Regex string `protobuf:"bytes,12,opt,name=regex,proto3,oneof"`
 }
 

--- a/gen/go/policy/v1alpha1/log_filter_policy_test.go
+++ b/gen/go/policy/v1alpha1/log_filter_policy_test.go
@@ -189,5 +189,14 @@ func TestLogFilterPolicy_JSONSerialization(t *testing.T) {
 	assert.Contains(t, string(marshaledUnpopulated), `"action":"ACTION_UNSPECIFIED"`)
 }
 
+func TestLogFilterPolicy_EnumValues(t *testing.T) {
+	assert.Equal(t, policyv1alpha1.LogRecordField(0), policyv1alpha1.LogRecordField_LOG_RECORD_FIELD_UNSPECIFIED)
+	assert.Equal(t, policyv1alpha1.LogRecordField(1), policyv1alpha1.LogRecordField_LOG_RECORD_FIELD_BODY)
+	assert.Equal(t, policyv1alpha1.LogRecordField(2), policyv1alpha1.LogRecordField_LOG_RECORD_FIELD_SEVERITY_TEXT)
+	assert.Equal(t, policyv1alpha1.LogRecordField(3), policyv1alpha1.LogRecordField_LOG_RECORD_FIELD_SEVERITY_NUMBER)
+	assert.Equal(t, policyv1alpha1.LogRecordField(4), policyv1alpha1.LogRecordField_LOG_RECORD_FIELD_TRACE_ID)
+	assert.Equal(t, policyv1alpha1.LogRecordField(5), policyv1alpha1.LogRecordField_LOG_RECORD_FIELD_SPAN_ID)
+}
+
 
 

--- a/gen/go/policy/v1alpha1/metric_filter_policy.pb.go
+++ b/gen/go/policy/v1alpha1/metric_filter_policy.pb.go
@@ -37,6 +37,8 @@ const (
 )
 
 // MetricDescriptorField identifies top-level descriptor fields of an OpenTelemetry Metric.
+// When evaluated with `exists`, first-class fields evaluate to true when set
+// to a non-default (non-empty / non-zero) value.
 type MetricDescriptorField int32
 
 const (
@@ -307,6 +309,11 @@ type isMetricMatcher_Predicate interface {
 
 type MetricMatcher_Exists struct {
 	// Matches if the selected field or attribute exists.
+	// For attributes, this evaluates to true if the attribute key exists.
+	// For first-class fields (descriptor_field, scope_field) that lack explicit
+	// presence tracking in the OpenTelemetry data model, this evaluates to true
+	// when the field is set to a non-default (non-zero/non-empty) value, and
+	// false when absent or default (e.g. empty string or 0).
 	Exists *emptypb.Empty `protobuf:"bytes,10,opt,name=exists,proto3,oneof"`
 }
 

--- a/gen/go/policy/v1alpha1/trace_filter_policy.pb.go
+++ b/gen/go/policy/v1alpha1/trace_filter_policy.pb.go
@@ -37,6 +37,8 @@ const (
 )
 
 // SpanRecordField identifies standard first-class fields of an OpenTelemetry Span.
+// When evaluated with `exists`, first-class fields evaluate to true when set
+// to a non-default (non-empty / non-zero) value.
 type SpanRecordField int32
 
 const (
@@ -55,15 +57,23 @@ const (
 	// per the OpenTelemetry / W3C Trace Context specification.
 	SpanRecordField_SPAN_RECORD_FIELD_SPAN_ID SpanRecordField = 3
 	// The 8-byte parent span identifier.
-	// When evaluated against string predicates (`exact`, `regex`), this matches
-	// against the 16-character lowercase hexadecimal string representation
-	// per the OpenTelemetry / W3C Trace Context specification.
+	// Root spans have no parent span identifier (in OpenTelemetry data models,
+	// parent_span_id is empty or all zeroes).
+	// When evaluated with `exists`, this evaluates to false for root spans (and true
+	// with `negate: true`, allowing explicit targeting or exemption of root spans).
+	// When evaluated against string predicates (`exact`, `regex`), a root span matches
+	// against the empty string `""`. For child spans, this matches against the
+	// 16-character lowercase hexadecimal string representation per the OpenTelemetry /
+	// W3C Trace Context specification.
 	SpanRecordField_SPAN_RECORD_FIELD_PARENT_SPAN_ID SpanRecordField = 4
 	// The status message describing an error.
 	SpanRecordField_SPAN_RECORD_FIELD_STATUS_MESSAGE SpanRecordField = 5
 	// The span kind (e.g. "INTERNAL", "SERVER", "CLIENT", "PRODUCER", "CONSUMER").
 	// When evaluated against string predicates (`exact`, `regex`), this matches
-	// against uppercase span kind string names.
+	// against uppercase span kind string names without the "SPAN_KIND_" prefix
+	// (matching OpenTelemetry specification conventions). Per the OpenTelemetry
+	// specification, if span kind is unset or SPAN_KIND_UNSPECIFIED,
+	// implementations treat it as "INTERNAL".
 	SpanRecordField_SPAN_RECORD_FIELD_KIND SpanRecordField = 6
 	// The span status code (e.g. "OK", "ERROR", "UNSET").
 	// When evaluated against string predicates (`exact`, `regex`), this matches
@@ -127,6 +137,19 @@ func (SpanRecordField) EnumDescriptor() ([]byte, []int) {
 // spans based on structured field, attribute, and status matches.
 //
 // Policies are declarative, atomic, and transport-agnostic.
+//
+// Evaluation Granularity & Action Precedence:
+//   - Span-Level Granularity: Spans are evaluated independently without trace
+//     reassembly. Filter policies remain fast, stateless, and evaluated per span.
+//   - Independent Decisions & Orphan Spans: Dropping a span does not drop its
+//     descendants. Dropping an intermediate span in a trace leaves child spans
+//     behind as orphans with a dangling parent_span_id.
+//   - Action Precedence & Exemptions: Telemetry passes through by default (default
+//     allow). When multiple policies match a span, ACTION_KEEP always overrides
+//     ACTION_DROP (keep always overrides drop). ACTION_KEEP acts as an explicit
+//     exemption retaining matching spans; it does not prune non-matching spans.
+//     To implement an allowlist that prunes non-matching spans, authors specify
+//     ACTION_DROP with negate: true on the matchers.
 type TraceFilterPolicy struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Unique identifier for the policy within its configuration scope
@@ -299,6 +322,12 @@ type isTraceMatcher_Predicate interface {
 
 type TraceMatcher_Exists struct {
 	// Matches if the selected field or attribute exists.
+	// For attributes, this evaluates to true if the attribute key exists.
+	// For first-class fields (record_field, scope_field) that lack explicit
+	// presence tracking in the OpenTelemetry data model, this evaluates to true
+	// when the field is set to a non-default (non-zero/non-empty) value, and
+	// false when absent or default (e.g. absent parent_span_id on a root span,
+	// or empty string/unset).
 	Exists *emptypb.Empty `protobuf:"bytes,10,opt,name=exists,proto3,oneof"`
 }
 
@@ -309,6 +338,9 @@ type TraceMatcher_Exact struct {
 
 type TraceMatcher_Regex struct {
 	// Regular expression match using RE2 syntax.
+	// Evaluates as an unanchored partial match (like Go regexp.MatchString and
+	// OpenTelemetry OTTL IsMatch). Callers requiring full string equality must
+	// provide explicit anchors ('^' and '$').
 	Regex string `protobuf:"bytes,12,opt,name=regex,proto3,oneof"`
 }
 

--- a/gen/go/policy/v1alpha1/trace_filter_policy_test.go
+++ b/gen/go/policy/v1alpha1/trace_filter_policy_test.go
@@ -260,3 +260,65 @@ func TestTraceFilterPolicy_JSONSerialization(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(marshaledUnpopulated), `"action":"ACTION_UNSPECIFIED"`)
 }
+
+func TestTraceFilterPolicy_ParentSpanIDAndKindMatchers(t *testing.T) {
+	// Policy targeting root spans (absent parent_span_id: exists with negate: true or exact: "")
+	rootSpanPolicy := &policyv1alpha1.TraceFilterPolicy{
+		Id:     "target-root-spans",
+		Action: actionPtr(policyv1alpha1.Action_ACTION_KEEP),
+		Matches: []*policyv1alpha1.TraceMatcher{
+			{
+				Target: &policyv1alpha1.TraceFieldSelector{
+					Target: &policyv1alpha1.TraceFieldSelector_RecordField{
+						RecordField: policyv1alpha1.SpanRecordField_SPAN_RECORD_FIELD_PARENT_SPAN_ID,
+					},
+				},
+				Predicate: &policyv1alpha1.TraceMatcher_Exists{
+					Exists: &emptypb.Empty{},
+				},
+				Negate: true,
+			},
+			{
+				Target: &policyv1alpha1.TraceFieldSelector{
+					Target: &policyv1alpha1.TraceFieldSelector_RecordField{
+						RecordField: policyv1alpha1.SpanRecordField_SPAN_RECORD_FIELD_KIND,
+					},
+				},
+				Predicate: &policyv1alpha1.TraceMatcher_Exact{
+					Exact: "INTERNAL",
+				},
+			},
+		},
+	}
+
+	data, err := proto.Marshal(rootSpanPolicy)
+	require.NoError(t, err)
+
+	unmarshaled := &policyv1alpha1.TraceFilterPolicy{}
+	require.NoError(t, proto.Unmarshal(data, unmarshaled))
+	assert.True(t, proto.Equal(rootSpanPolicy, unmarshaled))
+
+	// Policy targeting child spans with explicit 16-char hex parent_span_id.
+	childSpanPolicy := &policyv1alpha1.TraceFilterPolicy{
+		Id:     "target-child-spans",
+		Action: actionPtr(policyv1alpha1.Action_ACTION_DROP),
+		Matches: []*policyv1alpha1.TraceMatcher{
+			{
+				Target: &policyv1alpha1.TraceFieldSelector{
+					Target: &policyv1alpha1.TraceFieldSelector_RecordField{
+						RecordField: policyv1alpha1.SpanRecordField_SPAN_RECORD_FIELD_PARENT_SPAN_ID,
+					},
+				},
+				Predicate: &policyv1alpha1.TraceMatcher_Exact{
+					Exact: "0123456789abcdef",
+				},
+			},
+		},
+	}
+
+	data, err = proto.Marshal(childSpanPolicy)
+	require.NoError(t, err)
+	unmarshaledChild := &policyv1alpha1.TraceFilterPolicy{}
+	require.NoError(t, proto.Unmarshal(data, unmarshaledChild))
+	assert.True(t, proto.Equal(childSpanPolicy, unmarshaledChild))
+}

--- a/proto/policy/v1alpha1/common_policy_types.proto
+++ b/proto/policy/v1alpha1/common_policy_types.proto
@@ -19,6 +19,15 @@ package google.telemetry.policy.v1alpha1;
 option go_package = "github.com/GoogleCloudPlatform/opentelemetry-operations-collector/gen/go/policy/v1alpha1;policyv1alpha1";
 
 // Action specifies what to do with a telemetry record that matches all conditions.
+//
+// Evaluation Semantics & Action Precedence:
+// - Default Allow: Telemetry records or streams pass through by default if no
+//   policy matches.
+// - Keep Overrides Drop: When multiple policies match a record, ACTION_KEEP
+//   always overrides ACTION_DROP (keep always overrides drop). ACTION_KEEP acts as
+//   an explicit exemption retaining matching records; it does not prune
+//   non-matching records. To implement an allowlist that prunes non-matching
+//   records, authors specify ACTION_DROP with negate: true on the matchers.
 enum Action {
   // Default unspecified action. A policy with an unspecified action is invalid.
   ACTION_UNSPECIFIED = 0;
@@ -31,6 +40,8 @@ enum Action {
 }
 
 // ScopeField identifies standard first-class fields of an InstrumentationScope.
+// For presence checking with `exists`, these fields lack explicit presence
+// tracking in OpenTelemetry and evaluate to true when set to a non-empty string.
 enum ScopeField {
   // Default unspecified scope field.
   SCOPE_FIELD_UNSPECIFIED = 0;

--- a/proto/policy/v1alpha1/log_filter_policy.proto
+++ b/proto/policy/v1alpha1/log_filter_policy.proto
@@ -25,6 +25,15 @@ option go_package = "github.com/GoogleCloudPlatform/opentelemetry-operations-col
 // log records based on structured field and attribute matches.
 //
 // Policies are declarative, atomic, and transport-agnostic.
+//
+// Evaluation Granularity & Action Precedence:
+// - Record-Level Granularity: Log records are evaluated individually.
+// - Action Precedence & Exemptions: Telemetry passes through by default (default
+//   allow). When multiple policies match a log record, ACTION_KEEP always
+//   overrides ACTION_DROP (keep always overrides drop). ACTION_KEEP acts as an
+//   explicit exemption retaining matching log records; it does not prune
+//   non-matching log records. To implement an allowlist that prunes non-matching
+//   log records, authors specify ACTION_DROP with negate: true on the matchers.
 message LogFilterPolicy {
   // Unique identifier for the policy within its configuration scope
   // (e.g. a UUID or namespaced URI like "io.opentelemetry.operator/{namespace}/policies/retain-error-logs").
@@ -50,12 +59,20 @@ message LogMatcher {
   // Exactly one predicate must be set.
   oneof predicate {
     // Matches if the selected field or attribute exists.
+    // For attributes, this evaluates to true if the attribute key exists.
+    // For first-class fields (record_field, scope_field) that lack explicit
+    // presence tracking in the OpenTelemetry data model, this evaluates to true
+    // when the field is set to a non-default (non-zero/non-empty) value, and
+    // false when absent or default (e.g. empty string or 0).
     google.protobuf.Empty exists = 10;
 
     // Exact string equality match.
     string exact = 11;
 
     // Regular expression match using RE2 syntax.
+    // Evaluates as an unanchored partial match (like Go regexp.MatchString and
+    // OpenTelemetry OTTL IsMatch). Callers requiring full string equality must
+    // provide explicit anchors ('^' and '$').
     string regex = 12;
   }
 
@@ -84,6 +101,8 @@ message LogFieldSelector {
 }
 
 // LogRecordField identifies standard first-class fields of an OpenTelemetry LogRecord.
+// When evaluated with `exists`, first-class fields evaluate to true when set
+// to a non-default (non-empty / non-zero) value.
 enum LogRecordField {
   // Default unspecified log record field.
   LOG_RECORD_FIELD_UNSPECIFIED = 0;

--- a/proto/policy/v1alpha1/metric_filter_policy.proto
+++ b/proto/policy/v1alpha1/metric_filter_policy.proto
@@ -71,6 +71,11 @@ message MetricMatcher {
   // Exactly one predicate must be set.
   oneof predicate {
     // Matches if the selected field or attribute exists.
+    // For attributes, this evaluates to true if the attribute key exists.
+    // For first-class fields (descriptor_field, scope_field) that lack explicit
+    // presence tracking in the OpenTelemetry data model, this evaluates to true
+    // when the field is set to a non-default (non-zero/non-empty) value, and
+    // false when absent or default (e.g. empty string or 0).
     google.protobuf.Empty exists = 10;
 
     // Exact string equality match.
@@ -108,6 +113,8 @@ message MetricFieldSelector {
 }
 
 // MetricDescriptorField identifies top-level descriptor fields of an OpenTelemetry Metric.
+// When evaluated with `exists`, first-class fields evaluate to true when set
+// to a non-default (non-empty / non-zero) value.
 enum MetricDescriptorField {
   // Default unspecified metric descriptor field.
   METRIC_DESCRIPTOR_FIELD_UNSPECIFIED = 0;

--- a/proto/policy/v1alpha1/trace_filter_policy.proto
+++ b/proto/policy/v1alpha1/trace_filter_policy.proto
@@ -25,6 +25,19 @@ option go_package = "github.com/GoogleCloudPlatform/opentelemetry-operations-col
 // spans based on structured field, attribute, and status matches.
 //
 // Policies are declarative, atomic, and transport-agnostic.
+//
+// Evaluation Granularity & Action Precedence:
+// - Span-Level Granularity: Spans are evaluated independently without trace
+//   reassembly. Filter policies remain fast, stateless, and evaluated per span.
+// - Independent Decisions & Orphan Spans: Dropping a span does not drop its
+//   descendants. Dropping an intermediate span in a trace leaves child spans
+//   behind as orphans with a dangling parent_span_id.
+// - Action Precedence & Exemptions: Telemetry passes through by default (default
+//   allow). When multiple policies match a span, ACTION_KEEP always overrides
+//   ACTION_DROP (keep always overrides drop). ACTION_KEEP acts as an explicit
+//   exemption retaining matching spans; it does not prune non-matching spans.
+//   To implement an allowlist that prunes non-matching spans, authors specify
+//   ACTION_DROP with negate: true on the matchers.
 message TraceFilterPolicy {
   // Unique identifier for the policy within its configuration scope
   // (e.g. a UUID or namespaced URI like "io.opentelemetry.operator/{namespace}/policies/retain-error-spans").
@@ -50,12 +63,21 @@ message TraceMatcher {
   // Exactly one predicate must be set.
   oneof predicate {
     // Matches if the selected field or attribute exists.
+    // For attributes, this evaluates to true if the attribute key exists.
+    // For first-class fields (record_field, scope_field) that lack explicit
+    // presence tracking in the OpenTelemetry data model, this evaluates to true
+    // when the field is set to a non-default (non-zero/non-empty) value, and
+    // false when absent or default (e.g. absent parent_span_id on a root span,
+    // or empty string/unset).
     google.protobuf.Empty exists = 10;
 
     // Exact string equality match.
     string exact = 11;
 
     // Regular expression match using RE2 syntax.
+    // Evaluates as an unanchored partial match (like Go regexp.MatchString and
+    // OpenTelemetry OTTL IsMatch). Callers requiring full string equality must
+    // provide explicit anchors ('^' and '$').
     string regex = 12;
   }
 
@@ -84,6 +106,8 @@ message TraceFieldSelector {
 }
 
 // SpanRecordField identifies standard first-class fields of an OpenTelemetry Span.
+// When evaluated with `exists`, first-class fields evaluate to true when set
+// to a non-default (non-empty / non-zero) value.
 enum SpanRecordField {
   // Default unspecified span record field.
   SPAN_RECORD_FIELD_UNSPECIFIED = 0;
@@ -104,9 +128,14 @@ enum SpanRecordField {
   SPAN_RECORD_FIELD_SPAN_ID = 3;
 
   // The 8-byte parent span identifier.
-  // When evaluated against string predicates (`exact`, `regex`), this matches
-  // against the 16-character lowercase hexadecimal string representation
-  // per the OpenTelemetry / W3C Trace Context specification.
+  // Root spans have no parent span identifier (in OpenTelemetry data models,
+  // parent_span_id is empty or all zeroes).
+  // When evaluated with `exists`, this evaluates to false for root spans (and true
+  // with `negate: true`, allowing explicit targeting or exemption of root spans).
+  // When evaluated against string predicates (`exact`, `regex`), a root span matches
+  // against the empty string `""`. For child spans, this matches against the
+  // 16-character lowercase hexadecimal string representation per the OpenTelemetry /
+  // W3C Trace Context specification.
   SPAN_RECORD_FIELD_PARENT_SPAN_ID = 4;
 
   // The status message describing an error.
@@ -114,7 +143,10 @@ enum SpanRecordField {
 
   // The span kind (e.g. "INTERNAL", "SERVER", "CLIENT", "PRODUCER", "CONSUMER").
   // When evaluated against string predicates (`exact`, `regex`), this matches
-  // against uppercase span kind string names.
+  // against uppercase span kind string names without the "SPAN_KIND_" prefix
+  // (matching OpenTelemetry specification conventions). Per the OpenTelemetry
+  // specification, if span kind is unset or SPAN_KIND_UNSPECIFIED,
+  // implementations treat it as "INTERNAL".
   SPAN_RECORD_FIELD_KIND = 6;
 
   // The span status code (e.g. "OK", "ERROR", "UNSET").


### PR DESCRIPTION
## Summary

This PR addresses follow-up items from #632 and #635 regarding telemetry filter policy semantics, default values, and CI test coverage for generated protobuf Go code.

## Changes

### 1. Filter Policy Semantics & Precedence Alignment
- **Trace Evaluation Granularity & Orphan Spans (#635)**: Added an `Evaluation Granularity & Action Precedence` section to `TraceFilterPolicy` clarifying that spans are evaluated independently without trace reassembly (stateless, fast, per-span) and warning policy authors that dropping an intermediate span leaves child spans behind with dangling `parent_span_id`s.
- **Shared Action Precedence (#632)**: Documented default allow and keep-overrides-drop precedence in `common_policy_types.proto` on `enum Action`, as well as on `LogFilterPolicy` and `TraceFilterPolicy`, matching `MetricFilterPolicy`.
- **`exists` Predicate Semantics (#632)**: Documented across `LogMatcher`, `TraceMatcher`, and `MetricMatcher` that for first-class fields lacking explicit presence tracking in OpenTelemetry (`record_field`, `descriptor_field`, `scope_field`), `exists` evaluates to true for non-default/non-empty values and false when absent or set to the default zero-value.
- **Unanchored Regex Clarification (#632)**: Documented that `regex` evaluates as an unanchored partial match (matching Go `regexp.MatchString` and OTTL `IsMatch`) across `LogMatcher` and `TraceMatcher`.

### 2. Root Span and Span Kind Defaults (#635)
- **`SPAN_RECORD_FIELD_PARENT_SPAN_ID`**: Explicitly documented that root spans have no parent span ID; `exists` evaluates to false (enabling root-span targeting with `negate: true`), and string predicates match against `""` for root spans versus 16-character hex strings for child spans.
- **`SPAN_RECORD_FIELD_KIND`**: Documented uppercase name matching without the `SPAN_KIND_` prefix and documented that unset or unspecified span kind is treated as `"INTERNAL"` per the OpenTelemetry specification.
- **Tests**: Added `TestTraceFilterPolicy_ParentSpanIDAndKindMatchers` and `TestLogFilterPolicy_EnumValues`.

### 3. Run Proto Go Tests in CI
- Confirmed that tests under `gen/go/...` were not being executed in CI.
- Added a `test-protos` target to `Makefile` (`go test -v ./gen/go/...`) and included it in `presubmit` and `precommit`, ensuring tests run on all pull requests and across matrix Go versions (`1.25`, `1.26`).
- Added a dedicated `proto-test` job in `.github/workflows/proto.yaml`.