### PR TITLE
Support typed attribute matching, attribute paths, and value containment in filter policies

### DIFF
--- a/gen/go/policy/v1alpha1/common_policy_types.pb.go
+++ b/gen/go/policy/v1alpha1/common_policy_types.pb.go
@@ -156,11 +156,304 @@ func (ScopeField) EnumDescriptor() ([]byte, []int) {
 	return file_policy_v1alpha1_common_policy_types_proto_rawDescGZIP(), []int{1}
 }
 
+// AttributePath specifies how to access an attribute value.
+//   - A single-element array accesses a flat attribute (e.g. ["http.status_code"]).
+//   - Multiple elements traverse nested maps (e.g. ["http", "request", "method"]).
+//   - When traversing array/list values, string segments representing non-negative
+//     integers (e.g. "0", "100") are interpreted as zero-based array indices
+//     (e.g. ["items", "0", "id"]).
+type AttributePath struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Path segments for attribute traversal.
+	Path          []string `protobuf:"bytes,1,rep,name=path,proto3" json:"path,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AttributePath) Reset() {
+	*x = AttributePath{}
+	mi := &file_policy_v1alpha1_common_policy_types_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AttributePath) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AttributePath) ProtoMessage() {}
+
+func (x *AttributePath) ProtoReflect() protoreflect.Message {
+	mi := &file_policy_v1alpha1_common_policy_types_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AttributePath.ProtoReflect.Descriptor instead.
+func (*AttributePath) Descriptor() ([]byte, []int) {
+	return file_policy_v1alpha1_common_policy_types_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *AttributePath) GetPath() []string {
+	if x != nil {
+		return x.Path
+	}
+	return nil
+}
+
+// Value carries a typed scalar for equality and containment comparisons.
+// Exactly one variant must be set.
+type Value struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The typed scalar value.
+	//
+	// Types that are valid to be assigned to Value:
+	//
+	//	*Value_StringValue
+	//	*Value_IntValue
+	//	*Value_BoolValue
+	//	*Value_DoubleValue
+	//	*Value_BytesValue
+	Value         isValue_Value `protobuf_oneof:"value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Value) Reset() {
+	*x = Value{}
+	mi := &file_policy_v1alpha1_common_policy_types_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Value) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Value) ProtoMessage() {}
+
+func (x *Value) ProtoReflect() protoreflect.Message {
+	mi := &file_policy_v1alpha1_common_policy_types_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Value.ProtoReflect.Descriptor instead.
+func (*Value) Descriptor() ([]byte, []int) {
+	return file_policy_v1alpha1_common_policy_types_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *Value) GetValue() isValue_Value {
+	if x != nil {
+		return x.Value
+	}
+	return nil
+}
+
+func (x *Value) GetStringValue() string {
+	if x != nil {
+		if x, ok := x.Value.(*Value_StringValue); ok {
+			return x.StringValue
+		}
+	}
+	return ""
+}
+
+func (x *Value) GetIntValue() int64 {
+	if x != nil {
+		if x, ok := x.Value.(*Value_IntValue); ok {
+			return x.IntValue
+		}
+	}
+	return 0
+}
+
+func (x *Value) GetBoolValue() bool {
+	if x != nil {
+		if x, ok := x.Value.(*Value_BoolValue); ok {
+			return x.BoolValue
+		}
+	}
+	return false
+}
+
+func (x *Value) GetDoubleValue() float64 {
+	if x != nil {
+		if x, ok := x.Value.(*Value_DoubleValue); ok {
+			return x.DoubleValue
+		}
+	}
+	return 0
+}
+
+func (x *Value) GetBytesValue() []byte {
+	if x != nil {
+		if x, ok := x.Value.(*Value_BytesValue); ok {
+			return x.BytesValue
+		}
+	}
+	return nil
+}
+
+type isValue_Value interface {
+	isValue_Value()
+}
+
+type Value_StringValue struct {
+	// String value.
+	StringValue string `protobuf:"bytes,1,opt,name=string_value,json=stringValue,proto3,oneof"`
+}
+
+type Value_IntValue struct {
+	// 64-bit signed integer value (e.g. http.status_code = 200).
+	IntValue int64 `protobuf:"varint,2,opt,name=int_value,json=intValue,proto3,oneof"`
+}
+
+type Value_BoolValue struct {
+	// Boolean value.
+	BoolValue bool `protobuf:"varint,3,opt,name=bool_value,json=boolValue,proto3,oneof"`
+}
+
+type Value_DoubleValue struct {
+	// 64-bit floating point value.
+	DoubleValue float64 `protobuf:"fixed64,4,opt,name=double_value,json=doubleValue,proto3,oneof"`
+}
+
+type Value_BytesValue struct {
+	// Byte sequence value.
+	BytesValue []byte `protobuf:"bytes,5,opt,name=bytes_value,json=bytesValue,proto3,oneof"`
+}
+
+func (*Value_StringValue) isValue_Value() {}
+
+func (*Value_IntValue) isValue_Value() {}
+
+func (*Value_BoolValue) isValue_Value() {}
+
+func (*Value_DoubleValue) isValue_Value() {}
+
+func (*Value_BytesValue) isValue_Value() {}
+
+// NumericValue carries a typed number for ordering comparisons (gt, gte, lt, lte).
+// Exactly one variant must be set.
+type NumericValue struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The typed numeric value.
+	//
+	// Types that are valid to be assigned to Value:
+	//
+	//	*NumericValue_IntValue
+	//	*NumericValue_DoubleValue
+	Value         isNumericValue_Value `protobuf_oneof:"value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *NumericValue) Reset() {
+	*x = NumericValue{}
+	mi := &file_policy_v1alpha1_common_policy_types_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NumericValue) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NumericValue) ProtoMessage() {}
+
+func (x *NumericValue) ProtoReflect() protoreflect.Message {
+	mi := &file_policy_v1alpha1_common_policy_types_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NumericValue.ProtoReflect.Descriptor instead.
+func (*NumericValue) Descriptor() ([]byte, []int) {
+	return file_policy_v1alpha1_common_policy_types_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *NumericValue) GetValue() isNumericValue_Value {
+	if x != nil {
+		return x.Value
+	}
+	return nil
+}
+
+func (x *NumericValue) GetIntValue() int64 {
+	if x != nil {
+		if x, ok := x.Value.(*NumericValue_IntValue); ok {
+			return x.IntValue
+		}
+	}
+	return 0
+}
+
+func (x *NumericValue) GetDoubleValue() float64 {
+	if x != nil {
+		if x, ok := x.Value.(*NumericValue_DoubleValue); ok {
+			return x.DoubleValue
+		}
+	}
+	return 0
+}
+
+type isNumericValue_Value interface {
+	isNumericValue_Value()
+}
+
+type NumericValue_IntValue struct {
+	// 64-bit signed integer value.
+	IntValue int64 `protobuf:"varint,1,opt,name=int_value,json=intValue,proto3,oneof"`
+}
+
+type NumericValue_DoubleValue struct {
+	// 64-bit floating point value.
+	DoubleValue float64 `protobuf:"fixed64,2,opt,name=double_value,json=doubleValue,proto3,oneof"`
+}
+
+func (*NumericValue_IntValue) isNumericValue_Value() {}
+
+func (*NumericValue_DoubleValue) isNumericValue_Value() {}
+
 var File_policy_v1alpha1_common_policy_types_proto protoreflect.FileDescriptor
 
 const file_policy_v1alpha1_common_policy_types_proto_rawDesc = "" +
 	"\n" +
-	")policy/v1alpha1/common_policy_types.proto\x12 google.telemetry.policy.v1alpha1*B\n" +
+	")policy/v1alpha1/common_policy_types.proto\x12 google.telemetry.policy.v1alpha1\"#\n" +
+	"\rAttributePath\x12\x12\n" +
+	"\x04path\x18\x01 \x03(\tR\x04path\"\xbd\x01\n" +
+	"\x05Value\x12#\n" +
+	"\fstring_value\x18\x01 \x01(\tH\x00R\vstringValue\x12\x1d\n" +
+	"\tint_value\x18\x02 \x01(\x03H\x00R\bintValue\x12\x1f\n" +
+	"\n" +
+	"bool_value\x18\x03 \x01(\bH\x00R\tboolValue\x12#\n" +
+	"\fdouble_value\x18\x04 \x01(\x01H\x00R\vdoubleValue\x12!\n" +
+	"\vbytes_value\x18\x05 \x01(\fH\x00R\n" +
+	"bytesValueB\a\n" +
+	"\x05value\"[\n" +
+	"\fNumericValue\x12\x1d\n" +
+	"\tint_value\x18\x01 \x01(\x03H\x00R\bintValue\x12#\n" +
+	"\fdouble_value\x18\x02 \x01(\x01H\x00R\vdoubleValueB\a\n" +
+	"\x05value*B\n" +
 	"\x06Action\x12\x16\n" +
 	"\x12ACTION_UNSPECIFIED\x10\x00\x12\x0f\n" +
 	"\vACTION_KEEP\x10\x01\x12\x0f\n" +
@@ -186,9 +479,13 @@ func file_policy_v1alpha1_common_policy_types_proto_rawDescGZIP() []byte {
 }
 
 var file_policy_v1alpha1_common_policy_types_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_policy_v1alpha1_common_policy_types_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_policy_v1alpha1_common_policy_types_proto_goTypes = []any{
-	(Action)(0),     // 0: google.telemetry.policy.v1alpha1.Action
-	(ScopeField)(0), // 1: google.telemetry.policy.v1alpha1.ScopeField
+	(Action)(0),           // 0: google.telemetry.policy.v1alpha1.Action
+	(ScopeField)(0),       // 1: google.telemetry.policy.v1alpha1.ScopeField
+	(*AttributePath)(nil), // 2: google.telemetry.policy.v1alpha1.AttributePath
+	(*Value)(nil),         // 3: google.telemetry.policy.v1alpha1.Value
+	(*NumericValue)(nil),  // 4: google.telemetry.policy.v1alpha1.NumericValue
 }
 var file_policy_v1alpha1_common_policy_types_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
@@ -203,19 +500,31 @@ func file_policy_v1alpha1_common_policy_types_proto_init() {
 	if File_policy_v1alpha1_common_policy_types_proto != nil {
 		return
 	}
+	file_policy_v1alpha1_common_policy_types_proto_msgTypes[1].OneofWrappers = []any{
+		(*Value_StringValue)(nil),
+		(*Value_IntValue)(nil),
+		(*Value_BoolValue)(nil),
+		(*Value_DoubleValue)(nil),
+		(*Value_BytesValue)(nil),
+	}
+	file_policy_v1alpha1_common_policy_types_proto_msgTypes[2].OneofWrappers = []any{
+		(*NumericValue_IntValue)(nil),
+		(*NumericValue_DoubleValue)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_policy_v1alpha1_common_policy_types_proto_rawDesc), len(file_policy_v1alpha1_common_policy_types_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   0,
+			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
 		GoTypes:           file_policy_v1alpha1_common_policy_types_proto_goTypes,
 		DependencyIndexes: file_policy_v1alpha1_common_policy_types_proto_depIdxs,
 		EnumInfos:         file_policy_v1alpha1_common_policy_types_proto_enumTypes,
+		MessageInfos:      file_policy_v1alpha1_common_policy_types_proto_msgTypes,
 	}.Build()
 	File_policy_v1alpha1_common_policy_types_proto = out.File
 	file_policy_v1alpha1_common_policy_types_proto_goTypes = nil

--- a/gen/go/policy/v1alpha1/common_policy_types_test.go
+++ b/gen/go/policy/v1alpha1/common_policy_types_test.go
@@ -1,0 +1,210 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policyv1alpha1_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	policyv1alpha1 "github.com/GoogleCloudPlatform/opentelemetry-operations-collector/gen/go/policy/v1alpha1"
+)
+
+func TestValue_Variants(t *testing.T) {
+	testCases := []struct {
+		name     string
+		val      *policyv1alpha1.Value
+		validate func(t *testing.T, v *policyv1alpha1.Value)
+	}{
+		{
+			name: "string_value",
+			val: &policyv1alpha1.Value{
+				Value: &policyv1alpha1.Value_StringValue{
+					StringValue: "production",
+				},
+			},
+			validate: func(t *testing.T, v *policyv1alpha1.Value) {
+				assert.Equal(t, "production", v.GetStringValue())
+				assert.IsType(t, &policyv1alpha1.Value_StringValue{}, v.GetValue())
+			},
+		},
+		{
+			name: "int_value",
+			val: &policyv1alpha1.Value{
+				Value: &policyv1alpha1.Value_IntValue{
+					IntValue: 200,
+				},
+			},
+			validate: func(t *testing.T, v *policyv1alpha1.Value) {
+				assert.Equal(t, int64(200), v.GetIntValue())
+				assert.IsType(t, &policyv1alpha1.Value_IntValue{}, v.GetValue())
+			},
+		},
+		{
+			name: "bool_value",
+			val: &policyv1alpha1.Value{
+				Value: &policyv1alpha1.Value_BoolValue{
+					BoolValue: true,
+				},
+			},
+			validate: func(t *testing.T, v *policyv1alpha1.Value) {
+				assert.True(t, v.GetBoolValue())
+				assert.IsType(t, &policyv1alpha1.Value_BoolValue{}, v.GetValue())
+			},
+		},
+		{
+			name: "double_value",
+			val: &policyv1alpha1.Value{
+				Value: &policyv1alpha1.Value_DoubleValue{
+					DoubleValue: 3.14159,
+				},
+			},
+			validate: func(t *testing.T, v *policyv1alpha1.Value) {
+				assert.InDelta(t, 3.14159, v.GetDoubleValue(), 0.00001)
+				assert.IsType(t, &policyv1alpha1.Value_DoubleValue{}, v.GetValue())
+			},
+		},
+		{
+			name: "bytes_value",
+			val: &policyv1alpha1.Value{
+				Value: &policyv1alpha1.Value_BytesValue{
+					BytesValue: []byte{0x01, 0x02, 0x03, 0x04},
+				},
+			},
+			validate: func(t *testing.T, v *policyv1alpha1.Value) {
+				assert.Equal(t, []byte{0x01, 0x02, 0x03, 0x04}, v.GetBytesValue())
+				assert.IsType(t, &policyv1alpha1.Value_BytesValue{}, v.GetValue())
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Round-trip binary proto.
+			data, err := proto.Marshal(tc.val)
+			require.NoError(t, err)
+
+			unmarshaled := &policyv1alpha1.Value{}
+			require.NoError(t, proto.Unmarshal(data, unmarshaled))
+			assert.True(t, proto.Equal(tc.val, unmarshaled))
+			tc.validate(t, unmarshaled)
+
+			// Round-trip JSON proto.
+			jsonData, err := protojson.Marshal(tc.val)
+			require.NoError(t, err)
+
+			jsonUnmarshaled := &policyv1alpha1.Value{}
+			require.NoError(t, protojson.Unmarshal(jsonData, jsonUnmarshaled))
+			assert.True(t, proto.Equal(tc.val, jsonUnmarshaled))
+			tc.validate(t, jsonUnmarshaled)
+		})
+	}
+}
+
+func TestNumericValue_Variants(t *testing.T) {
+	testCases := []struct {
+		name     string
+		num      *policyv1alpha1.NumericValue
+		validate func(t *testing.T, n *policyv1alpha1.NumericValue)
+	}{
+		{
+			name: "int_value",
+			num: &policyv1alpha1.NumericValue{
+				Value: &policyv1alpha1.NumericValue_IntValue{
+					IntValue: 404,
+				},
+			},
+			validate: func(t *testing.T, n *policyv1alpha1.NumericValue) {
+				assert.Equal(t, int64(404), n.GetIntValue())
+				assert.IsType(t, &policyv1alpha1.NumericValue_IntValue{}, n.GetValue())
+			},
+		},
+		{
+			name: "double_value",
+			num: &policyv1alpha1.NumericValue{
+				Value: &policyv1alpha1.NumericValue_DoubleValue{
+					DoubleValue: 99.99,
+				},
+			},
+			validate: func(t *testing.T, n *policyv1alpha1.NumericValue) {
+				assert.InDelta(t, 99.99, n.GetDoubleValue(), 0.001)
+				assert.IsType(t, &policyv1alpha1.NumericValue_DoubleValue{}, n.GetValue())
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := proto.Marshal(tc.num)
+			require.NoError(t, err)
+
+			unmarshaled := &policyv1alpha1.NumericValue{}
+			require.NoError(t, proto.Unmarshal(data, unmarshaled))
+			assert.True(t, proto.Equal(tc.num, unmarshaled))
+			tc.validate(t, unmarshaled)
+
+			jsonData, err := protojson.Marshal(tc.num)
+			require.NoError(t, err)
+
+			jsonUnmarshaled := &policyv1alpha1.NumericValue{}
+			require.NoError(t, protojson.Unmarshal(jsonData, jsonUnmarshaled))
+			assert.True(t, proto.Equal(tc.num, jsonUnmarshaled))
+			tc.validate(t, jsonUnmarshaled)
+		})
+	}
+}
+
+func TestAttributePath_Serialization(t *testing.T) {
+	testCases := []struct {
+		name string
+		path *policyv1alpha1.AttributePath
+	}{
+		{
+			name: "single_segment_flat",
+			path: &policyv1alpha1.AttributePath{
+				Path: []string{"http.status_code"},
+			},
+		},
+		{
+			name: "multi_segment_nested",
+			path: &policyv1alpha1.AttributePath{
+				Path: []string{"http", "request", "headers", "authorization"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := proto.Marshal(tc.path)
+			require.NoError(t, err)
+
+			unmarshaled := &policyv1alpha1.AttributePath{}
+			require.NoError(t, proto.Unmarshal(data, unmarshaled))
+			assert.True(t, proto.Equal(tc.path, unmarshaled))
+			assert.Equal(t, tc.path.GetPath(), unmarshaled.GetPath())
+
+			jsonData, err := protojson.Marshal(tc.path)
+			require.NoError(t, err)
+
+			jsonUnmarshaled := &policyv1alpha1.AttributePath{}
+			require.NoError(t, protojson.Unmarshal(jsonData, jsonUnmarshaled))
+			assert.True(t, proto.Equal(tc.path, jsonUnmarshaled))
+			assert.Equal(t, tc.path.GetPath(), jsonUnmarshaled.GetPath())
+		})
+	}
+}

--- a/gen/go/policy/v1alpha1/log_filter_policy.pb.go
+++ b/gen/go/policy/v1alpha1/log_filter_policy.pb.go
@@ -49,8 +49,8 @@ const (
 	// The string severity of the log (e.g. "INFO", "ERROR", "DEBUG").
 	LogRecordField_LOG_RECORD_FIELD_SEVERITY_TEXT LogRecordField = 2
 	// The numerical severity of the log (1-24 per OpenTelemetry specification).
-	// When evaluated against string predicates (`exact`, `regex`), this matches
-	// against the canonical base-10 integer string representation (e.g. "17").
+	// Evaluates against typed `equals` (`int_value`), numeric range comparisons
+	// (`gt`, `gte`, `lt`, `lte`), or canonical base-10 string representations for `regex`.
 	LogRecordField_LOG_RECORD_FIELD_SEVERITY_NUMBER LogRecordField = 3
 	// The 16-byte trace identifier associated with the log record.
 	// When evaluated against string predicates (`exact`, `regex`), this matches
@@ -203,8 +203,13 @@ type LogMatcher struct {
 	// Types that are valid to be assigned to Predicate:
 	//
 	//	*LogMatcher_Exists
-	//	*LogMatcher_Exact
+	//	*LogMatcher_Equals
 	//	*LogMatcher_Regex
+	//	*LogMatcher_Gt
+	//	*LogMatcher_Gte
+	//	*LogMatcher_Lt
+	//	*LogMatcher_Lte
+	//	*LogMatcher_Contains
 	Predicate isLogMatcher_Predicate `protobuf_oneof:"predicate"`
 	// If true, inverts the result of the predicate (logical NOT).
 	Negate        bool `protobuf:"varint,2,opt,name=negate,proto3" json:"negate,omitempty"`
@@ -265,13 +270,13 @@ func (x *LogMatcher) GetExists() *emptypb.Empty {
 	return nil
 }
 
-func (x *LogMatcher) GetExact() string {
+func (x *LogMatcher) GetEquals() *Value {
 	if x != nil {
-		if x, ok := x.Predicate.(*LogMatcher_Exact); ok {
-			return x.Exact
+		if x, ok := x.Predicate.(*LogMatcher_Equals); ok {
+			return x.Equals
 		}
 	}
-	return ""
+	return nil
 }
 
 func (x *LogMatcher) GetRegex() string {
@@ -281,6 +286,51 @@ func (x *LogMatcher) GetRegex() string {
 		}
 	}
 	return ""
+}
+
+func (x *LogMatcher) GetGt() *NumericValue {
+	if x != nil {
+		if x, ok := x.Predicate.(*LogMatcher_Gt); ok {
+			return x.Gt
+		}
+	}
+	return nil
+}
+
+func (x *LogMatcher) GetGte() *NumericValue {
+	if x != nil {
+		if x, ok := x.Predicate.(*LogMatcher_Gte); ok {
+			return x.Gte
+		}
+	}
+	return nil
+}
+
+func (x *LogMatcher) GetLt() *NumericValue {
+	if x != nil {
+		if x, ok := x.Predicate.(*LogMatcher_Lt); ok {
+			return x.Lt
+		}
+	}
+	return nil
+}
+
+func (x *LogMatcher) GetLte() *NumericValue {
+	if x != nil {
+		if x, ok := x.Predicate.(*LogMatcher_Lte); ok {
+			return x.Lte
+		}
+	}
+	return nil
+}
+
+func (x *LogMatcher) GetContains() *Value {
+	if x != nil {
+		if x, ok := x.Predicate.(*LogMatcher_Contains); ok {
+			return x.Contains
+		}
+	}
+	return nil
 }
 
 func (x *LogMatcher) GetNegate() bool {
@@ -304,24 +354,67 @@ type LogMatcher_Exists struct {
 	Exists *emptypb.Empty `protobuf:"bytes,10,opt,name=exists,proto3,oneof"`
 }
 
-type LogMatcher_Exact struct {
-	// Exact string equality match.
-	Exact string `protobuf:"bytes,11,opt,name=exact,proto3,oneof"`
+type LogMatcher_Equals struct {
+	// Typed scalar equality match (supporting string, int64, bool, double, bytes).
+	Equals *Value `protobuf:"bytes,11,opt,name=equals,proto3,oneof"`
 }
 
 type LogMatcher_Regex struct {
 	// Regular expression match using RE2 syntax.
 	// Evaluates as an unanchored partial match (like Go regexp.MatchString and
 	// OpenTelemetry OTTL IsMatch). Callers requiring full string equality must
-	// provide explicit anchors ('^' and '$').
+	// provide explicit anchors ('^' and '$'). Applies strictly to string
+	// fields and string attribute values.
 	Regex string `protobuf:"bytes,12,opt,name=regex,proto3,oneof"`
+}
+
+type LogMatcher_Gt struct {
+	// Matches if the target numeric value is strictly greater than this value.
+	// Applies strictly to int64 and double fields and attribute values.
+	Gt *NumericValue `protobuf:"bytes,13,opt,name=gt,proto3,oneof"`
+}
+
+type LogMatcher_Gte struct {
+	// Matches if the target numeric value is greater than or equal to this value.
+	// Applies strictly to int64 and double fields and attribute values.
+	Gte *NumericValue `protobuf:"bytes,14,opt,name=gte,proto3,oneof"`
+}
+
+type LogMatcher_Lt struct {
+	// Matches if the target numeric value is strictly less than this value.
+	// Applies strictly to int64 and double fields and attribute values.
+	Lt *NumericValue `protobuf:"bytes,15,opt,name=lt,proto3,oneof"`
+}
+
+type LogMatcher_Lte struct {
+	// Matches if the target numeric value is less than or equal to this value.
+	// Applies strictly to int64 and double fields and attribute values.
+	Lte *NumericValue `protobuf:"bytes,16,opt,name=lte,proto3,oneof"`
+}
+
+type LogMatcher_Contains struct {
+	// Value containment:
+	// - For list (ArrayValue) attributes: matches if any element in the list equals this value.
+	// - For string fields or attribute values: matches if the string contains this value's string_value as a substring.
+	// - For bytes fields or attribute values: matches if the bytes contain this value's bytes_value as a subsequence.
+	Contains *Value `protobuf:"bytes,17,opt,name=contains,proto3,oneof"`
 }
 
 func (*LogMatcher_Exists) isLogMatcher_Predicate() {}
 
-func (*LogMatcher_Exact) isLogMatcher_Predicate() {}
+func (*LogMatcher_Equals) isLogMatcher_Predicate() {}
 
 func (*LogMatcher_Regex) isLogMatcher_Predicate() {}
+
+func (*LogMatcher_Gt) isLogMatcher_Predicate() {}
+
+func (*LogMatcher_Gte) isLogMatcher_Predicate() {}
+
+func (*LogMatcher_Lt) isLogMatcher_Predicate() {}
+
+func (*LogMatcher_Lte) isLogMatcher_Predicate() {}
+
+func (*LogMatcher_Contains) isLogMatcher_Predicate() {}
 
 // LogFieldSelector designates a first-class OTel log field, attribute, or metadata.
 type LogFieldSelector struct {
@@ -384,31 +477,31 @@ func (x *LogFieldSelector) GetRecordField() LogRecordField {
 	return LogRecordField_LOG_RECORD_FIELD_UNSPECIFIED
 }
 
-func (x *LogFieldSelector) GetLogAttribute() string {
+func (x *LogFieldSelector) GetLogAttribute() *AttributePath {
 	if x != nil {
 		if x, ok := x.Target.(*LogFieldSelector_LogAttribute); ok {
 			return x.LogAttribute
 		}
 	}
-	return ""
+	return nil
 }
 
-func (x *LogFieldSelector) GetResourceAttribute() string {
+func (x *LogFieldSelector) GetResourceAttribute() *AttributePath {
 	if x != nil {
 		if x, ok := x.Target.(*LogFieldSelector_ResourceAttribute); ok {
 			return x.ResourceAttribute
 		}
 	}
-	return ""
+	return nil
 }
 
-func (x *LogFieldSelector) GetScopeAttribute() string {
+func (x *LogFieldSelector) GetScopeAttribute() *AttributePath {
 	if x != nil {
 		if x, ok := x.Target.(*LogFieldSelector_ScopeAttribute); ok {
 			return x.ScopeAttribute
 		}
 	}
-	return ""
+	return nil
 }
 
 func (x *LogFieldSelector) GetScopeField() ScopeField {
@@ -425,27 +518,27 @@ type isLogFieldSelector_Target interface {
 }
 
 type LogFieldSelector_RecordField struct {
-	// Standard first-class OpenTelemetry LogRecord fields (OTLP path: log_record.*).
+	// Standard first-class OpenTelemetry LogRecord fields (e.g. severity_number, body).
 	RecordField LogRecordField `protobuf:"varint,1,opt,name=record_field,json=recordField,proto3,enum=google.telemetry.policy.v1alpha1.LogRecordField,oneof"`
 }
 
 type LogFieldSelector_LogAttribute struct {
-	// Log record attribute by key (OTLP path: log_record.attributes[*], e.g. "http.route", "user_id").
-	LogAttribute string `protobuf:"bytes,2,opt,name=log_attribute,json=logAttribute,proto3,oneof"`
+	// Log record attribute by key or path (e.g. ["http.route"] or ["http", "method"]).
+	LogAttribute *AttributePath `protobuf:"bytes,2,opt,name=log_attribute,json=logAttribute,proto3,oneof"`
 }
 
 type LogFieldSelector_ResourceAttribute struct {
-	// Resource attribute by key (OTLP path: resource.attributes[*], e.g. "service.name", "k8s.pod.name").
-	ResourceAttribute string `protobuf:"bytes,3,opt,name=resource_attribute,json=resourceAttribute,proto3,oneof"`
+	// Resource attribute by key or path (e.g. ["service.name"] or ["host", "id"]).
+	ResourceAttribute *AttributePath `protobuf:"bytes,3,opt,name=resource_attribute,json=resourceAttribute,proto3,oneof"`
 }
 
 type LogFieldSelector_ScopeAttribute struct {
-	// Instrumentation scope attribute by key (OTLP path: scope.attributes[*], e.g. "library.name").
-	ScopeAttribute string `protobuf:"bytes,4,opt,name=scope_attribute,json=scopeAttribute,proto3,oneof"`
+	// Instrumentation scope attribute by key or path (e.g. ["library.name"]).
+	ScopeAttribute *AttributePath `protobuf:"bytes,4,opt,name=scope_attribute,json=scopeAttribute,proto3,oneof"`
 }
 
 type LogFieldSelector_ScopeField struct {
-	// Standard first-class OpenTelemetry InstrumentationScope fields (OTLP path: scope.*).
+	// Standard first-class OpenTelemetry InstrumentationScope fields (e.g. name, version).
 	ScopeField ScopeField `protobuf:"varint,5,opt,name=scope_field,json=scopeField,proto3,enum=google.telemetry.policy.v1alpha1.ScopeField,oneof"`
 }
 
@@ -468,21 +561,26 @@ const file_policy_v1alpha1_log_filter_policy_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12E\n" +
 	"\x06action\x18\x02 \x01(\x0e2(.google.telemetry.policy.v1alpha1.ActionH\x00R\x06action\x88\x01\x01\x12F\n" +
 	"\amatches\x18\x03 \x03(\v2,.google.telemetry.policy.v1alpha1.LogMatcherR\amatchesB\t\n" +
-	"\a_action\"\xdf\x01\n" +
+	"\a_action\"\xdd\x04\n" +
 	"\n" +
 	"LogMatcher\x12J\n" +
 	"\x06target\x18\x01 \x01(\v22.google.telemetry.policy.v1alpha1.LogFieldSelectorR\x06target\x120\n" +
 	"\x06exists\x18\n" +
-	" \x01(\v2\x16.google.protobuf.EmptyH\x00R\x06exists\x12\x16\n" +
-	"\x05exact\x18\v \x01(\tH\x00R\x05exact\x12\x16\n" +
-	"\x05regex\x18\f \x01(\tH\x00R\x05regex\x12\x16\n" +
+	" \x01(\v2\x16.google.protobuf.EmptyH\x00R\x06exists\x12A\n" +
+	"\x06equals\x18\v \x01(\v2'.google.telemetry.policy.v1alpha1.ValueH\x00R\x06equals\x12\x16\n" +
+	"\x05regex\x18\f \x01(\tH\x00R\x05regex\x12@\n" +
+	"\x02gt\x18\r \x01(\v2..google.telemetry.policy.v1alpha1.NumericValueH\x00R\x02gt\x12B\n" +
+	"\x03gte\x18\x0e \x01(\v2..google.telemetry.policy.v1alpha1.NumericValueH\x00R\x03gte\x12@\n" +
+	"\x02lt\x18\x0f \x01(\v2..google.telemetry.policy.v1alpha1.NumericValueH\x00R\x02lt\x12B\n" +
+	"\x03lte\x18\x10 \x01(\v2..google.telemetry.policy.v1alpha1.NumericValueH\x00R\x03lte\x12E\n" +
+	"\bcontains\x18\x11 \x01(\v2'.google.telemetry.policy.v1alpha1.ValueH\x00R\bcontains\x12\x16\n" +
 	"\x06negate\x18\x02 \x01(\bR\x06negateB\v\n" +
-	"\tpredicate\"\xc7\x02\n" +
+	"\tpredicate\"\xda\x03\n" +
 	"\x10LogFieldSelector\x12U\n" +
-	"\frecord_field\x18\x01 \x01(\x0e20.google.telemetry.policy.v1alpha1.LogRecordFieldH\x00R\vrecordField\x12%\n" +
-	"\rlog_attribute\x18\x02 \x01(\tH\x00R\flogAttribute\x12/\n" +
-	"\x12resource_attribute\x18\x03 \x01(\tH\x00R\x11resourceAttribute\x12)\n" +
-	"\x0fscope_attribute\x18\x04 \x01(\tH\x00R\x0escopeAttribute\x12O\n" +
+	"\frecord_field\x18\x01 \x01(\x0e20.google.telemetry.policy.v1alpha1.LogRecordFieldH\x00R\vrecordField\x12V\n" +
+	"\rlog_attribute\x18\x02 \x01(\v2/.google.telemetry.policy.v1alpha1.AttributePathH\x00R\flogAttribute\x12`\n" +
+	"\x12resource_attribute\x18\x03 \x01(\v2/.google.telemetry.policy.v1alpha1.AttributePathH\x00R\x11resourceAttribute\x12Z\n" +
+	"\x0fscope_attribute\x18\x04 \x01(\v2/.google.telemetry.policy.v1alpha1.AttributePathH\x00R\x0escopeAttribute\x12O\n" +
 	"\vscope_field\x18\x05 \x01(\x0e2,.google.telemetry.policy.v1alpha1.ScopeFieldH\x00R\n" +
 	"scopeFieldB\b\n" +
 	"\x06target*\xd4\x01\n" +
@@ -516,20 +614,32 @@ var file_policy_v1alpha1_log_filter_policy_proto_goTypes = []any{
 	(*LogFieldSelector)(nil), // 3: google.telemetry.policy.v1alpha1.LogFieldSelector
 	(Action)(0),              // 4: google.telemetry.policy.v1alpha1.Action
 	(*emptypb.Empty)(nil),    // 5: google.protobuf.Empty
-	(ScopeField)(0),          // 6: google.telemetry.policy.v1alpha1.ScopeField
+	(*Value)(nil),            // 6: google.telemetry.policy.v1alpha1.Value
+	(*NumericValue)(nil),     // 7: google.telemetry.policy.v1alpha1.NumericValue
+	(*AttributePath)(nil),    // 8: google.telemetry.policy.v1alpha1.AttributePath
+	(ScopeField)(0),          // 9: google.telemetry.policy.v1alpha1.ScopeField
 }
 var file_policy_v1alpha1_log_filter_policy_proto_depIdxs = []int32{
-	4, // 0: google.telemetry.policy.v1alpha1.LogFilterPolicy.action:type_name -> google.telemetry.policy.v1alpha1.Action
-	2, // 1: google.telemetry.policy.v1alpha1.LogFilterPolicy.matches:type_name -> google.telemetry.policy.v1alpha1.LogMatcher
-	3, // 2: google.telemetry.policy.v1alpha1.LogMatcher.target:type_name -> google.telemetry.policy.v1alpha1.LogFieldSelector
-	5, // 3: google.telemetry.policy.v1alpha1.LogMatcher.exists:type_name -> google.protobuf.Empty
-	0, // 4: google.telemetry.policy.v1alpha1.LogFieldSelector.record_field:type_name -> google.telemetry.policy.v1alpha1.LogRecordField
-	6, // 5: google.telemetry.policy.v1alpha1.LogFieldSelector.scope_field:type_name -> google.telemetry.policy.v1alpha1.ScopeField
-	6, // [6:6] is the sub-list for method output_type
-	6, // [6:6] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	4,  // 0: google.telemetry.policy.v1alpha1.LogFilterPolicy.action:type_name -> google.telemetry.policy.v1alpha1.Action
+	2,  // 1: google.telemetry.policy.v1alpha1.LogFilterPolicy.matches:type_name -> google.telemetry.policy.v1alpha1.LogMatcher
+	3,  // 2: google.telemetry.policy.v1alpha1.LogMatcher.target:type_name -> google.telemetry.policy.v1alpha1.LogFieldSelector
+	5,  // 3: google.telemetry.policy.v1alpha1.LogMatcher.exists:type_name -> google.protobuf.Empty
+	6,  // 4: google.telemetry.policy.v1alpha1.LogMatcher.equals:type_name -> google.telemetry.policy.v1alpha1.Value
+	7,  // 5: google.telemetry.policy.v1alpha1.LogMatcher.gt:type_name -> google.telemetry.policy.v1alpha1.NumericValue
+	7,  // 6: google.telemetry.policy.v1alpha1.LogMatcher.gte:type_name -> google.telemetry.policy.v1alpha1.NumericValue
+	7,  // 7: google.telemetry.policy.v1alpha1.LogMatcher.lt:type_name -> google.telemetry.policy.v1alpha1.NumericValue
+	7,  // 8: google.telemetry.policy.v1alpha1.LogMatcher.lte:type_name -> google.telemetry.policy.v1alpha1.NumericValue
+	6,  // 9: google.telemetry.policy.v1alpha1.LogMatcher.contains:type_name -> google.telemetry.policy.v1alpha1.Value
+	0,  // 10: google.telemetry.policy.v1alpha1.LogFieldSelector.record_field:type_name -> google.telemetry.policy.v1alpha1.LogRecordField
+	8,  // 11: google.telemetry.policy.v1alpha1.LogFieldSelector.log_attribute:type_name -> google.telemetry.policy.v1alpha1.AttributePath
+	8,  // 12: google.telemetry.policy.v1alpha1.LogFieldSelector.resource_attribute:type_name -> google.telemetry.policy.v1alpha1.AttributePath
+	8,  // 13: google.telemetry.policy.v1alpha1.LogFieldSelector.scope_attribute:type_name -> google.telemetry.policy.v1alpha1.AttributePath
+	9,  // 14: google.telemetry.policy.v1alpha1.LogFieldSelector.scope_field:type_name -> google.telemetry.policy.v1alpha1.ScopeField
+	15, // [15:15] is the sub-list for method output_type
+	15, // [15:15] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_policy_v1alpha1_log_filter_policy_proto_init() }
@@ -541,8 +651,13 @@ func file_policy_v1alpha1_log_filter_policy_proto_init() {
 	file_policy_v1alpha1_log_filter_policy_proto_msgTypes[0].OneofWrappers = []any{}
 	file_policy_v1alpha1_log_filter_policy_proto_msgTypes[1].OneofWrappers = []any{
 		(*LogMatcher_Exists)(nil),
-		(*LogMatcher_Exact)(nil),
+		(*LogMatcher_Equals)(nil),
 		(*LogMatcher_Regex)(nil),
+		(*LogMatcher_Gt)(nil),
+		(*LogMatcher_Gte)(nil),
+		(*LogMatcher_Lt)(nil),
+		(*LogMatcher_Lte)(nil),
+		(*LogMatcher_Contains)(nil),
 	}
 	file_policy_v1alpha1_log_filter_policy_proto_msgTypes[2].OneofWrappers = []any{
 		(*LogFieldSelector_RecordField)(nil),

--- a/gen/go/policy/v1alpha1/log_filter_policy_test.go
+++ b/gen/go/policy/v1alpha1/log_filter_policy_test.go
@@ -47,17 +47,135 @@ func TestLogFilterPolicy_Serialization(t *testing.T) {
 			{
 				Target: &policyv1alpha1.LogFieldSelector{
 					Target: &policyv1alpha1.LogFieldSelector_LogAttribute{
-						LogAttribute: "http.route",
+						LogAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"http.route"},
+						},
 					},
 				},
-				Predicate: &policyv1alpha1.LogMatcher_Exact{
-					Exact: "/healthz",
+				Predicate: &policyv1alpha1.LogMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "/healthz",
+						},
+					},
+				},
+			},
+			{
+				Target: &policyv1alpha1.LogFieldSelector{
+					Target: &policyv1alpha1.LogFieldSelector_LogAttribute{
+						LogAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"http.status_code"},
+						},
+					},
+				},
+				Predicate: &policyv1alpha1.LogMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_IntValue{
+							IntValue: 200,
+						},
+					},
+				},
+			},
+			{
+				Target: &policyv1alpha1.LogFieldSelector{
+					Target: &policyv1alpha1.LogFieldSelector_LogAttribute{
+						LogAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"feature_flag.enabled"},
+						},
+					},
+				},
+				Predicate: &policyv1alpha1.LogMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_BoolValue{
+							BoolValue: true,
+						},
+					},
+				},
+			},
+			{
+				Target: &policyv1alpha1.LogFieldSelector{
+					Target: &policyv1alpha1.LogFieldSelector_LogAttribute{
+						LogAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"sampling.threshold"},
+						},
+					},
+				},
+				Predicate: &policyv1alpha1.LogMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_DoubleValue{
+							DoubleValue: 0.05,
+						},
+					},
+				},
+			},
+			{
+				Target: &policyv1alpha1.LogFieldSelector{
+					Target: &policyv1alpha1.LogFieldSelector_LogAttribute{
+						LogAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"binary.signature"},
+						},
+					},
+				},
+				Predicate: &policyv1alpha1.LogMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_BytesValue{
+							BytesValue: []byte{0xde, 0xad, 0xbe, 0xef},
+						},
+					},
+				},
+			},
+			{
+				Target: &policyv1alpha1.LogFieldSelector{
+					Target: &policyv1alpha1.LogFieldSelector_LogAttribute{
+						LogAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"user", "roles"},
+						},
+					},
+				},
+				Predicate: &policyv1alpha1.LogMatcher_Contains{
+					Contains: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "admin",
+						},
+					},
+				},
+			},
+			{
+				Target: &policyv1alpha1.LogFieldSelector{
+					Target: &policyv1alpha1.LogFieldSelector_RecordField{
+						RecordField: policyv1alpha1.LogRecordField_LOG_RECORD_FIELD_SEVERITY_NUMBER,
+					},
+				},
+				Predicate: &policyv1alpha1.LogMatcher_Gte{
+					Gte: &policyv1alpha1.NumericValue{
+						Value: &policyv1alpha1.NumericValue_IntValue{
+							IntValue: 17, // ERROR
+						},
+					},
+				},
+			},
+			{
+				Target: &policyv1alpha1.LogFieldSelector{
+					Target: &policyv1alpha1.LogFieldSelector_LogAttribute{
+						LogAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"latency_seconds"},
+						},
+					},
+				},
+				Predicate: &policyv1alpha1.LogMatcher_Gt{
+					Gt: &policyv1alpha1.NumericValue{
+						Value: &policyv1alpha1.NumericValue_DoubleValue{
+							DoubleValue: 2.5,
+						},
+					},
 				},
 			},
 			{
 				Target: &policyv1alpha1.LogFieldSelector{
 					Target: &policyv1alpha1.LogFieldSelector_ResourceAttribute{
-						ResourceAttribute: "service.name",
+						ResourceAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"service.name"},
+						},
 					},
 				},
 				Predicate: &policyv1alpha1.LogMatcher_Exists{
@@ -68,11 +186,17 @@ func TestLogFilterPolicy_Serialization(t *testing.T) {
 			{
 				Target: &policyv1alpha1.LogFieldSelector{
 					Target: &policyv1alpha1.LogFieldSelector_ScopeAttribute{
-						ScopeAttribute: "library.name",
+						ScopeAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"library.name"},
+						},
 					},
 				},
-				Predicate: &policyv1alpha1.LogMatcher_Exact{
-					Exact: "my-library",
+				Predicate: &policyv1alpha1.LogMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "my-library",
+						},
+					},
 				},
 			},
 			{
@@ -81,8 +205,12 @@ func TestLogFilterPolicy_Serialization(t *testing.T) {
 						ScopeField: policyv1alpha1.ScopeField_SCOPE_FIELD_NAME,
 					},
 				},
-				Predicate: &policyv1alpha1.LogMatcher_Exact{
-					Exact: "my-scope",
+				Predicate: &policyv1alpha1.LogMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "my-scope",
+						},
+					},
 				},
 			},
 			{
@@ -91,8 +219,12 @@ func TestLogFilterPolicy_Serialization(t *testing.T) {
 						ScopeField: policyv1alpha1.ScopeField_SCOPE_FIELD_VERSION,
 					},
 				},
-				Predicate: &policyv1alpha1.LogMatcher_Exact{
-					Exact: "v1.2.3",
+				Predicate: &policyv1alpha1.LogMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "v1.2.3",
+						},
+					},
 				},
 			},
 			{
@@ -101,8 +233,12 @@ func TestLogFilterPolicy_Serialization(t *testing.T) {
 						ScopeField: policyv1alpha1.ScopeField_SCOPE_FIELD_SCHEMA_URL,
 					},
 				},
-				Predicate: &policyv1alpha1.LogMatcher_Exact{
-					Exact: "https://opentelemetry.io/schemas/1.24.0",
+				Predicate: &policyv1alpha1.LogMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "https://opentelemetry.io/schemas/1.24.0",
+						},
+					},
 				},
 			},
 		},
@@ -124,7 +260,7 @@ func TestLogFilterPolicy_Serialization(t *testing.T) {
 	assert.Equal(t, "drop-noisy-healthchecks", unmarshaled.GetId())
 	assert.NotNil(t, unmarshaled.Action)
 	assert.Equal(t, policyv1alpha1.Action_ACTION_DROP, unmarshaled.GetAction())
-	require.Len(t, unmarshaled.GetMatches(), 7)
+	require.Len(t, unmarshaled.GetMatches(), 14)
 }
 
 func TestLogFilterPolicy_JSONSerialization(t *testing.T) {
@@ -135,13 +271,35 @@ func TestLogFilterPolicy_JSONSerialization(t *testing.T) {
 			{
 				Target: &policyv1alpha1.LogFieldSelector{
 					Target: &policyv1alpha1.LogFieldSelector_LogAttribute{
-						LogAttribute: "http.route",
+						LogAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"http.route"},
+						},
 					},
 				},
-				Predicate: &policyv1alpha1.LogMatcher_Exact{
-					Exact: "/healthz",
+				Predicate: &policyv1alpha1.LogMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "/healthz",
+						},
+					},
 				},
 				Negate: false,
+			},
+			{
+				Target: &policyv1alpha1.LogFieldSelector{
+					Target: &policyv1alpha1.LogFieldSelector_LogAttribute{
+						LogAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"http.status_code"},
+						},
+					},
+				},
+				Predicate: &policyv1alpha1.LogMatcher_Gte{
+					Gte: &policyv1alpha1.NumericValue{
+						Value: &policyv1alpha1.NumericValue_IntValue{
+							IntValue: 400,
+						},
+					},
+				},
 			},
 			{
 				Target: &policyv1alpha1.LogFieldSelector{
@@ -156,6 +314,7 @@ func TestLogFilterPolicy_JSONSerialization(t *testing.T) {
 			},
 		},
 	}
+
 
 
 	// ProtoJSON marshal and unmarshal round-trip.

--- a/gen/go/policy/v1alpha1/metric_filter_policy.pb.go
+++ b/gen/go/policy/v1alpha1/metric_filter_policy.pb.go
@@ -52,14 +52,14 @@ const (
 	MetricDescriptorField_METRIC_DESCRIPTOR_FIELD_UNIT MetricDescriptorField = 3
 	// The primary data type of the metric (e.g. "GAUGE", "SUM", "HISTOGRAM",
 	// "EXPONENTIAL_HISTOGRAM", "SUMMARY"). When selected, string predicates
-	// (`exact`, `regex`) evaluate against uppercase type names.
+	// (`equals` with string_value, `regex`) evaluate against uppercase type names.
 	MetricDescriptorField_METRIC_DESCRIPTOR_FIELD_TYPE MetricDescriptorField = 4
 	// The aggregation temporality of the metric (OTLP path: metric.*.aggregation_temporality,
 	// e.g. for Sum, Histogram, ExponentialHistogram). When selected, string predicates
-	// (`exact`, `regex`) evaluate against uppercase names: "DELTA" or "CUMULATIVE".
+	// (`equals` with string_value, `regex`) evaluate against uppercase names: "DELTA" or "CUMULATIVE".
 	MetricDescriptorField_METRIC_DESCRIPTOR_FIELD_AGGREGATION_TEMPORALITY MetricDescriptorField = 5
 	// Whether a Sum metric is monotonic (OTLP path: metric.sum.is_monotonic).
-	// When selected, string predicates (`exact`, `regex`) evaluate against "true" or "false".
+	// Evaluates against typed `equals` (`bool_value`), or "true"/"false" for `regex`.
 	MetricDescriptorField_METRIC_DESCRIPTOR_FIELD_IS_MONOTONIC MetricDescriptorField = 6
 )
 
@@ -216,8 +216,13 @@ type MetricMatcher struct {
 	// Types that are valid to be assigned to Predicate:
 	//
 	//	*MetricMatcher_Exists
-	//	*MetricMatcher_Exact
+	//	*MetricMatcher_Equals
 	//	*MetricMatcher_Regex
+	//	*MetricMatcher_Gt
+	//	*MetricMatcher_Gte
+	//	*MetricMatcher_Lt
+	//	*MetricMatcher_Lte
+	//	*MetricMatcher_Contains
 	Predicate isMetricMatcher_Predicate `protobuf_oneof:"predicate"`
 	// If true, inverts the result of the predicate (logical NOT).
 	Negate        bool `protobuf:"varint,2,opt,name=negate,proto3" json:"negate,omitempty"`
@@ -278,13 +283,13 @@ func (x *MetricMatcher) GetExists() *emptypb.Empty {
 	return nil
 }
 
-func (x *MetricMatcher) GetExact() string {
+func (x *MetricMatcher) GetEquals() *Value {
 	if x != nil {
-		if x, ok := x.Predicate.(*MetricMatcher_Exact); ok {
-			return x.Exact
+		if x, ok := x.Predicate.(*MetricMatcher_Equals); ok {
+			return x.Equals
 		}
 	}
-	return ""
+	return nil
 }
 
 func (x *MetricMatcher) GetRegex() string {
@@ -294,6 +299,51 @@ func (x *MetricMatcher) GetRegex() string {
 		}
 	}
 	return ""
+}
+
+func (x *MetricMatcher) GetGt() *NumericValue {
+	if x != nil {
+		if x, ok := x.Predicate.(*MetricMatcher_Gt); ok {
+			return x.Gt
+		}
+	}
+	return nil
+}
+
+func (x *MetricMatcher) GetGte() *NumericValue {
+	if x != nil {
+		if x, ok := x.Predicate.(*MetricMatcher_Gte); ok {
+			return x.Gte
+		}
+	}
+	return nil
+}
+
+func (x *MetricMatcher) GetLt() *NumericValue {
+	if x != nil {
+		if x, ok := x.Predicate.(*MetricMatcher_Lt); ok {
+			return x.Lt
+		}
+	}
+	return nil
+}
+
+func (x *MetricMatcher) GetLte() *NumericValue {
+	if x != nil {
+		if x, ok := x.Predicate.(*MetricMatcher_Lte); ok {
+			return x.Lte
+		}
+	}
+	return nil
+}
+
+func (x *MetricMatcher) GetContains() *Value {
+	if x != nil {
+		if x, ok := x.Predicate.(*MetricMatcher_Contains); ok {
+			return x.Contains
+		}
+	}
+	return nil
 }
 
 func (x *MetricMatcher) GetNegate() bool {
@@ -317,24 +367,67 @@ type MetricMatcher_Exists struct {
 	Exists *emptypb.Empty `protobuf:"bytes,10,opt,name=exists,proto3,oneof"`
 }
 
-type MetricMatcher_Exact struct {
-	// Exact string equality match.
-	Exact string `protobuf:"bytes,11,opt,name=exact,proto3,oneof"`
+type MetricMatcher_Equals struct {
+	// Typed scalar equality match (supporting string, int64, bool, double, bytes).
+	Equals *Value `protobuf:"bytes,11,opt,name=equals,proto3,oneof"`
 }
 
 type MetricMatcher_Regex struct {
 	// Regular expression match using RE2 syntax.
 	// Evaluates as an unanchored partial match (like Go regexp.MatchString and
 	// OpenTelemetry OTTL IsMatch). Callers requiring full string equality must
-	// provide explicit anchors ('^' and '$').
+	// provide explicit anchors ('^' and '$'). Applies strictly to string
+	// fields and string attribute values.
 	Regex string `protobuf:"bytes,12,opt,name=regex,proto3,oneof"`
+}
+
+type MetricMatcher_Gt struct {
+	// Matches if the target numeric value is strictly greater than this value.
+	// Applies strictly to int64 and double fields and attribute values.
+	Gt *NumericValue `protobuf:"bytes,13,opt,name=gt,proto3,oneof"`
+}
+
+type MetricMatcher_Gte struct {
+	// Matches if the target numeric value is greater than or equal to this value.
+	// Applies strictly to int64 and double fields and attribute values.
+	Gte *NumericValue `protobuf:"bytes,14,opt,name=gte,proto3,oneof"`
+}
+
+type MetricMatcher_Lt struct {
+	// Matches if the target numeric value is strictly less than this value.
+	// Applies strictly to int64 and double fields and attribute values.
+	Lt *NumericValue `protobuf:"bytes,15,opt,name=lt,proto3,oneof"`
+}
+
+type MetricMatcher_Lte struct {
+	// Matches if the target numeric value is less than or equal to this value.
+	// Applies strictly to int64 and double fields and attribute values.
+	Lte *NumericValue `protobuf:"bytes,16,opt,name=lte,proto3,oneof"`
+}
+
+type MetricMatcher_Contains struct {
+	// Value containment:
+	// - For list (ArrayValue) attributes: matches if any element in the list equals this value.
+	// - For string fields or attribute values: matches if the string contains this value's string_value as a substring.
+	// - For bytes fields or attribute values: matches if the bytes contain this value's bytes_value as a subsequence.
+	Contains *Value `protobuf:"bytes,17,opt,name=contains,proto3,oneof"`
 }
 
 func (*MetricMatcher_Exists) isMetricMatcher_Predicate() {}
 
-func (*MetricMatcher_Exact) isMetricMatcher_Predicate() {}
+func (*MetricMatcher_Equals) isMetricMatcher_Predicate() {}
 
 func (*MetricMatcher_Regex) isMetricMatcher_Predicate() {}
+
+func (*MetricMatcher_Gt) isMetricMatcher_Predicate() {}
+
+func (*MetricMatcher_Gte) isMetricMatcher_Predicate() {}
+
+func (*MetricMatcher_Lt) isMetricMatcher_Predicate() {}
+
+func (*MetricMatcher_Lte) isMetricMatcher_Predicate() {}
+
+func (*MetricMatcher_Contains) isMetricMatcher_Predicate() {}
 
 // MetricFieldSelector designates a first-class OTel metric field, attribute, or metadata.
 type MetricFieldSelector struct {
@@ -397,31 +490,31 @@ func (x *MetricFieldSelector) GetDescriptorField() MetricDescriptorField {
 	return MetricDescriptorField_METRIC_DESCRIPTOR_FIELD_UNSPECIFIED
 }
 
-func (x *MetricFieldSelector) GetDatapointAttribute() string {
+func (x *MetricFieldSelector) GetDatapointAttribute() *AttributePath {
 	if x != nil {
 		if x, ok := x.Target.(*MetricFieldSelector_DatapointAttribute); ok {
 			return x.DatapointAttribute
 		}
 	}
-	return ""
+	return nil
 }
 
-func (x *MetricFieldSelector) GetResourceAttribute() string {
+func (x *MetricFieldSelector) GetResourceAttribute() *AttributePath {
 	if x != nil {
 		if x, ok := x.Target.(*MetricFieldSelector_ResourceAttribute); ok {
 			return x.ResourceAttribute
 		}
 	}
-	return ""
+	return nil
 }
 
-func (x *MetricFieldSelector) GetScopeAttribute() string {
+func (x *MetricFieldSelector) GetScopeAttribute() *AttributePath {
 	if x != nil {
 		if x, ok := x.Target.(*MetricFieldSelector_ScopeAttribute); ok {
 			return x.ScopeAttribute
 		}
 	}
-	return ""
+	return nil
 }
 
 func (x *MetricFieldSelector) GetScopeField() ScopeField {
@@ -438,27 +531,27 @@ type isMetricFieldSelector_Target interface {
 }
 
 type MetricFieldSelector_DescriptorField struct {
-	// Top-level metric descriptor fields (OTLP path: metric.*).
+	// Top-level metric descriptor fields (e.g. name, description, unit).
 	DescriptorField MetricDescriptorField `protobuf:"varint,1,opt,name=descriptor_field,json=descriptorField,proto3,enum=google.telemetry.policy.v1alpha1.MetricDescriptorField,oneof"`
 }
 
 type MetricFieldSelector_DatapointAttribute struct {
-	// Attribute on an individual metric data point (OTLP path: metric.*.data_points[*].attributes[*], e.g. "http.status_code", "env").
-	DatapointAttribute string `protobuf:"bytes,2,opt,name=datapoint_attribute,json=datapointAttribute,proto3,oneof"`
+	// Attribute on an individual metric data point by key or path (e.g. ["http.status_code"] or ["env"]).
+	DatapointAttribute *AttributePath `protobuf:"bytes,2,opt,name=datapoint_attribute,json=datapointAttribute,proto3,oneof"`
 }
 
 type MetricFieldSelector_ResourceAttribute struct {
-	// Resource attribute by key (OTLP path: resource.attributes[*], e.g. "service.name", "k8s.pod.name").
-	ResourceAttribute string `protobuf:"bytes,3,opt,name=resource_attribute,json=resourceAttribute,proto3,oneof"`
+	// Resource attribute by key or path (e.g. ["service.name"] or ["host", "id"]).
+	ResourceAttribute *AttributePath `protobuf:"bytes,3,opt,name=resource_attribute,json=resourceAttribute,proto3,oneof"`
 }
 
 type MetricFieldSelector_ScopeAttribute struct {
-	// Instrumentation scope attribute by key (OTLP path: scope.attributes[*], e.g. "library.name").
-	ScopeAttribute string `protobuf:"bytes,4,opt,name=scope_attribute,json=scopeAttribute,proto3,oneof"`
+	// Instrumentation scope attribute by key or path (e.g. ["library.name"]).
+	ScopeAttribute *AttributePath `protobuf:"bytes,4,opt,name=scope_attribute,json=scopeAttribute,proto3,oneof"`
 }
 
 type MetricFieldSelector_ScopeField struct {
-	// Standard first-class OpenTelemetry InstrumentationScope fields (OTLP path: scope.*).
+	// Standard first-class OpenTelemetry InstrumentationScope fields (e.g. name, version).
 	ScopeField ScopeField `protobuf:"varint,5,opt,name=scope_field,json=scopeField,proto3,enum=google.telemetry.policy.v1alpha1.ScopeField,oneof"`
 }
 
@@ -481,20 +574,25 @@ const file_policy_v1alpha1_metric_filter_policy_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12E\n" +
 	"\x06action\x18\x02 \x01(\x0e2(.google.telemetry.policy.v1alpha1.ActionH\x00R\x06action\x88\x01\x01\x12I\n" +
 	"\amatches\x18\x03 \x03(\v2/.google.telemetry.policy.v1alpha1.MetricMatcherR\amatchesB\t\n" +
-	"\a_action\"\xe5\x01\n" +
+	"\a_action\"\xe3\x04\n" +
 	"\rMetricMatcher\x12M\n" +
 	"\x06target\x18\x01 \x01(\v25.google.telemetry.policy.v1alpha1.MetricFieldSelectorR\x06target\x120\n" +
 	"\x06exists\x18\n" +
-	" \x01(\v2\x16.google.protobuf.EmptyH\x00R\x06exists\x12\x16\n" +
-	"\x05exact\x18\v \x01(\tH\x00R\x05exact\x12\x16\n" +
-	"\x05regex\x18\f \x01(\tH\x00R\x05regex\x12\x16\n" +
+	" \x01(\v2\x16.google.protobuf.EmptyH\x00R\x06exists\x12A\n" +
+	"\x06equals\x18\v \x01(\v2'.google.telemetry.policy.v1alpha1.ValueH\x00R\x06equals\x12\x16\n" +
+	"\x05regex\x18\f \x01(\tH\x00R\x05regex\x12@\n" +
+	"\x02gt\x18\r \x01(\v2..google.telemetry.policy.v1alpha1.NumericValueH\x00R\x02gt\x12B\n" +
+	"\x03gte\x18\x0e \x01(\v2..google.telemetry.policy.v1alpha1.NumericValueH\x00R\x03gte\x12@\n" +
+	"\x02lt\x18\x0f \x01(\v2..google.telemetry.policy.v1alpha1.NumericValueH\x00R\x02lt\x12B\n" +
+	"\x03lte\x18\x10 \x01(\v2..google.telemetry.policy.v1alpha1.NumericValueH\x00R\x03lte\x12E\n" +
+	"\bcontains\x18\x11 \x01(\v2'.google.telemetry.policy.v1alpha1.ValueH\x00R\bcontains\x12\x16\n" +
 	"\x06negate\x18\x02 \x01(\bR\x06negateB\v\n" +
-	"\tpredicate\"\xe5\x02\n" +
+	"\tpredicate\"\xf8\x03\n" +
 	"\x13MetricFieldSelector\x12d\n" +
-	"\x10descriptor_field\x18\x01 \x01(\x0e27.google.telemetry.policy.v1alpha1.MetricDescriptorFieldH\x00R\x0fdescriptorField\x121\n" +
-	"\x13datapoint_attribute\x18\x02 \x01(\tH\x00R\x12datapointAttribute\x12/\n" +
-	"\x12resource_attribute\x18\x03 \x01(\tH\x00R\x11resourceAttribute\x12)\n" +
-	"\x0fscope_attribute\x18\x04 \x01(\tH\x00R\x0escopeAttribute\x12O\n" +
+	"\x10descriptor_field\x18\x01 \x01(\x0e27.google.telemetry.policy.v1alpha1.MetricDescriptorFieldH\x00R\x0fdescriptorField\x12b\n" +
+	"\x13datapoint_attribute\x18\x02 \x01(\v2/.google.telemetry.policy.v1alpha1.AttributePathH\x00R\x12datapointAttribute\x12`\n" +
+	"\x12resource_attribute\x18\x03 \x01(\v2/.google.telemetry.policy.v1alpha1.AttributePathH\x00R\x11resourceAttribute\x12Z\n" +
+	"\x0fscope_attribute\x18\x04 \x01(\v2/.google.telemetry.policy.v1alpha1.AttributePathH\x00R\x0escopeAttribute\x12O\n" +
 	"\vscope_field\x18\x05 \x01(\x0e2,.google.telemetry.policy.v1alpha1.ScopeFieldH\x00R\n" +
 	"scopeFieldB\b\n" +
 	"\x06target*\xae\x02\n" +
@@ -529,20 +627,32 @@ var file_policy_v1alpha1_metric_filter_policy_proto_goTypes = []any{
 	(*MetricFieldSelector)(nil), // 3: google.telemetry.policy.v1alpha1.MetricFieldSelector
 	(Action)(0),                 // 4: google.telemetry.policy.v1alpha1.Action
 	(*emptypb.Empty)(nil),       // 5: google.protobuf.Empty
-	(ScopeField)(0),             // 6: google.telemetry.policy.v1alpha1.ScopeField
+	(*Value)(nil),               // 6: google.telemetry.policy.v1alpha1.Value
+	(*NumericValue)(nil),        // 7: google.telemetry.policy.v1alpha1.NumericValue
+	(*AttributePath)(nil),       // 8: google.telemetry.policy.v1alpha1.AttributePath
+	(ScopeField)(0),             // 9: google.telemetry.policy.v1alpha1.ScopeField
 }
 var file_policy_v1alpha1_metric_filter_policy_proto_depIdxs = []int32{
-	4, // 0: google.telemetry.policy.v1alpha1.MetricFilterPolicy.action:type_name -> google.telemetry.policy.v1alpha1.Action
-	2, // 1: google.telemetry.policy.v1alpha1.MetricFilterPolicy.matches:type_name -> google.telemetry.policy.v1alpha1.MetricMatcher
-	3, // 2: google.telemetry.policy.v1alpha1.MetricMatcher.target:type_name -> google.telemetry.policy.v1alpha1.MetricFieldSelector
-	5, // 3: google.telemetry.policy.v1alpha1.MetricMatcher.exists:type_name -> google.protobuf.Empty
-	0, // 4: google.telemetry.policy.v1alpha1.MetricFieldSelector.descriptor_field:type_name -> google.telemetry.policy.v1alpha1.MetricDescriptorField
-	6, // 5: google.telemetry.policy.v1alpha1.MetricFieldSelector.scope_field:type_name -> google.telemetry.policy.v1alpha1.ScopeField
-	6, // [6:6] is the sub-list for method output_type
-	6, // [6:6] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	4,  // 0: google.telemetry.policy.v1alpha1.MetricFilterPolicy.action:type_name -> google.telemetry.policy.v1alpha1.Action
+	2,  // 1: google.telemetry.policy.v1alpha1.MetricFilterPolicy.matches:type_name -> google.telemetry.policy.v1alpha1.MetricMatcher
+	3,  // 2: google.telemetry.policy.v1alpha1.MetricMatcher.target:type_name -> google.telemetry.policy.v1alpha1.MetricFieldSelector
+	5,  // 3: google.telemetry.policy.v1alpha1.MetricMatcher.exists:type_name -> google.protobuf.Empty
+	6,  // 4: google.telemetry.policy.v1alpha1.MetricMatcher.equals:type_name -> google.telemetry.policy.v1alpha1.Value
+	7,  // 5: google.telemetry.policy.v1alpha1.MetricMatcher.gt:type_name -> google.telemetry.policy.v1alpha1.NumericValue
+	7,  // 6: google.telemetry.policy.v1alpha1.MetricMatcher.gte:type_name -> google.telemetry.policy.v1alpha1.NumericValue
+	7,  // 7: google.telemetry.policy.v1alpha1.MetricMatcher.lt:type_name -> google.telemetry.policy.v1alpha1.NumericValue
+	7,  // 8: google.telemetry.policy.v1alpha1.MetricMatcher.lte:type_name -> google.telemetry.policy.v1alpha1.NumericValue
+	6,  // 9: google.telemetry.policy.v1alpha1.MetricMatcher.contains:type_name -> google.telemetry.policy.v1alpha1.Value
+	0,  // 10: google.telemetry.policy.v1alpha1.MetricFieldSelector.descriptor_field:type_name -> google.telemetry.policy.v1alpha1.MetricDescriptorField
+	8,  // 11: google.telemetry.policy.v1alpha1.MetricFieldSelector.datapoint_attribute:type_name -> google.telemetry.policy.v1alpha1.AttributePath
+	8,  // 12: google.telemetry.policy.v1alpha1.MetricFieldSelector.resource_attribute:type_name -> google.telemetry.policy.v1alpha1.AttributePath
+	8,  // 13: google.telemetry.policy.v1alpha1.MetricFieldSelector.scope_attribute:type_name -> google.telemetry.policy.v1alpha1.AttributePath
+	9,  // 14: google.telemetry.policy.v1alpha1.MetricFieldSelector.scope_field:type_name -> google.telemetry.policy.v1alpha1.ScopeField
+	15, // [15:15] is the sub-list for method output_type
+	15, // [15:15] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_policy_v1alpha1_metric_filter_policy_proto_init() }
@@ -554,8 +664,13 @@ func file_policy_v1alpha1_metric_filter_policy_proto_init() {
 	file_policy_v1alpha1_metric_filter_policy_proto_msgTypes[0].OneofWrappers = []any{}
 	file_policy_v1alpha1_metric_filter_policy_proto_msgTypes[1].OneofWrappers = []any{
 		(*MetricMatcher_Exists)(nil),
-		(*MetricMatcher_Exact)(nil),
+		(*MetricMatcher_Equals)(nil),
 		(*MetricMatcher_Regex)(nil),
+		(*MetricMatcher_Gt)(nil),
+		(*MetricMatcher_Gte)(nil),
+		(*MetricMatcher_Lt)(nil),
+		(*MetricMatcher_Lte)(nil),
+		(*MetricMatcher_Contains)(nil),
 	}
 	file_policy_v1alpha1_metric_filter_policy_proto_msgTypes[2].OneofWrappers = []any{
 		(*MetricFieldSelector_DescriptorField)(nil),

--- a/gen/go/policy/v1alpha1/metric_filter_policy_test.go
+++ b/gen/go/policy/v1alpha1/metric_filter_policy_test.go
@@ -51,14 +51,68 @@ func TestMetricFilterPolicy_Serialization(t *testing.T) {
 						DescriptorField: policyv1alpha1.MetricDescriptorField_METRIC_DESCRIPTOR_FIELD_TYPE,
 					},
 				},
-				Predicate: &policyv1alpha1.MetricMatcher_Exact{
-					Exact: "HISTOGRAM",
+				Predicate: &policyv1alpha1.MetricMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "HISTOGRAM",
+						},
+					},
 				},
 			},
 			{
 				Target: &policyv1alpha1.MetricFieldSelector{
 					Target: &policyv1alpha1.MetricFieldSelector_DatapointAttribute{
-						DatapointAttribute: "http.status_code",
+						DatapointAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"http.status_code"},
+						},
+					},
+				},
+				Predicate: &policyv1alpha1.MetricMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_IntValue{
+							IntValue: 200,
+						},
+					},
+				},
+			},
+			{
+				Target: &policyv1alpha1.MetricFieldSelector{
+					Target: &policyv1alpha1.MetricFieldSelector_DatapointAttribute{
+						DatapointAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"http.status_code"},
+						},
+					},
+				},
+				Predicate: &policyv1alpha1.MetricMatcher_Gte{
+					Gte: &policyv1alpha1.NumericValue{
+						Value: &policyv1alpha1.NumericValue_IntValue{
+							IntValue: 400,
+						},
+					},
+				},
+			},
+			{
+				Target: &policyv1alpha1.MetricFieldSelector{
+					Target: &policyv1alpha1.MetricFieldSelector_DatapointAttribute{
+						DatapointAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"pools", "active"},
+						},
+					},
+				},
+				Predicate: &policyv1alpha1.MetricMatcher_Contains{
+					Contains: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "worker",
+						},
+					},
+				},
+			},
+			{
+				Target: &policyv1alpha1.MetricFieldSelector{
+					Target: &policyv1alpha1.MetricFieldSelector_DatapointAttribute{
+						DatapointAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"http.status_code"},
+						},
 					},
 				},
 				Predicate: &policyv1alpha1.MetricMatcher_Exists{
@@ -69,21 +123,33 @@ func TestMetricFilterPolicy_Serialization(t *testing.T) {
 			{
 				Target: &policyv1alpha1.MetricFieldSelector{
 					Target: &policyv1alpha1.MetricFieldSelector_ResourceAttribute{
-						ResourceAttribute: "service.name",
+						ResourceAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"service.name"},
+						},
 					},
 				},
-				Predicate: &policyv1alpha1.MetricMatcher_Exact{
-					Exact: "frontend",
+				Predicate: &policyv1alpha1.MetricMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "frontend",
+						},
+					},
 				},
 			},
 			{
 				Target: &policyv1alpha1.MetricFieldSelector{
 					Target: &policyv1alpha1.MetricFieldSelector_ScopeAttribute{
-						ScopeAttribute: "library.name",
+						ScopeAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"library.name"},
+						},
 					},
 				},
-				Predicate: &policyv1alpha1.MetricMatcher_Exact{
-					Exact: "net/http",
+				Predicate: &policyv1alpha1.MetricMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "net/http",
+						},
+					},
 				},
 			},
 			{
@@ -92,8 +158,12 @@ func TestMetricFilterPolicy_Serialization(t *testing.T) {
 						ScopeField: policyv1alpha1.ScopeField_SCOPE_FIELD_NAME,
 					},
 				},
-				Predicate: &policyv1alpha1.MetricMatcher_Exact{
-					Exact: "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",
+				Predicate: &policyv1alpha1.MetricMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",
+						},
+					},
 				},
 			},
 			{
@@ -102,8 +172,12 @@ func TestMetricFilterPolicy_Serialization(t *testing.T) {
 						ScopeField: policyv1alpha1.ScopeField_SCOPE_FIELD_VERSION,
 					},
 				},
-				Predicate: &policyv1alpha1.MetricMatcher_Exact{
-					Exact: "v0.40.0",
+				Predicate: &policyv1alpha1.MetricMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "v0.40.0",
+						},
+					},
 				},
 			},
 			{
@@ -112,8 +186,12 @@ func TestMetricFilterPolicy_Serialization(t *testing.T) {
 						ScopeField: policyv1alpha1.ScopeField_SCOPE_FIELD_SCHEMA_URL,
 					},
 				},
-				Predicate: &policyv1alpha1.MetricMatcher_Exact{
-					Exact: "https://opentelemetry.io/schemas/1.24.0",
+				Predicate: &policyv1alpha1.MetricMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "https://opentelemetry.io/schemas/1.24.0",
+						},
+					},
 				},
 			},
 			{
@@ -122,8 +200,12 @@ func TestMetricFilterPolicy_Serialization(t *testing.T) {
 						DescriptorField: policyv1alpha1.MetricDescriptorField_METRIC_DESCRIPTOR_FIELD_AGGREGATION_TEMPORALITY,
 					},
 				},
-				Predicate: &policyv1alpha1.MetricMatcher_Exact{
-					Exact: "DELTA",
+				Predicate: &policyv1alpha1.MetricMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "DELTA",
+						},
+					},
 				},
 			},
 			{
@@ -132,8 +214,12 @@ func TestMetricFilterPolicy_Serialization(t *testing.T) {
 						DescriptorField: policyv1alpha1.MetricDescriptorField_METRIC_DESCRIPTOR_FIELD_IS_MONOTONIC,
 					},
 				},
-				Predicate: &policyv1alpha1.MetricMatcher_Exact{
-					Exact: "true",
+				Predicate: &policyv1alpha1.MetricMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_BoolValue{
+							BoolValue: true,
+						},
+					},
 				},
 			},
 		},
@@ -150,7 +236,7 @@ func TestMetricFilterPolicy_Serialization(t *testing.T) {
 	assert.NotNil(t, unmarshaled.Action)
 	assert.Equal(t, policy.GetId(), unmarshaled.GetId())
 	assert.Equal(t, policy.GetAction(), unmarshaled.GetAction())
-	require.Len(t, unmarshaled.GetMatches(), 10)
+	require.Len(t, unmarshaled.GetMatches(), 13)
 
 	// Check descriptor field name matcher.
 	matcher0 := unmarshaled.GetMatches()[0]
@@ -163,30 +249,45 @@ func TestMetricFilterPolicy_Serialization(t *testing.T) {
 	matcher1 := unmarshaled.GetMatches()[1]
 	descFieldType := matcher1.GetTarget().GetDescriptorField()
 	assert.Equal(t, policyv1alpha1.MetricDescriptorField_METRIC_DESCRIPTOR_FIELD_TYPE, descFieldType)
-	assert.Equal(t, "HISTOGRAM", matcher1.GetExact())
+	assert.Equal(t, "HISTOGRAM", matcher1.GetEquals().GetStringValue())
+
+	// Check datapoint attribute equals matcher with int value.
+	matcher2 := unmarshaled.GetMatches()[2]
+	assert.Equal(t, "http.status_code", matcher2.GetTarget().GetDatapointAttribute().GetPath()[0])
+	assert.Equal(t, int64(200), matcher2.GetEquals().GetIntValue())
+
+	// Check datapoint attribute gte matcher with int value.
+	matcher3 := unmarshaled.GetMatches()[3]
+	assert.Equal(t, "http.status_code", matcher3.GetTarget().GetDatapointAttribute().GetPath()[0])
+	assert.Equal(t, int64(400), matcher3.GetGte().GetIntValue())
+
+	// Check contains matcher.
+	matcher4 := unmarshaled.GetMatches()[4]
+	assert.Equal(t, []string{"pools", "active"}, matcher4.GetTarget().GetDatapointAttribute().GetPath())
+	assert.Equal(t, "worker", matcher4.GetContains().GetStringValue())
 
 	// Check datapoint attribute exists matcher with negate.
-	matcher2 := unmarshaled.GetMatches()[2]
-	assert.Equal(t, "http.status_code", matcher2.GetTarget().GetDatapointAttribute())
-	assert.NotNil(t, matcher2.GetExists())
-	assert.True(t, matcher2.GetNegate())
+	matcher5 := unmarshaled.GetMatches()[5]
+	assert.Equal(t, "http.status_code", matcher5.GetTarget().GetDatapointAttribute().GetPath()[0])
+	assert.NotNil(t, matcher5.GetExists())
+	assert.True(t, matcher5.GetNegate())
 
 	// Check scope field matcher.
-	matcher5 := unmarshaled.GetMatches()[5]
-	assert.Equal(t, policyv1alpha1.ScopeField_SCOPE_FIELD_NAME, matcher5.GetTarget().GetScopeField())
-	assert.Equal(t, "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp", matcher5.GetExact())
+	matcher8 := unmarshaled.GetMatches()[8]
+	assert.Equal(t, policyv1alpha1.ScopeField_SCOPE_FIELD_NAME, matcher8.GetTarget().GetScopeField())
+	assert.Equal(t, "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp", matcher8.GetEquals().GetStringValue())
 
 	// Check descriptor field aggregation temporality matcher.
-	matcher8 := unmarshaled.GetMatches()[8]
-	descFieldTemporality := matcher8.GetTarget().GetDescriptorField()
+	matcher11 := unmarshaled.GetMatches()[11]
+	descFieldTemporality := matcher11.GetTarget().GetDescriptorField()
 	assert.Equal(t, policyv1alpha1.MetricDescriptorField_METRIC_DESCRIPTOR_FIELD_AGGREGATION_TEMPORALITY, descFieldTemporality)
-	assert.Equal(t, "DELTA", matcher8.GetExact())
+	assert.Equal(t, "DELTA", matcher11.GetEquals().GetStringValue())
 
 	// Check descriptor field is monotonic matcher.
-	matcher9 := unmarshaled.GetMatches()[9]
-	descFieldMonotonic := matcher9.GetTarget().GetDescriptorField()
+	matcher12 := unmarshaled.GetMatches()[12]
+	descFieldMonotonic := matcher12.GetTarget().GetDescriptorField()
 	assert.Equal(t, policyv1alpha1.MetricDescriptorField_METRIC_DESCRIPTOR_FIELD_IS_MONOTONIC, descFieldMonotonic)
-	assert.Equal(t, "true", matcher9.GetExact())
+	assert.True(t, matcher12.GetEquals().GetBoolValue())
 }
 
 func TestMetricFilterPolicy_AnyPackaging(t *testing.T) {
@@ -234,11 +335,17 @@ func TestMetricFilterPolicy_JSONSerialization(t *testing.T) {
 			{
 				Target: &policyv1alpha1.MetricFieldSelector{
 					Target: &policyv1alpha1.MetricFieldSelector_DatapointAttribute{
-						DatapointAttribute: "http.status_code",
+						DatapointAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"http.status_code"},
+						},
 					},
 				},
-				Predicate: &policyv1alpha1.MetricMatcher_Exact{
-					Exact: "200",
+				Predicate: &policyv1alpha1.MetricMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_IntValue{
+							IntValue: 200,
+						},
+					},
 				},
 				Negate: false,
 			},

--- a/gen/go/policy/v1alpha1/trace_filter_policy.pb.go
+++ b/gen/go/policy/v1alpha1/trace_filter_policy.pb.go
@@ -229,8 +229,13 @@ type TraceMatcher struct {
 	// Types that are valid to be assigned to Predicate:
 	//
 	//	*TraceMatcher_Exists
-	//	*TraceMatcher_Exact
+	//	*TraceMatcher_Equals
 	//	*TraceMatcher_Regex
+	//	*TraceMatcher_Gt
+	//	*TraceMatcher_Gte
+	//	*TraceMatcher_Lt
+	//	*TraceMatcher_Lte
+	//	*TraceMatcher_Contains
 	Predicate isTraceMatcher_Predicate `protobuf_oneof:"predicate"`
 	// If true, inverts the result of the predicate (logical NOT).
 	Negate        bool `protobuf:"varint,2,opt,name=negate,proto3" json:"negate,omitempty"`
@@ -291,13 +296,13 @@ func (x *TraceMatcher) GetExists() *emptypb.Empty {
 	return nil
 }
 
-func (x *TraceMatcher) GetExact() string {
+func (x *TraceMatcher) GetEquals() *Value {
 	if x != nil {
-		if x, ok := x.Predicate.(*TraceMatcher_Exact); ok {
-			return x.Exact
+		if x, ok := x.Predicate.(*TraceMatcher_Equals); ok {
+			return x.Equals
 		}
 	}
-	return ""
+	return nil
 }
 
 func (x *TraceMatcher) GetRegex() string {
@@ -307,6 +312,51 @@ func (x *TraceMatcher) GetRegex() string {
 		}
 	}
 	return ""
+}
+
+func (x *TraceMatcher) GetGt() *NumericValue {
+	if x != nil {
+		if x, ok := x.Predicate.(*TraceMatcher_Gt); ok {
+			return x.Gt
+		}
+	}
+	return nil
+}
+
+func (x *TraceMatcher) GetGte() *NumericValue {
+	if x != nil {
+		if x, ok := x.Predicate.(*TraceMatcher_Gte); ok {
+			return x.Gte
+		}
+	}
+	return nil
+}
+
+func (x *TraceMatcher) GetLt() *NumericValue {
+	if x != nil {
+		if x, ok := x.Predicate.(*TraceMatcher_Lt); ok {
+			return x.Lt
+		}
+	}
+	return nil
+}
+
+func (x *TraceMatcher) GetLte() *NumericValue {
+	if x != nil {
+		if x, ok := x.Predicate.(*TraceMatcher_Lte); ok {
+			return x.Lte
+		}
+	}
+	return nil
+}
+
+func (x *TraceMatcher) GetContains() *Value {
+	if x != nil {
+		if x, ok := x.Predicate.(*TraceMatcher_Contains); ok {
+			return x.Contains
+		}
+	}
+	return nil
 }
 
 func (x *TraceMatcher) GetNegate() bool {
@@ -331,24 +381,67 @@ type TraceMatcher_Exists struct {
 	Exists *emptypb.Empty `protobuf:"bytes,10,opt,name=exists,proto3,oneof"`
 }
 
-type TraceMatcher_Exact struct {
-	// Exact string equality match.
-	Exact string `protobuf:"bytes,11,opt,name=exact,proto3,oneof"`
+type TraceMatcher_Equals struct {
+	// Typed scalar equality match (supporting string, int64, bool, double, bytes).
+	Equals *Value `protobuf:"bytes,11,opt,name=equals,proto3,oneof"`
 }
 
 type TraceMatcher_Regex struct {
 	// Regular expression match using RE2 syntax.
 	// Evaluates as an unanchored partial match (like Go regexp.MatchString and
 	// OpenTelemetry OTTL IsMatch). Callers requiring full string equality must
-	// provide explicit anchors ('^' and '$').
+	// provide explicit anchors ('^' and '$'). Applies strictly to string
+	// fields and string attribute values.
 	Regex string `protobuf:"bytes,12,opt,name=regex,proto3,oneof"`
+}
+
+type TraceMatcher_Gt struct {
+	// Matches if the target numeric value is strictly greater than this value.
+	// Applies strictly to int64 and double fields and attribute values.
+	Gt *NumericValue `protobuf:"bytes,13,opt,name=gt,proto3,oneof"`
+}
+
+type TraceMatcher_Gte struct {
+	// Matches if the target numeric value is greater than or equal to this value.
+	// Applies strictly to int64 and double fields and attribute values.
+	Gte *NumericValue `protobuf:"bytes,14,opt,name=gte,proto3,oneof"`
+}
+
+type TraceMatcher_Lt struct {
+	// Matches if the target numeric value is strictly less than this value.
+	// Applies strictly to int64 and double fields and attribute values.
+	Lt *NumericValue `protobuf:"bytes,15,opt,name=lt,proto3,oneof"`
+}
+
+type TraceMatcher_Lte struct {
+	// Matches if the target numeric value is less than or equal to this value.
+	// Applies strictly to int64 and double fields and attribute values.
+	Lte *NumericValue `protobuf:"bytes,16,opt,name=lte,proto3,oneof"`
+}
+
+type TraceMatcher_Contains struct {
+	// Value containment:
+	// - For list (ArrayValue) attributes: matches if any element in the list equals this value.
+	// - For string fields or attribute values: matches if the string contains this value's string_value as a substring.
+	// - For bytes fields or attribute values: matches if the bytes contain this value's bytes_value as a subsequence.
+	Contains *Value `protobuf:"bytes,17,opt,name=contains,proto3,oneof"`
 }
 
 func (*TraceMatcher_Exists) isTraceMatcher_Predicate() {}
 
-func (*TraceMatcher_Exact) isTraceMatcher_Predicate() {}
+func (*TraceMatcher_Equals) isTraceMatcher_Predicate() {}
 
 func (*TraceMatcher_Regex) isTraceMatcher_Predicate() {}
+
+func (*TraceMatcher_Gt) isTraceMatcher_Predicate() {}
+
+func (*TraceMatcher_Gte) isTraceMatcher_Predicate() {}
+
+func (*TraceMatcher_Lt) isTraceMatcher_Predicate() {}
+
+func (*TraceMatcher_Lte) isTraceMatcher_Predicate() {}
+
+func (*TraceMatcher_Contains) isTraceMatcher_Predicate() {}
 
 // TraceFieldSelector designates a first-class OTel span field, attribute, or metadata.
 type TraceFieldSelector struct {
@@ -411,31 +504,31 @@ func (x *TraceFieldSelector) GetRecordField() SpanRecordField {
 	return SpanRecordField_SPAN_RECORD_FIELD_UNSPECIFIED
 }
 
-func (x *TraceFieldSelector) GetSpanAttribute() string {
+func (x *TraceFieldSelector) GetSpanAttribute() *AttributePath {
 	if x != nil {
 		if x, ok := x.Target.(*TraceFieldSelector_SpanAttribute); ok {
 			return x.SpanAttribute
 		}
 	}
-	return ""
+	return nil
 }
 
-func (x *TraceFieldSelector) GetResourceAttribute() string {
+func (x *TraceFieldSelector) GetResourceAttribute() *AttributePath {
 	if x != nil {
 		if x, ok := x.Target.(*TraceFieldSelector_ResourceAttribute); ok {
 			return x.ResourceAttribute
 		}
 	}
-	return ""
+	return nil
 }
 
-func (x *TraceFieldSelector) GetScopeAttribute() string {
+func (x *TraceFieldSelector) GetScopeAttribute() *AttributePath {
 	if x != nil {
 		if x, ok := x.Target.(*TraceFieldSelector_ScopeAttribute); ok {
 			return x.ScopeAttribute
 		}
 	}
-	return ""
+	return nil
 }
 
 func (x *TraceFieldSelector) GetScopeField() ScopeField {
@@ -452,27 +545,27 @@ type isTraceFieldSelector_Target interface {
 }
 
 type TraceFieldSelector_RecordField struct {
-	// Standard first-class OpenTelemetry Span fields (OTLP path: span.*).
+	// Standard first-class OpenTelemetry Span fields (e.g. name, status_code).
 	RecordField SpanRecordField `protobuf:"varint,1,opt,name=record_field,json=recordField,proto3,enum=google.telemetry.policy.v1alpha1.SpanRecordField,oneof"`
 }
 
 type TraceFieldSelector_SpanAttribute struct {
-	// Span attribute by key (OTLP path: span.attributes[*], e.g. "http.route", "db.system", "rpc.method").
-	SpanAttribute string `protobuf:"bytes,2,opt,name=span_attribute,json=spanAttribute,proto3,oneof"`
+	// Span attribute by key or path (e.g. ["http.route"] or ["rpc", "service"]).
+	SpanAttribute *AttributePath `protobuf:"bytes,2,opt,name=span_attribute,json=spanAttribute,proto3,oneof"`
 }
 
 type TraceFieldSelector_ResourceAttribute struct {
-	// Resource attribute by key (OTLP path: resource.attributes[*], e.g. "service.name", "k8s.pod.name").
-	ResourceAttribute string `protobuf:"bytes,3,opt,name=resource_attribute,json=resourceAttribute,proto3,oneof"`
+	// Resource attribute by key or path (e.g. ["service.name"] or ["host", "id"]).
+	ResourceAttribute *AttributePath `protobuf:"bytes,3,opt,name=resource_attribute,json=resourceAttribute,proto3,oneof"`
 }
 
 type TraceFieldSelector_ScopeAttribute struct {
-	// Instrumentation scope attribute by key (OTLP path: scope.attributes[*], e.g. "library.name").
-	ScopeAttribute string `protobuf:"bytes,4,opt,name=scope_attribute,json=scopeAttribute,proto3,oneof"`
+	// Instrumentation scope attribute by key or path (e.g. ["library.name"]).
+	ScopeAttribute *AttributePath `protobuf:"bytes,4,opt,name=scope_attribute,json=scopeAttribute,proto3,oneof"`
 }
 
 type TraceFieldSelector_ScopeField struct {
-	// Standard first-class OpenTelemetry InstrumentationScope fields (OTLP path: scope.*).
+	// Standard first-class OpenTelemetry InstrumentationScope fields (e.g. name, version).
 	ScopeField ScopeField `protobuf:"varint,5,opt,name=scope_field,json=scopeField,proto3,enum=google.telemetry.policy.v1alpha1.ScopeField,oneof"`
 }
 
@@ -495,20 +588,25 @@ const file_policy_v1alpha1_trace_filter_policy_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12E\n" +
 	"\x06action\x18\x02 \x01(\x0e2(.google.telemetry.policy.v1alpha1.ActionH\x00R\x06action\x88\x01\x01\x12H\n" +
 	"\amatches\x18\x03 \x03(\v2..google.telemetry.policy.v1alpha1.TraceMatcherR\amatchesB\t\n" +
-	"\a_action\"\xe3\x01\n" +
+	"\a_action\"\xe1\x04\n" +
 	"\fTraceMatcher\x12L\n" +
 	"\x06target\x18\x01 \x01(\v24.google.telemetry.policy.v1alpha1.TraceFieldSelectorR\x06target\x120\n" +
 	"\x06exists\x18\n" +
-	" \x01(\v2\x16.google.protobuf.EmptyH\x00R\x06exists\x12\x16\n" +
-	"\x05exact\x18\v \x01(\tH\x00R\x05exact\x12\x16\n" +
-	"\x05regex\x18\f \x01(\tH\x00R\x05regex\x12\x16\n" +
+	" \x01(\v2\x16.google.protobuf.EmptyH\x00R\x06exists\x12A\n" +
+	"\x06equals\x18\v \x01(\v2'.google.telemetry.policy.v1alpha1.ValueH\x00R\x06equals\x12\x16\n" +
+	"\x05regex\x18\f \x01(\tH\x00R\x05regex\x12@\n" +
+	"\x02gt\x18\r \x01(\v2..google.telemetry.policy.v1alpha1.NumericValueH\x00R\x02gt\x12B\n" +
+	"\x03gte\x18\x0e \x01(\v2..google.telemetry.policy.v1alpha1.NumericValueH\x00R\x03gte\x12@\n" +
+	"\x02lt\x18\x0f \x01(\v2..google.telemetry.policy.v1alpha1.NumericValueH\x00R\x02lt\x12B\n" +
+	"\x03lte\x18\x10 \x01(\v2..google.telemetry.policy.v1alpha1.NumericValueH\x00R\x03lte\x12E\n" +
+	"\bcontains\x18\x11 \x01(\v2'.google.telemetry.policy.v1alpha1.ValueH\x00R\bcontains\x12\x16\n" +
 	"\x06negate\x18\x02 \x01(\bR\x06negateB\v\n" +
-	"\tpredicate\"\xcc\x02\n" +
+	"\tpredicate\"\xdf\x03\n" +
 	"\x12TraceFieldSelector\x12V\n" +
-	"\frecord_field\x18\x01 \x01(\x0e21.google.telemetry.policy.v1alpha1.SpanRecordFieldH\x00R\vrecordField\x12'\n" +
-	"\x0espan_attribute\x18\x02 \x01(\tH\x00R\rspanAttribute\x12/\n" +
-	"\x12resource_attribute\x18\x03 \x01(\tH\x00R\x11resourceAttribute\x12)\n" +
-	"\x0fscope_attribute\x18\x04 \x01(\tH\x00R\x0escopeAttribute\x12O\n" +
+	"\frecord_field\x18\x01 \x01(\x0e21.google.telemetry.policy.v1alpha1.SpanRecordFieldH\x00R\vrecordField\x12X\n" +
+	"\x0espan_attribute\x18\x02 \x01(\v2/.google.telemetry.policy.v1alpha1.AttributePathH\x00R\rspanAttribute\x12`\n" +
+	"\x12resource_attribute\x18\x03 \x01(\v2/.google.telemetry.policy.v1alpha1.AttributePathH\x00R\x11resourceAttribute\x12Z\n" +
+	"\x0fscope_attribute\x18\x04 \x01(\v2/.google.telemetry.policy.v1alpha1.AttributePathH\x00R\x0escopeAttribute\x12O\n" +
 	"\vscope_field\x18\x05 \x01(\x0e2,.google.telemetry.policy.v1alpha1.ScopeFieldH\x00R\n" +
 	"scopeFieldB\b\n" +
 	"\x06target*\x9a\x02\n" +
@@ -544,20 +642,32 @@ var file_policy_v1alpha1_trace_filter_policy_proto_goTypes = []any{
 	(*TraceFieldSelector)(nil), // 3: google.telemetry.policy.v1alpha1.TraceFieldSelector
 	(Action)(0),                // 4: google.telemetry.policy.v1alpha1.Action
 	(*emptypb.Empty)(nil),      // 5: google.protobuf.Empty
-	(ScopeField)(0),            // 6: google.telemetry.policy.v1alpha1.ScopeField
+	(*Value)(nil),              // 6: google.telemetry.policy.v1alpha1.Value
+	(*NumericValue)(nil),       // 7: google.telemetry.policy.v1alpha1.NumericValue
+	(*AttributePath)(nil),      // 8: google.telemetry.policy.v1alpha1.AttributePath
+	(ScopeField)(0),            // 9: google.telemetry.policy.v1alpha1.ScopeField
 }
 var file_policy_v1alpha1_trace_filter_policy_proto_depIdxs = []int32{
-	4, // 0: google.telemetry.policy.v1alpha1.TraceFilterPolicy.action:type_name -> google.telemetry.policy.v1alpha1.Action
-	2, // 1: google.telemetry.policy.v1alpha1.TraceFilterPolicy.matches:type_name -> google.telemetry.policy.v1alpha1.TraceMatcher
-	3, // 2: google.telemetry.policy.v1alpha1.TraceMatcher.target:type_name -> google.telemetry.policy.v1alpha1.TraceFieldSelector
-	5, // 3: google.telemetry.policy.v1alpha1.TraceMatcher.exists:type_name -> google.protobuf.Empty
-	0, // 4: google.telemetry.policy.v1alpha1.TraceFieldSelector.record_field:type_name -> google.telemetry.policy.v1alpha1.SpanRecordField
-	6, // 5: google.telemetry.policy.v1alpha1.TraceFieldSelector.scope_field:type_name -> google.telemetry.policy.v1alpha1.ScopeField
-	6, // [6:6] is the sub-list for method output_type
-	6, // [6:6] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	4,  // 0: google.telemetry.policy.v1alpha1.TraceFilterPolicy.action:type_name -> google.telemetry.policy.v1alpha1.Action
+	2,  // 1: google.telemetry.policy.v1alpha1.TraceFilterPolicy.matches:type_name -> google.telemetry.policy.v1alpha1.TraceMatcher
+	3,  // 2: google.telemetry.policy.v1alpha1.TraceMatcher.target:type_name -> google.telemetry.policy.v1alpha1.TraceFieldSelector
+	5,  // 3: google.telemetry.policy.v1alpha1.TraceMatcher.exists:type_name -> google.protobuf.Empty
+	6,  // 4: google.telemetry.policy.v1alpha1.TraceMatcher.equals:type_name -> google.telemetry.policy.v1alpha1.Value
+	7,  // 5: google.telemetry.policy.v1alpha1.TraceMatcher.gt:type_name -> google.telemetry.policy.v1alpha1.NumericValue
+	7,  // 6: google.telemetry.policy.v1alpha1.TraceMatcher.gte:type_name -> google.telemetry.policy.v1alpha1.NumericValue
+	7,  // 7: google.telemetry.policy.v1alpha1.TraceMatcher.lt:type_name -> google.telemetry.policy.v1alpha1.NumericValue
+	7,  // 8: google.telemetry.policy.v1alpha1.TraceMatcher.lte:type_name -> google.telemetry.policy.v1alpha1.NumericValue
+	6,  // 9: google.telemetry.policy.v1alpha1.TraceMatcher.contains:type_name -> google.telemetry.policy.v1alpha1.Value
+	0,  // 10: google.telemetry.policy.v1alpha1.TraceFieldSelector.record_field:type_name -> google.telemetry.policy.v1alpha1.SpanRecordField
+	8,  // 11: google.telemetry.policy.v1alpha1.TraceFieldSelector.span_attribute:type_name -> google.telemetry.policy.v1alpha1.AttributePath
+	8,  // 12: google.telemetry.policy.v1alpha1.TraceFieldSelector.resource_attribute:type_name -> google.telemetry.policy.v1alpha1.AttributePath
+	8,  // 13: google.telemetry.policy.v1alpha1.TraceFieldSelector.scope_attribute:type_name -> google.telemetry.policy.v1alpha1.AttributePath
+	9,  // 14: google.telemetry.policy.v1alpha1.TraceFieldSelector.scope_field:type_name -> google.telemetry.policy.v1alpha1.ScopeField
+	15, // [15:15] is the sub-list for method output_type
+	15, // [15:15] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_policy_v1alpha1_trace_filter_policy_proto_init() }
@@ -569,8 +679,13 @@ func file_policy_v1alpha1_trace_filter_policy_proto_init() {
 	file_policy_v1alpha1_trace_filter_policy_proto_msgTypes[0].OneofWrappers = []any{}
 	file_policy_v1alpha1_trace_filter_policy_proto_msgTypes[1].OneofWrappers = []any{
 		(*TraceMatcher_Exists)(nil),
-		(*TraceMatcher_Exact)(nil),
+		(*TraceMatcher_Equals)(nil),
 		(*TraceMatcher_Regex)(nil),
+		(*TraceMatcher_Gt)(nil),
+		(*TraceMatcher_Gte)(nil),
+		(*TraceMatcher_Lt)(nil),
+		(*TraceMatcher_Lte)(nil),
+		(*TraceMatcher_Contains)(nil),
 	}
 	file_policy_v1alpha1_trace_filter_policy_proto_msgTypes[2].OneofWrappers = []any{
 		(*TraceFieldSelector_RecordField)(nil),

--- a/gen/go/policy/v1alpha1/trace_filter_policy_test.go
+++ b/gen/go/policy/v1alpha1/trace_filter_policy_test.go
@@ -52,11 +52,65 @@ func TestTraceFilterPolicy_Serialization(t *testing.T) {
 			{
 				Target: &policyv1alpha1.TraceFieldSelector{
 					Target: &policyv1alpha1.TraceFieldSelector_SpanAttribute{
-						SpanAttribute: "http.route",
+						SpanAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"http.route"},
+						},
 					},
 				},
-				Predicate: &policyv1alpha1.TraceMatcher_Exact{
-					Exact: "/ready",
+				Predicate: &policyv1alpha1.TraceMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "/ready",
+						},
+					},
+				},
+			},
+			{
+				Target: &policyv1alpha1.TraceFieldSelector{
+					Target: &policyv1alpha1.TraceFieldSelector_SpanAttribute{
+						SpanAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"http.status_code"},
+						},
+					},
+				},
+				Predicate: &policyv1alpha1.TraceMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_IntValue{
+							IntValue: 200,
+						},
+					},
+				},
+			},
+			{
+				Target: &policyv1alpha1.TraceFieldSelector{
+					Target: &policyv1alpha1.TraceFieldSelector_SpanAttribute{
+						SpanAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"http.status_code"},
+						},
+					},
+				},
+				Predicate: &policyv1alpha1.TraceMatcher_Gte{
+					Gte: &policyv1alpha1.NumericValue{
+						Value: &policyv1alpha1.NumericValue_IntValue{
+							IntValue: 400,
+						},
+					},
+				},
+			},
+			{
+				Target: &policyv1alpha1.TraceFieldSelector{
+					Target: &policyv1alpha1.TraceFieldSelector_SpanAttribute{
+						SpanAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"deployment", "tags"},
+						},
+					},
+				},
+				Predicate: &policyv1alpha1.TraceMatcher_Contains{
+					Contains: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "canary",
+						},
+					},
 				},
 			},
 			{
@@ -65,8 +119,12 @@ func TestTraceFilterPolicy_Serialization(t *testing.T) {
 						RecordField: policyv1alpha1.SpanRecordField_SPAN_RECORD_FIELD_KIND,
 					},
 				},
-				Predicate: &policyv1alpha1.TraceMatcher_Exact{
-					Exact: "SERVER",
+				Predicate: &policyv1alpha1.TraceMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "SERVER",
+						},
+					},
 				},
 			},
 			{
@@ -75,25 +133,37 @@ func TestTraceFilterPolicy_Serialization(t *testing.T) {
 						RecordField: policyv1alpha1.SpanRecordField_SPAN_RECORD_FIELD_STATUS_CODE,
 					},
 				},
-				Predicate: &policyv1alpha1.TraceMatcher_Exact{
-					Exact: "ERROR",
+				Predicate: &policyv1alpha1.TraceMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "ERROR",
+						},
+					},
 				},
 				Negate: true,
 			},
 			{
 				Target: &policyv1alpha1.TraceFieldSelector{
 					Target: &policyv1alpha1.TraceFieldSelector_ResourceAttribute{
-						ResourceAttribute: "service.name",
+						ResourceAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"service.name"},
+						},
 					},
 				},
-				Predicate: &policyv1alpha1.TraceMatcher_Exact{
-					Exact: "frontend",
+				Predicate: &policyv1alpha1.TraceMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "frontend",
+						},
+					},
 				},
 			},
 			{
 				Target: &policyv1alpha1.TraceFieldSelector{
 					Target: &policyv1alpha1.TraceFieldSelector_ScopeAttribute{
-						ScopeAttribute: "library.name",
+						ScopeAttribute: &policyv1alpha1.AttributePath{
+							Path: []string{"library.name"},
+						},
 					},
 				},
 				Predicate: &policyv1alpha1.TraceMatcher_Exists{
@@ -106,8 +176,12 @@ func TestTraceFilterPolicy_Serialization(t *testing.T) {
 						ScopeField: policyv1alpha1.ScopeField_SCOPE_FIELD_NAME,
 					},
 				},
-				Predicate: &policyv1alpha1.TraceMatcher_Exact{
-					Exact: "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",
+				Predicate: &policyv1alpha1.TraceMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",
+						},
+					},
 				},
 			},
 			{
@@ -116,19 +190,26 @@ func TestTraceFilterPolicy_Serialization(t *testing.T) {
 						ScopeField: policyv1alpha1.ScopeField_SCOPE_FIELD_VERSION,
 					},
 				},
-				Predicate: &policyv1alpha1.TraceMatcher_Exact{
-					Exact: "v0.45.0",
+				Predicate: &policyv1alpha1.TraceMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "v0.45.0",
+						},
+					},
 				},
 			},
-
 			{
 				Target: &policyv1alpha1.TraceFieldSelector{
 					Target: &policyv1alpha1.TraceFieldSelector_ScopeField{
 						ScopeField: policyv1alpha1.ScopeField_SCOPE_FIELD_SCHEMA_URL,
 					},
 				},
-				Predicate: &policyv1alpha1.TraceMatcher_Exact{
-					Exact: "https://opentelemetry.io/schemas/1.24.0",
+				Predicate: &policyv1alpha1.TraceMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "https://opentelemetry.io/schemas/1.24.0",
+						},
+					},
 				},
 			},
 		},
@@ -143,7 +224,7 @@ func TestTraceFilterPolicy_Serialization(t *testing.T) {
 	assert.True(t, proto.Equal(policy, unmarshaled))
 	assert.Equal(t, "drop-healthcheck-spans", unmarshaled.GetId())
 	assert.Equal(t, policyv1alpha1.Action_ACTION_DROP, unmarshaled.GetAction())
-	require.Len(t, unmarshaled.GetMatches(), 9)
+	require.Len(t, unmarshaled.GetMatches(), 12)
 }
 
 func TestTraceFilterPolicy_AnyPackaging(t *testing.T) {
@@ -215,8 +296,12 @@ func TestTraceFilterPolicy_JSONSerialization(t *testing.T) {
 						RecordField: policyv1alpha1.SpanRecordField_SPAN_RECORD_FIELD_NAME,
 					},
 				},
-				Predicate: &policyv1alpha1.TraceMatcher_Exact{
-					Exact: "/healthz",
+				Predicate: &policyv1alpha1.TraceMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "/healthz",
+						},
+					},
 				},
 				Negate: false,
 			},
@@ -226,8 +311,12 @@ func TestTraceFilterPolicy_JSONSerialization(t *testing.T) {
 						RecordField: policyv1alpha1.SpanRecordField_SPAN_RECORD_FIELD_KIND,
 					},
 				},
-				Predicate: &policyv1alpha1.TraceMatcher_Exact{
-					Exact: "SERVER",
+				Predicate: &policyv1alpha1.TraceMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "SERVER",
+						},
+					},
 				},
 			},
 		},
@@ -284,8 +373,12 @@ func TestTraceFilterPolicy_ParentSpanIDAndKindMatchers(t *testing.T) {
 						RecordField: policyv1alpha1.SpanRecordField_SPAN_RECORD_FIELD_KIND,
 					},
 				},
-				Predicate: &policyv1alpha1.TraceMatcher_Exact{
-					Exact: "INTERNAL",
+				Predicate: &policyv1alpha1.TraceMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "INTERNAL",
+						},
+					},
 				},
 			},
 		},
@@ -309,8 +402,12 @@ func TestTraceFilterPolicy_ParentSpanIDAndKindMatchers(t *testing.T) {
 						RecordField: policyv1alpha1.SpanRecordField_SPAN_RECORD_FIELD_PARENT_SPAN_ID,
 					},
 				},
-				Predicate: &policyv1alpha1.TraceMatcher_Exact{
-					Exact: "0123456789abcdef",
+				Predicate: &policyv1alpha1.TraceMatcher_Equals{
+					Equals: &policyv1alpha1.Value{
+						Value: &policyv1alpha1.Value_StringValue{
+							StringValue: "0123456789abcdef",
+						},
+					},
 				},
 			},
 		},

--- a/proto/policy/v1alpha1/common_policy_types.proto
+++ b/proto/policy/v1alpha1/common_policy_types.proto
@@ -18,6 +18,52 @@ package google.telemetry.policy.v1alpha1;
 
 option go_package = "github.com/GoogleCloudPlatform/opentelemetry-operations-collector/gen/go/policy/v1alpha1;policyv1alpha1";
 
+// AttributePath specifies how to access an attribute value.
+// - A single-element array accesses a flat attribute (e.g. ["http.status_code"]).
+// - Multiple elements traverse nested maps (e.g. ["http", "request", "method"]).
+// - When traversing array/list values, string segments representing non-negative
+//   integers (e.g. "0", "100") are interpreted as zero-based array indices
+//   (e.g. ["items", "0", "id"]).
+message AttributePath {
+  // Path segments for attribute traversal.
+  repeated string path = 1;
+}
+
+// Value carries a typed scalar for equality and containment comparisons.
+// Exactly one variant must be set.
+message Value {
+  // The typed scalar value.
+  oneof value {
+    // String value.
+    string string_value = 1;
+
+    // 64-bit signed integer value (e.g. http.status_code = 200).
+    int64 int_value = 2;
+
+    // Boolean value.
+    bool bool_value = 3;
+
+    // 64-bit floating point value.
+    double double_value = 4;
+
+    // Byte sequence value.
+    bytes bytes_value = 5;
+  }
+}
+
+// NumericValue carries a typed number for ordering comparisons (gt, gte, lt, lte).
+// Exactly one variant must be set.
+message NumericValue {
+  // The typed numeric value.
+  oneof value {
+    // 64-bit signed integer value.
+    int64 int_value = 1;
+
+    // 64-bit floating point value.
+    double double_value = 2;
+  }
+}
+
 // Action specifies what to do with a telemetry record that matches all conditions.
 //
 // Evaluation Semantics & Action Precedence:

--- a/proto/policy/v1alpha1/log_filter_policy.proto
+++ b/proto/policy/v1alpha1/log_filter_policy.proto
@@ -66,14 +66,37 @@ message LogMatcher {
     // false when absent or default (e.g. empty string or 0).
     google.protobuf.Empty exists = 10;
 
-    // Exact string equality match.
-    string exact = 11;
+    // Typed scalar equality match (supporting string, int64, bool, double, bytes).
+    Value equals = 11;
 
     // Regular expression match using RE2 syntax.
     // Evaluates as an unanchored partial match (like Go regexp.MatchString and
     // OpenTelemetry OTTL IsMatch). Callers requiring full string equality must
-    // provide explicit anchors ('^' and '$').
+    // provide explicit anchors ('^' and '$'). Applies strictly to string
+    // fields and string attribute values.
     string regex = 12;
+
+    // Matches if the target numeric value is strictly greater than this value.
+    // Applies strictly to int64 and double fields and attribute values.
+    NumericValue gt = 13;
+
+    // Matches if the target numeric value is greater than or equal to this value.
+    // Applies strictly to int64 and double fields and attribute values.
+    NumericValue gte = 14;
+
+    // Matches if the target numeric value is strictly less than this value.
+    // Applies strictly to int64 and double fields and attribute values.
+    NumericValue lt = 15;
+
+    // Matches if the target numeric value is less than or equal to this value.
+    // Applies strictly to int64 and double fields and attribute values.
+    NumericValue lte = 16;
+
+    // Value containment:
+    // - For list (ArrayValue) attributes: matches if any element in the list equals this value.
+    // - For string fields or attribute values: matches if the string contains this value's string_value as a substring.
+    // - For bytes fields or attribute values: matches if the bytes contain this value's bytes_value as a subsequence.
+    Value contains = 17;
   }
 
   // If true, inverts the result of the predicate (logical NOT).
@@ -83,19 +106,19 @@ message LogMatcher {
 // LogFieldSelector designates a first-class OTel log field, attribute, or metadata.
 message LogFieldSelector {
   oneof target {
-    // Standard first-class OpenTelemetry LogRecord fields (OTLP path: log_record.*).
+    // Standard first-class OpenTelemetry LogRecord fields (e.g. severity_number, body).
     LogRecordField record_field = 1;
 
-    // Log record attribute by key (OTLP path: log_record.attributes[*], e.g. "http.route", "user_id").
-    string log_attribute = 2;
+    // Log record attribute by key or path (e.g. ["http.route"] or ["http", "method"]).
+    AttributePath log_attribute = 2;
 
-    // Resource attribute by key (OTLP path: resource.attributes[*], e.g. "service.name", "k8s.pod.name").
-    string resource_attribute = 3;
+    // Resource attribute by key or path (e.g. ["service.name"] or ["host", "id"]).
+    AttributePath resource_attribute = 3;
 
-    // Instrumentation scope attribute by key (OTLP path: scope.attributes[*], e.g. "library.name").
-    string scope_attribute = 4;
+    // Instrumentation scope attribute by key or path (e.g. ["library.name"]).
+    AttributePath scope_attribute = 4;
 
-    // Standard first-class OpenTelemetry InstrumentationScope fields (OTLP path: scope.*).
+    // Standard first-class OpenTelemetry InstrumentationScope fields (e.g. name, version).
     ScopeField scope_field = 5;
   }
 }
@@ -114,8 +137,8 @@ enum LogRecordField {
   LOG_RECORD_FIELD_SEVERITY_TEXT = 2;
 
   // The numerical severity of the log (1-24 per OpenTelemetry specification).
-  // When evaluated against string predicates (`exact`, `regex`), this matches
-  // against the canonical base-10 integer string representation (e.g. "17").
+  // Evaluates against typed `equals` (`int_value`), numeric range comparisons
+  // (`gt`, `gte`, `lt`, `lte`), or canonical base-10 string representations for `regex`.
   LOG_RECORD_FIELD_SEVERITY_NUMBER = 3;
 
   // The 16-byte trace identifier associated with the log record.

--- a/proto/policy/v1alpha1/metric_filter_policy.proto
+++ b/proto/policy/v1alpha1/metric_filter_policy.proto
@@ -78,14 +78,37 @@ message MetricMatcher {
     // false when absent or default (e.g. empty string or 0).
     google.protobuf.Empty exists = 10;
 
-    // Exact string equality match.
-    string exact = 11;
+    // Typed scalar equality match (supporting string, int64, bool, double, bytes).
+    Value equals = 11;
 
     // Regular expression match using RE2 syntax.
     // Evaluates as an unanchored partial match (like Go regexp.MatchString and
     // OpenTelemetry OTTL IsMatch). Callers requiring full string equality must
-    // provide explicit anchors ('^' and '$').
+    // provide explicit anchors ('^' and '$'). Applies strictly to string
+    // fields and string attribute values.
     string regex = 12;
+
+    // Matches if the target numeric value is strictly greater than this value.
+    // Applies strictly to int64 and double fields and attribute values.
+    NumericValue gt = 13;
+
+    // Matches if the target numeric value is greater than or equal to this value.
+    // Applies strictly to int64 and double fields and attribute values.
+    NumericValue gte = 14;
+
+    // Matches if the target numeric value is strictly less than this value.
+    // Applies strictly to int64 and double fields and attribute values.
+    NumericValue lt = 15;
+
+    // Matches if the target numeric value is less than or equal to this value.
+    // Applies strictly to int64 and double fields and attribute values.
+    NumericValue lte = 16;
+
+    // Value containment:
+    // - For list (ArrayValue) attributes: matches if any element in the list equals this value.
+    // - For string fields or attribute values: matches if the string contains this value's string_value as a substring.
+    // - For bytes fields or attribute values: matches if the bytes contain this value's bytes_value as a subsequence.
+    Value contains = 17;
   }
 
   // If true, inverts the result of the predicate (logical NOT).
@@ -95,19 +118,19 @@ message MetricMatcher {
 // MetricFieldSelector designates a first-class OTel metric field, attribute, or metadata.
 message MetricFieldSelector {
   oneof target {
-    // Top-level metric descriptor fields (OTLP path: metric.*).
+    // Top-level metric descriptor fields (e.g. name, description, unit).
     MetricDescriptorField descriptor_field = 1;
 
-    // Attribute on an individual metric data point (OTLP path: metric.*.data_points[*].attributes[*], e.g. "http.status_code", "env").
-    string datapoint_attribute = 2;
+    // Attribute on an individual metric data point by key or path (e.g. ["http.status_code"] or ["env"]).
+    AttributePath datapoint_attribute = 2;
 
-    // Resource attribute by key (OTLP path: resource.attributes[*], e.g. "service.name", "k8s.pod.name").
-    string resource_attribute = 3;
+    // Resource attribute by key or path (e.g. ["service.name"] or ["host", "id"]).
+    AttributePath resource_attribute = 3;
 
-    // Instrumentation scope attribute by key (OTLP path: scope.attributes[*], e.g. "library.name").
-    string scope_attribute = 4;
+    // Instrumentation scope attribute by key or path (e.g. ["library.name"]).
+    AttributePath scope_attribute = 4;
 
-    // Standard first-class OpenTelemetry InstrumentationScope fields (OTLP path: scope.*).
+    // Standard first-class OpenTelemetry InstrumentationScope fields (e.g. name, version).
     ScopeField scope_field = 5;
   }
 }
@@ -130,15 +153,15 @@ enum MetricDescriptorField {
 
   // The primary data type of the metric (e.g. "GAUGE", "SUM", "HISTOGRAM",
   // "EXPONENTIAL_HISTOGRAM", "SUMMARY"). When selected, string predicates
-  // (`exact`, `regex`) evaluate against uppercase type names.
+  // (`equals` with string_value, `regex`) evaluate against uppercase type names.
   METRIC_DESCRIPTOR_FIELD_TYPE = 4;
 
   // The aggregation temporality of the metric (OTLP path: metric.*.aggregation_temporality,
   // e.g. for Sum, Histogram, ExponentialHistogram). When selected, string predicates
-  // (`exact`, `regex`) evaluate against uppercase names: "DELTA" or "CUMULATIVE".
+  // (`equals` with string_value, `regex`) evaluate against uppercase names: "DELTA" or "CUMULATIVE".
   METRIC_DESCRIPTOR_FIELD_AGGREGATION_TEMPORALITY = 5;
 
   // Whether a Sum metric is monotonic (OTLP path: metric.sum.is_monotonic).
-  // When selected, string predicates (`exact`, `regex`) evaluate against "true" or "false".
+  // Evaluates against typed `equals` (`bool_value`), or "true"/"false" for `regex`.
   METRIC_DESCRIPTOR_FIELD_IS_MONOTONIC = 6;
 }

--- a/proto/policy/v1alpha1/trace_filter_policy.proto
+++ b/proto/policy/v1alpha1/trace_filter_policy.proto
@@ -71,14 +71,37 @@ message TraceMatcher {
     // or empty string/unset).
     google.protobuf.Empty exists = 10;
 
-    // Exact string equality match.
-    string exact = 11;
+    // Typed scalar equality match (supporting string, int64, bool, double, bytes).
+    Value equals = 11;
 
     // Regular expression match using RE2 syntax.
     // Evaluates as an unanchored partial match (like Go regexp.MatchString and
     // OpenTelemetry OTTL IsMatch). Callers requiring full string equality must
-    // provide explicit anchors ('^' and '$').
+    // provide explicit anchors ('^' and '$'). Applies strictly to string
+    // fields and string attribute values.
     string regex = 12;
+
+    // Matches if the target numeric value is strictly greater than this value.
+    // Applies strictly to int64 and double fields and attribute values.
+    NumericValue gt = 13;
+
+    // Matches if the target numeric value is greater than or equal to this value.
+    // Applies strictly to int64 and double fields and attribute values.
+    NumericValue gte = 14;
+
+    // Matches if the target numeric value is strictly less than this value.
+    // Applies strictly to int64 and double fields and attribute values.
+    NumericValue lt = 15;
+
+    // Matches if the target numeric value is less than or equal to this value.
+    // Applies strictly to int64 and double fields and attribute values.
+    NumericValue lte = 16;
+
+    // Value containment:
+    // - For list (ArrayValue) attributes: matches if any element in the list equals this value.
+    // - For string fields or attribute values: matches if the string contains this value's string_value as a substring.
+    // - For bytes fields or attribute values: matches if the bytes contain this value's bytes_value as a subsequence.
+    Value contains = 17;
   }
 
   // If true, inverts the result of the predicate (logical NOT).
@@ -88,19 +111,19 @@ message TraceMatcher {
 // TraceFieldSelector designates a first-class OTel span field, attribute, or metadata.
 message TraceFieldSelector {
   oneof target {
-    // Standard first-class OpenTelemetry Span fields (OTLP path: span.*).
+    // Standard first-class OpenTelemetry Span fields (e.g. name, status_code).
     SpanRecordField record_field = 1;
 
-    // Span attribute by key (OTLP path: span.attributes[*], e.g. "http.route", "db.system", "rpc.method").
-    string span_attribute = 2;
+    // Span attribute by key or path (e.g. ["http.route"] or ["rpc", "service"]).
+    AttributePath span_attribute = 2;
 
-    // Resource attribute by key (OTLP path: resource.attributes[*], e.g. "service.name", "k8s.pod.name").
-    string resource_attribute = 3;
+    // Resource attribute by key or path (e.g. ["service.name"] or ["host", "id"]).
+    AttributePath resource_attribute = 3;
 
-    // Instrumentation scope attribute by key (OTLP path: scope.attributes[*], e.g. "library.name").
-    string scope_attribute = 4;
+    // Instrumentation scope attribute by key or path (e.g. ["library.name"]).
+    AttributePath scope_attribute = 4;
 
-    // Standard first-class OpenTelemetry InstrumentationScope fields (OTLP path: scope.*).
+    // Standard first-class OpenTelemetry InstrumentationScope fields (e.g. name, version).
     ScopeField scope_field = 5;
   }
 }


### PR DESCRIPTION
## Summary

OTLP telemetry attributes use `opentelemetry.proto.common.v1.AnyValue`, which supports primitive non-string types (`int64`, `bool`, `double`, `bytes`) alongside strings.

Previously, filter policy matchers (`LogMatcher`, `TraceMatcher`, `MetricMatcher`) only supported untyped `string exact` and single-string attribute keys. This prevented matching against non-string attributes, lacked numeric comparisons (e.g. `http.status_code >= 400`), lacked support for traversing nested map attributes, and lacked array containment matching.

This PR introduces typed attribute matching, nested attribute path traversal, and value containment across all three signal filter policies.

---

## Changes

* **`AttributePath` Traversal**: Added `AttributePath` (`repeated string path = 1`) in `common_policy_types.proto` for all attribute selectors. A single segment accesses flat attributes (e.g. `["http.status_code"]`), multiple segments traverse nested maps (e.g. `["http", "request", "method"]`), and string forms of non-negative integers (e.g. `"0"`, `"100"`) are interpreted as zero-based array indices (e.g. `["items", "0", "id"]`).
* **Typed Values (`Value` & `NumericValue`)**:
  * `Value`: Strongly-typed scalar union (`string_value`, `int_value`, `bool_value`, `double_value`, `bytes_value`) used for equality (`equals: Value`).
  * `NumericValue`: Typed numeric union (`int_value`, `double_value`) used for ordering comparisons (`gt`, `gte`, `lt`, `lte`).
* **Value Containment (`contains: Value`)**: Added `contains` predicate across all matchers:
  * For list attributes (`ArrayValue`): matches if any element in the list equals the scalar value (e.g. `roles contains "admin"`).
  * For string fields/attributes: matches substring containment (e.g. `message contains "timeout"`).
* **Generated Code & Tests**: Regenerated Go bindings (`make gen-protos`) and added test coverage for `Value`, `NumericValue`, `AttributePath`, and updated matchers.

---

## Comparison with Upstream OTEP 4738 and `usetero/policy`

* **OTEP 4738**:
  * *Alignment:* Adopts identical `AttributePath` model for attribute selection.
  * *Enhancement:* Adds typed scalar values (`Value`), numeric comparisons (`NumericValue`), and `contains` (OTEP 4738 only specified string `exact` and `regex`).
* **`usetero/policy`**:
  * *Alignment:* Adopts `Value` (scalars), `NumericValue`, and `AttributePath`.
  * *Deviations:*
    1. **Polymorphic `contains`**: `usetero` only supported `string contains = 15;` for substring matching. This PR defines `Value contains = 17;` which matches both string substrings and array element membership (mirroring OTTL's `Contains`).
    2. **Canonical Bytes**: Uses standard protobuf `bytes bytes_value` rather than adding a separate redundant `hex_value` string (per Google AIP-140/143). In our policies, Trace/Span IDs are first-class fields that already match against canonical lowercase hex strings when using string matchers.
    3. **No Deprecated Fields**: Starts cleanly with `Value equals = 11;` and omits `string exact [deprecated = true]`.
    4. **Metric Granularity**: Supports both metric-level and data point-level filtering via `datapoint_attribute`.

---

## Alternatives Considered (Rejected)

* **Single Dot-Delimited String for Paths**: Rejected because OTel attribute keys canonically contain dots in flat names (e.g. `http.status_code`). A single string cannot distinguish between flat keys and nested maps without complex escaping rules (`"http\\.status_code"` vs `"http.status_code"`). `repeated string path = 1` makes the hierarchy structural and unambiguous.
* **Single `double` for Range Comparisons**: Rejected because IEEE 754 `double` loses precision for integers $> 2^{53}$ (common in telemetry: nanosecond timestamps $\approx 1.7 \times 10^{18}$, 64-bit IDs, byte counters). `NumericValue` (`int64` and `double`) preserves 64-bit fidelity and schema safety, while evaluation engines cross-promote int and float at runtime.
* **Path Wildcards (`*`) for Array Traversal**: Rejected because wildcard segments introduce backtracking and branching complexity. Pointing `AttributePath` to the array and matching with `contains: Value` solves array element matching in linear time without wildcard traversal.

---

## Deferred Features

* **Compound Types in `Value` (`ListValue` / `MapValue`)**: Tags 6 and 7 in `Value` are open and can be added if deep equality matching on entire lists or maps is ever needed. Deferred because element containment (`contains`) and nested map path traversal (`AttributePath`) solve the actual filtering requirements without compound comparison overhead.
* **Dedicated String Matchers (`starts_with`, `ends_with`)**: Deferred in favor of standard regular expressions (`regex: "^prefix.*"`, `regex: ".*suffix$"`), aligning with OTEP 4738. Can be added as non-breaking variants later if profiling under Hyperscan/RE2 demonstrates a compelling performance benefit.
