### PR TITLE
fix: remove deprecated debian-11 (bullseye) target

### DIFF
--- a/distros.yaml
+++ b/distros.yaml
@@ -25,14 +25,6 @@ targets:
         test_distros:
           representative:
           - debian-cloud:debian-12-arm64
-  bullseye:
-    package_extension:
-      deb
-    architectures:
-      x86_64:
-        test_distros:
-          representative:
-          - debian-cloud:debian-11
   centos8:
     package_extension:
       rpm


### PR DESCRIPTION
Debian 11 has reached end-of-life and its image family (projects/debian-cloud/global/images/family/debian-11) was removed in Google Cloud. Removing the bullseye target removes debian-11 from Kokoro test matrices including TestSmoke.